### PR TITLE
[FIXED] Wrong error returned in NextMsg and NextMsgWithContext

### DIFF
--- a/context.go
+++ b/context.go
@@ -140,10 +140,7 @@ func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error) {
 	select {
 	case msg, ok = <-mch:
 		if !ok {
-			s.mu.Lock()
-			err = s.validateNextMsgState()
-			s.mu.Unlock()
-			return nil, err
+			return nil, s.getNextMsgErr()
 		}
 		if err := s.processNextMsgDelivered(msg); err != nil {
 			return nil, err
@@ -156,10 +153,7 @@ func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error) {
 	select {
 	case msg, ok = <-mch:
 		if !ok {
-			s.mu.Lock()
-			err = s.validateNextMsgState()
-			s.mu.Unlock()
-			return nil, err
+			return nil, s.getNextMsgErr()
 		}
 		if err := s.processNextMsgDelivered(msg); err != nil {
 			return nil, err

--- a/context.go
+++ b/context.go
@@ -140,7 +140,10 @@ func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error) {
 	select {
 	case msg, ok = <-mch:
 		if !ok {
-			return nil, ErrConnectionClosed
+			s.mu.Lock()
+			err = s.validateNextMsgState()
+			s.mu.Unlock()
+			return nil, err
 		}
 		if err := s.processNextMsgDelivered(msg); err != nil {
 			return nil, err
@@ -153,7 +156,10 @@ func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error) {
 	select {
 	case msg, ok = <-mch:
 		if !ok {
-			return nil, ErrConnectionClosed
+			s.mu.Lock()
+			err = s.validateNextMsgState()
+			s.mu.Unlock()
+			return nil, err
 		}
 		if err := s.processNextMsgDelivered(msg); err != nil {
 			return nil, err

--- a/nats.go
+++ b/nats.go
@@ -3100,10 +3100,7 @@ func (s *Subscription) NextMsg(timeout time.Duration) (*Msg, error) {
 	select {
 	case msg, ok = <-mch:
 		if !ok {
-			s.mu.Lock()
-			err = s.validateNextMsgState()
-			s.mu.Unlock()
-			return nil, err
+			return nil, s.getNextMsgErr()
 		}
 		if err := s.processNextMsgDelivered(msg); err != nil {
 			return nil, err
@@ -3122,10 +3119,7 @@ func (s *Subscription) NextMsg(timeout time.Duration) (*Msg, error) {
 	select {
 	case msg, ok = <-mch:
 		if !ok {
-			s.mu.Lock()
-			err = s.validateNextMsgState()
-			s.mu.Unlock()
-			return nil, err
+			return nil, s.getNextMsgErr()
 		}
 		if err := s.processNextMsgDelivered(msg); err != nil {
 			return nil, err
@@ -3160,6 +3154,18 @@ func (s *Subscription) validateNextMsgState() error {
 	}
 
 	return nil
+}
+
+// This is called when the sync channel has been closed.
+// The error returned will be either connection or subscription
+// closed depending on what caused NextMsg() to fail.
+func (s *Subscription) getNextMsgErr() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.connClosed {
+		return ErrConnectionClosed
+	}
+	return ErrBadSubscription
 }
 
 // processNextMsgDelivered takes a message and applies the needed

--- a/nats.go
+++ b/nats.go
@@ -3100,7 +3100,10 @@ func (s *Subscription) NextMsg(timeout time.Duration) (*Msg, error) {
 	select {
 	case msg, ok = <-mch:
 		if !ok {
-			return nil, ErrConnectionClosed
+			s.mu.Lock()
+			err = s.validateNextMsgState()
+			s.mu.Unlock()
+			return nil, err
 		}
 		if err := s.processNextMsgDelivered(msg); err != nil {
 			return nil, err
@@ -3119,7 +3122,10 @@ func (s *Subscription) NextMsg(timeout time.Duration) (*Msg, error) {
 	select {
 	case msg, ok = <-mch:
 		if !ok {
-			return nil, ErrConnectionClosed
+			s.mu.Lock()
+			err = s.validateNextMsgState()
+			s.mu.Unlock()
+			return nil, err
 		}
 		if err := s.processNextMsgDelivered(msg); err != nil {
 			return nil, err


### PR DESCRIPTION
If the application is in NextMsg() (or NextMsgWithContext()) and
the subscription is unsubscribed from a different go routine, the
NextMsg() call would return that the connection is closed, instead
of the subscription.

Resolves #404

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>