### PR TITLE
Synchronous write mode

### DIFF
--- a/examples/nats-bench.go
+++ b/examples/nats-bench.go
@@ -48,6 +48,7 @@ func main() {
 	var numMsgs = flag.Int("n", DefaultNumMsgs, "Number of Messages to Publish")
 	var msgSize = flag.Int("ms", DefaultMessageSize, "Size of the message.")
 	var csvFile = flag.String("csv", "", "Save bench data to csv file")
+	var publishSync = flag.Bool("publishsync", false, "Flush to the socket on publish")
 
 	log.SetFlags(0)
 	flag.Usage = usage
@@ -69,6 +70,7 @@ func main() {
 		opts.Servers[i] = strings.Trim(s, " ")
 	}
 	opts.Secure = *tls
+	opts.PublishSync = *publishSync
 
 	benchmark = bench.NewBenchmark("NATS", *numSubs, *numPubs)
 


### PR DESCRIPTION
In order to better support a more "realtime" use case, this adds a synchronous mode where publishing and subscribing writes to the socket immediately.
Obviously the throughput in this mode is much lower than with buffered/async flush. But the throughput for a single connection is largely enough for us (and probably anyone) and it matches our use case better.

This is still work in progress but I wanted to allow you to tell me what you think early.
This lacks test and probably the SubscribeSync option is badly named as it collides with a method name with a different meaning.
