### PR TITLE
Update the "go get" instructions to avoid error report [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 
 ```bash
 # Go client
-go get github.com/nats-io/nats.go
+go get github.com/nats-io/nats.go/
 
 # Server
 go get github.com/nats-io/nats-server


### PR DESCRIPTION
Adding the trailing "/" avoids an error report about "no such
file or directory"

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>