### PR TITLE
renamed DisconnectErrHandler to ConnErrHandler

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -150,9 +150,9 @@ const (
 // disconnected and closed connections.
 type ConnHandler func(*Conn)
 
-// DisconnectErrHandler is used to process asynchronous disconnected connections events,
-// with the error (if any) that caused the disconnect.
-type DisconnectErrHandler func(*Conn, error)
+// ConnErrHandler is used to process asynchronous events like
+// disconnected connection with the error (if any).
+type ConnErrHandler func(*Conn, error)
 
 // ErrHandler is used to process asynchronous errors encountered
 // while processing inbound messages.
@@ -279,7 +279,7 @@ type Options struct {
 	// whenever the connection is disconnected.
 	// Disconnected error could be nil, for instance when user explicitly closes the connection.
 	// DisconnectedCB will not be called if DisconnectedErrCB is set
-	DisconnectedErrCB DisconnectErrHandler
+	DisconnectedErrCB ConnErrHandler
 
 	// ReconnectedCB sets the reconnected handler called whenever
 	// the connection is successfully reconnected.
@@ -701,7 +701,7 @@ func DrainTimeout(t time.Duration) Option {
 }
 
 // DisconnectErrHandler is an Option to set the disconnected error handler.
-func DisconnectedErrHandler(cb DisconnectErrHandler) Option {
+func DisconnectedErrHandler(cb ConnErrHandler) Option {
 	return func(o *Options) error {
 		o.DisconnectedErrCB = cb
 		return nil
@@ -883,7 +883,7 @@ func (nc *Conn) SetDisconnectHandler(dcb ConnHandler) {
 }
 
 // SetDisconnectErrHandler will set the disconnect event handler.
-func (nc *Conn) SetDisconnectErrHandler(dcb DisconnectErrHandler) {
+func (nc *Conn) SetDisconnectErrHandler(dcb ConnErrHandler) {
 	if nc == nil {
 		return
 	}

--- a/nats.go
+++ b/nats.go
@@ -709,7 +709,7 @@ func DisconnectErrHandler(cb ConnErrHandler) Option {
 }
 
 // DisconnectHandler is an Option to set the disconnected handler.
-// DEPRECATED: Use Use DisconnectErrHandler.
+// DEPRECATED: Use DisconnectErrHandler.
 func DisconnectHandler(cb ConnHandler) Option {
 	return func(o *Options) error {
 		o.DisconnectedCB = cb

--- a/nats.go
+++ b/nats.go
@@ -701,7 +701,7 @@ func DrainTimeout(t time.Duration) Option {
 }
 
 // DisconnectErrHandler is an Option to set the disconnected error handler.
-func DisconnectedErrHandler(cb ConnErrHandler) Option {
+func DisconnectErrHandler(cb ConnErrHandler) Option {
 	return func(o *Options) error {
 		o.DisconnectedErrCB = cb
 		return nil
@@ -709,6 +709,7 @@ func DisconnectedErrHandler(cb ConnErrHandler) Option {
 }
 
 // DisconnectHandler is an Option to set the disconnected handler.
+// DEPRECATED: Use Use DisconnectErrHandler.
 func DisconnectHandler(cb ConnHandler) Option {
 	return func(o *Options) error {
 		o.DisconnectedCB = cb
@@ -872,7 +873,7 @@ func UseOldRequestStyle() Option {
 // Handler processing
 
 // SetDisconnectHandler will set the disconnect event handler.
-// DEPRECATED. use SetDisconnectErrHandler
+// DEPRECATED: Use SetDisconnectErrHandler
 func (nc *Conn) SetDisconnectHandler(dcb ConnHandler) {
 	if nc == nil {
 		return

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -200,7 +200,7 @@ func TestBasicClusterReconnect(t *testing.T) {
 	dcbCalled := false
 
 	opts := []nats.Option{nats.DontRandomize(),
-		nats.DisconnectedErrHandler(func(nc *nats.Conn, _ error) {
+		nats.DisconnectErrHandler(func(nc *nats.Conn, _ error) {
 			// Suppress any additional callbacks
 			if dcbCalled {
 				return

--- a/test/reconnect_test.go
+++ b/test/reconnect_test.go
@@ -684,7 +684,7 @@ func TestReconnectTLSHostNoIP(t *testing.T) {
 
 	nc, err := nats.Connect(secureURL,
 		nats.RootCAs("./configs/certs/ca.pem"),
-		nats.DisconnectedErrHandler(dcb),
+		nats.DisconnectErrHandler(dcb),
 		nats.ReconnectHandler(rcb))
 	if err != nil {
 		t.Fatalf("Failed to create secure (TLS) connection: %v", err)


### PR DESCRIPTION
As @kozlovic proposed this PR renames handler type to be more abstract so could be reused in future.