### PR TITLE
Add Respond()

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ nc.Subscribe("foo", func(m *nats.Msg) {
     fmt.Printf("Received a message: %s\n", string(m.Data))
 })
 
+// Responding to a request message
+nc.Subscribe("request", func(m *nats.Msg) {
+    m.Respond([]byte("answer is 42")
+})
+
 // Simple Sync Subscriber
 sub, err := nc.SubscribeSync("foo")
 m, err := sub.NextMsg(timeout)


### PR DESCRIPTION
This will allow a user to respond to a subscription callback that has not closed over a connection by referencing the request message.

```go
func cb(m *nats.Msg) {
  m.Respond([]byte("I am here")
}
```