### PR TITLE
Add note to README on using go get and Go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ go get github.com/nats-io/nats.go/
 go get github.com/nats-io/nats-server
 ```
 
+When using Go modules (`GO111MODULE=on`):
+
+```bash
+# Go client latest and explicit version
+go get github.com/nats-io/nats.go/@latest
+go get github.com/nats-io/nats.go/@v1.8.1
+
+# Server
+go get github.com/nats-io/nats-server/v2
+```
+
 ## Basic Usage
 
 ```go

--- a/README.md
+++ b/README.md
@@ -15,15 +15,18 @@ go get github.com/nats-io/nats.go/
 go get github.com/nats-io/nats-server
 ```
 
-When using Go modules (`GO111MODULE=on`):
+When using or transitioning to Go modules support:
 
 ```bash
-# Go client latest and explicit version
+# Go client latest or explicit version
 go get github.com/nats-io/nats.go/@latest
 go get github.com/nats-io/nats.go/@v1.8.1
 
-# Server
+# For latest NATS Server, add /v2 at the end
 go get github.com/nats-io/nats-server/v2
+
+# NATS Server v1 is installed otherwise
+# go get github.com/nats-io/nats-server
 ```
 
 ## Basic Usage


### PR DESCRIPTION
`go get` needs special handling with trailing slashes when using Go modules so adding to the readme (more info at https://github.com/nats-io/nats.go/issues/478)