### PR TITLE
[FIXED] Request() may receive invalid reply if responder sends multiple replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ When using or transitioning to Go modules support:
 ```bash
 # Go client latest or explicit version
 go get github.com/nats-io/nats.go/@latest
-go get github.com/nats-io/nats.go/@v1.9.0
+go get github.com/nats-io/nats.go/@v1.9.1
 
 # For latest NATS Server, add /v2 at the end
 go get github.com/nats-io/nats-server/v2

--- a/nats.go
+++ b/nats.go
@@ -45,7 +45,7 @@ import (
 
 // Default Constants
 const (
-	Version                 = "1.9.0"
+	Version                 = "1.9.1"
 	DefaultURL              = "nats://127.0.0.1:4222"
 	DefaultPort             = 4222
 	DefaultMaxReconnect     = 60
@@ -2656,14 +2656,18 @@ func (nc *Conn) respHandler(m *Msg) {
 		return
 	}
 
+	var mch chan *Msg
+
 	// Grab mch
 	rt := nc.respToken(m.Subject)
-	mch := nc.respMap[rt]
-	// Delete the key regardless, one response only.
-	delete(nc.respMap, rt)
-	// If something went wrong and we only have one entry, use that.
-	// This can happen if the system rewrites the subject, e.g. js.
-	if mch == nil && len(nc.respMap) == 1 {
+	if rt != _EMPTY_ {
+		mch = nc.respMap[rt]
+		// Delete the key regardless, one response only.
+		delete(nc.respMap, rt)
+	} else if len(nc.respMap) == 1 {
+		// If the server has rewritten the subject, the response token (rt)
+		// will not match (could be the case with JetStream). If that is the
+		// case and there is a single entry, use that.
 		for k, v := range nc.respMap {
 			mch = v
 			delete(nc.respMap, k)


### PR DESCRIPTION
PR #523 introduced and issue that could cause a Request() call
to receive a reply that was intended for another Request() call
if the responder sent multiple replies for the same request.

This issue is only in v1.9.0

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>