### PR TITLE
README: Fix syntax errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ nc.Subscribe("foo", func(m *nats.Msg) {
 
 // Responding to a request message
 nc.Subscribe("request", func(m *nats.Msg) {
-    m.Respond([]byte("answer is 42")
+    m.Respond([]byte("answer is 42"))
 })
 
 // Simple Sync Subscriber
@@ -116,12 +116,12 @@ c.Publish("hello", me)
 
 // Unsubscribe
 sub, err := c.Subscribe("foo", nil)
-...
+// ...
 sub.Unsubscribe()
 
 // Requests
 var response string
-err := c.Request("help", "help me", &response, 10*time.Millisecond)
+err = c.Request("help", "help me", &response, 10*time.Millisecond)
 if err != nil {
     fmt.Printf("Request failed: %v\n", err)
 }


### PR DESCRIPTION
This PR proposes 2 small fixes on the README examples.

The current examples focuses on the concept introduction rather than compilable snippets.
To keep the current philosophy of the examples without having as a newcomer to dig into the `examples/` directory straight away, these fixes help to reduce the overhead of copy/pasting/editing prior the first execution.