### PR TITLE
allow multiple server URLs in the example code

### DIFF
--- a/examples/nats-pub.go
+++ b/examples/nats-pub.go
@@ -6,7 +6,7 @@ package main
 import (
 	"flag"
 	"log"
-
+	"strings"
 	"github.com/apcera/nats"
 )
 
@@ -15,7 +15,7 @@ func usage() {
 }
 
 func main() {
-	var url = flag.String("s", nats.DefaultURL, "The nats server URL")
+	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
 	var ssl = flag.Bool("ssl", false, "Use Secure Connection")
 
 	log.SetFlags(0)
@@ -28,7 +28,11 @@ func main() {
 	}
 
 	opts := nats.DefaultOptions
-	opts.Url = *url
+	opts.Servers = strings.Split(*urls, ",")
+	for i, s := range opts.Servers {
+    		opts.Servers[i] = strings.Trim(s, " ")
+	}
+
 	opts.Secure = *ssl
 
 	nc, err := opts.Connect()

--- a/examples/nats-sub.go
+++ b/examples/nats-sub.go
@@ -7,7 +7,7 @@ import (
 	"flag"
 	"log"
 	"runtime"
-
+	"strings"
 	"github.com/apcera/nats"
 )
 
@@ -23,7 +23,7 @@ func printMsg(m *nats.Msg, i int) {
 }
 
 func main() {
-	var url = flag.String("s", nats.DefaultURL, "The nats server URL")
+	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
 	var showTime = flag.Bool("t", false, "Display timestamps")
 	var ssl = flag.Bool("ssl", false, "Use Secure Connection")
 
@@ -37,7 +37,10 @@ func main() {
 	}
 
 	opts := nats.DefaultOptions
-	opts.Url = *url
+	opts.Servers = strings.Split(*urls, ",")
+	for i, s := range opts.Servers {
+    		opts.Servers[i] = strings.Trim(s, " ")
+	}
 	opts.Secure = *ssl
 
 	nc, err := opts.Connect()


### PR DESCRIPTION
this patch makes the examples work with a clustered gnatsd setup.

this is how i invoke them:

```
go run nats-pub.go  -s nats://localhost:4245,nats://localhost:4242 key.abc hello-world
go run nats-sub.go -s nats://localhost:4242,nats://localhost:4245 \*.\*
```
