### PR TITLE
publish not checking reconnecting status after closing.

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -2558,6 +2558,11 @@ func (nc *Conn) publish(subj, reply string, data []byte) error {
 		return ErrConnectionDraining
 	}
 
+	if nc.isReconnecting() {
+		nc.mu.Unlock()
+		return ErrConnectionReconnecting
+	}
+
 	// Proactively reject payloads over the threshold set by server.
 	msgSize := int64(len(data))
 	if msgSize > nc.info.MaxPayload {


### PR DESCRIPTION
After successful initialization if nats server fails Conn status is set to Reconnecting but publish function is not checking and not returning error.

![image](https://user-images.githubusercontent.com/5095281/74344951-62817e00-4dbe-11ea-8222-2c87bf062a2c.png)
