### PR TITLE
Add new client inboxes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ _testmain.go
 .settings/
 
 # bin
+.idea/

--- a/nats.go
+++ b/nats.go
@@ -2655,9 +2655,9 @@ func (nc *Conn) oldRequest(subj string, data []byte, timeout time.Duration) (*Ms
 const (
 	InboxPrefix        = "_INBOX."
 	InboxClientsPrefix = "_INBOX._CLIENTS."
-	replySuffixLen = 8 // Gives us 62^8
-	rdigits        = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-	base           = 62
+	replySuffixLen     = 8 // Gives us 62^8
+	rdigits            = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	base               = 62
 	delimer            = "."
 )
 

--- a/nats.go
+++ b/nats.go
@@ -2653,14 +2653,11 @@ func (nc *Conn) oldRequest(subj string, data []byte, timeout time.Duration) (*Ms
 
 // InboxPrefix is the prefix for all inbox subjects.
 const (
+	InboxPrefix        = "_INBOX."
+	InboxClientsPrefix = "_INBOX._CLIENTS."
 	replySuffixLen = 8 // Gives us 62^8
 	rdigits        = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 	base           = 62
-)
-
-const (
-	InboxPrefix        = "_INBOX."
-	InboxClientsPrefix = "_INBOX._CLIENTS."
 	delimer            = "."
 )
 

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -693,6 +693,20 @@ func TestInbox(t *testing.T) {
 	}
 }
 
+func TestInboxWithPath(t *testing.T) {
+	inbox := nats.NewInboxWithPath("_TMP")
+	if matched, _ := regexp.Match(`_INBOX.\S`, []byte(inbox)); !matched {
+		t.Fatal("Bad INBOX format")
+	}
+}
+
+func TestClientInbox(t *testing.T) {
+	inbox := nats.NewClientInbox("TMP")
+	if matched, _ := regexp.Match(`_INBOX._CLIENTS.\S`, []byte(inbox)); !matched {
+		t.Fatal("Bad INBOX format")
+	}
+}
+
 func TestStats(t *testing.T) {
 	s := RunDefaultServer()
 	defer s.Shutdown()

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -120,6 +120,18 @@ func BenchmarkInboxCreation(b *testing.B) {
 	}
 }
 
+func BenchmarkInboxWithPathCreation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		nats.NewInboxWithPath("_TMP")
+	}
+}
+
+func BenchmarkClientInboxCreation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		nats.NewClientInbox("TMP_Client")
+	}
+}
+
 func BenchmarkNewInboxCreation(b *testing.B) {
 	s := RunDefaultServer()
 	defer s.Shutdown()

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -679,7 +679,7 @@ func TestAsyncSubscriberStarvation(t *testing.T) {
 	// Kickoff
 	nc.Subscribe("start", func(m *nats.Msg) {
 		// Helper Response
-		response := nats.NewInbox()
+		response := nats.NewInboxWithPath("_TMP")
 		nc.Subscribe(response, func(_ *nats.Msg) {
 			ch <- true
 		})


### PR DESCRIPTION
New clients inboxes.  Necessary changes to integrate access control in NATS streaming
In new version use clients section in config for automatically allow subscribe and publish to "_INBOX._CLIENTS.ClientIdXYZ.>". Not use "_INBOX.>" publish and subscribe with clients. "_INBOX.>" will be allowed to write and read other _INBOX._CLIENTS.