### PR TITLE
[FIXED] Possible panic on connect if discovered server list shrinks in that process

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1450,6 +1450,7 @@ func (nc *Conn) connect() error {
 	// For first connect we walk all servers in the pool and try
 	// to connect immediately.
 	nc.mu.Lock()
+	defer nc.mu.Unlock()
 	nc.initc = true
 	// The pool may change inside the loop iteration due to INFO protocol.
 	for i := 0; i < len(nc.srvPool); i++ {
@@ -1463,8 +1464,8 @@ func (nc *Conn) connect() error {
 			err = nc.processConnectInit()
 
 			if err == nil {
-				nc.srvPool[i].didConnect = true
-				nc.srvPool[i].reconnects = 0
+				nc.current.didConnect = true
+				nc.current.reconnects = 0
 				nc.current.lastErr = nil
 				returnedErr = nil
 				break
@@ -1487,7 +1488,7 @@ func (nc *Conn) connect() error {
 	if returnedErr == nil && nc.status != CONNECTED {
 		returnedErr = ErrNoServers
 	}
-	nc.mu.Unlock()
+	
 	return returnedErr
 }
 

--- a/nats.go
+++ b/nats.go
@@ -1488,7 +1488,7 @@ func (nc *Conn) connect() error {
 	if returnedErr == nil && nc.status != CONNECTED {
 		returnedErr = ErrNoServers
 	}
-	
+
 	return returnedErr
 }
 

--- a/nats_test.go
+++ b/nats_test.go
@@ -2264,3 +2264,80 @@ func TestRequestInit(t *testing.T) {
 		t.Fatalf("Error on request: %v", err)
 	}
 }
+
+func TestNoPanicOnSrvPoolSizeChanging(t *testing.T) {
+	listeners := []net.Listener{}
+	ports := []int{}
+
+	for i := 0; i < 3; i++ {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("Could not listen on an ephemeral port: %v", err)
+		}
+		defer l.Close()
+		tl := l.(*net.TCPListener)
+		ports = append(ports, tl.Addr().(*net.TCPAddr).Port)
+		listeners = append(listeners, l)
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(listeners))
+
+	connect := int32(0)
+	srv := func(l net.Listener) {
+		defer wg.Done()
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+
+			var info string
+
+			reject := atomic.AddInt32(&connect, 1) <= 2
+			if reject {
+				// Sends a list of 3 servers, where the second does not actually run.
+				// This server is going to reject the connect (with auth error), so
+				// client will move to 2nd, fail, then go to third...
+				info = fmt.Sprintf("INFO {\"server_id\":\"foobar\",\"connect_urls\":[\"127.0.0.1:%d\",\"127.0.0.1:%d\",\"127.0.0.1:%d\"]}\r\n",
+					ports[0], ports[1], ports[2])
+			} else {
+				// This third server will return the INFO with only the original server
+				// and the third one, which will make the srvPool size shrink down to 2.
+				info = fmt.Sprintf("INFO {\"server_id\":\"foobar\",\"connect_urls\":[\"127.0.0.1:%d\",\"127.0.0.1:%d\"]}\r\n",
+					ports[0], ports[2])
+			}
+			conn.Write([]byte(info))
+
+			// Read connect and ping commands sent from the client
+			br := bufio.NewReaderSize(conn, 10*1024)
+			br.ReadLine()
+			br.ReadLine()
+
+			if reject {
+				conn.Write([]byte(fmt.Sprintf("-ERR '%s'\r\n", AUTHORIZATION_ERR)))
+				conn.Close()
+			} else {
+				conn.Write([]byte(pongProto))
+				br.ReadLine()
+			}
+		}
+	}
+
+	for _, l := range listeners {
+		go srv(l)
+	}
+
+	time.Sleep(250 * time.Millisecond)
+
+	nc, err := Connect(fmt.Sprintf("nats://127.0.0.1:%d", ports[0]))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	nc.Close()
+	for _, l := range listeners {
+		l.Close()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
panic: runtime error: index out of range [7] with length 7

goroutine 73 [running]:
github.com/nats-io/nats%2ego.(*Conn).connect(0xc000516000, 0x0, 0x0)
        /home/andrezen/go/src/github.com/nats-io/nats.go/nats.go:1466 +0x3f8
github.com/nats-io/nats%2ego.Options.Connect(0x0, 0x0, 0xc000101d40, 0x4, 0x4, 0x0, 0xc00056a160, 0x1b, 0x0, 0x0, ...)
        /home/andrezen/go/src/github.com/nats-io/nats.go/nats.go:1020 +0x39a
github.com/nats-io/nats%2ego.Connect(0xc000250120, 0x8b, 0xc0005b1de8, 0xa, 0xa, 0x0, 0x0, 0x0)
        /home/andrezen/go/src/github.com/nats-io/nats.go/nats.go:556 +0x2b7
gitlab.biocad.ru/ais/a2/lib/rpc_nsr_srv.(*ClientNSR).runNatsConnNc(0xc0005a8300, 0xc0000c0200, 0x0)
        /home/andrezen/go/src/gitlab.biocad.ru/ais/a2/lib/rpc_nsr_srv/c.runNatsConnNc.go:14 +0x627
gitlab.biocad.ru/ais/a2/lib/rpc_nsr_srv.(*ClientNSR).RunNats(0xc0005a8300, 0x0, 0x0, 0xc000542c01)
        /home/andrezen/go/src/gitlab.biocad.ru/ais/a2/lib/rpc_nsr_srv/c.RunNats.go:30 +0x164
created by gitlab.biocad.ru/ais/a2/lib/rpc_nsr_srv.(*ClientNSR).InitClientNSR
        /home/andrezen/go/src/gitlab.biocad.ru/ais/a2/lib/rpc_nsr_srv/c.InitClientNSR.go:4 +0x61