### PR TITLE
Fixed nats-server import paths

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -43,7 +43,7 @@ import (
 
 // Default Constants
 const (
-	Version                 = "1.8.0"
+	Version                 = "1.8.1"
 	DefaultURL              = "nats://127.0.0.1:4222"
 	DefaultPort             = 4222
 	DefaultMaxReconnect     = 60

--- a/nats_test.go
+++ b/nats_test.go
@@ -36,8 +36,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-server/server"
-	natsserver "github.com/nats-io/nats-server/test"
+	"github.com/nats-io/nats-server/v2/server"
+	natsserver "github.com/nats-io/nats-server/v2/test"
 	"github.com/nats-io/nkeys"
 )
 

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-server/server"
-	"github.com/nats-io/nats-server/test"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats-server/v2/test"
 	"github.com/nats-io/nats.go"
 )
 

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-server/server"
-	"github.com/nats-io/nats-server/test"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats-server/v2/test"
 	"github.com/nats-io/nats.go"
 )
 

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -29,8 +29,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-server/server"
-	"github.com/nats-io/nats-server/test"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats-server/v2/test"
 	"github.com/nats-io/nats.go"
 )
 

--- a/test/helper_test.go
+++ b/test/helper_test.go
@@ -20,10 +20,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nats-io/nats-server/server"
+	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 
-	natsserver "github.com/nats-io/nats-server/test"
+	natsserver "github.com/nats-io/nats-server/v2/test"
 )
 
 // So that we can pass tests and benchmarks...

--- a/test/reconnect_test.go
+++ b/test/reconnect_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats-server/server"
+	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 )
 


### PR DESCRIPTION
Otherwise, projects pulling nats.go end-up with issues.

Resovles #478

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>