### PR TITLE
[FIXED] Request() with UseOldRequest not kicked out on Close()

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -2749,7 +2749,7 @@ func (nc *Conn) oldRequest(subj string, data []byte, timeout time.Duration) (*Ms
 	inbox := NewInbox()
 	ch := make(chan *Msg, RequestChanLen)
 
-	s, err := nc.subscribe(inbox, _EMPTY_, nil, ch, false)
+	s, err := nc.subscribe(inbox, _EMPTY_, nil, ch, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Applies only when UseOldRequest() options is passed to Connect():

If a Request() was issued and the connection closed, the Request()
call would not return with "connection closed" error, instead it
would wait for the provided timeout.

The issue would not exist in the RequestWithContext() API, even
when using the old style request, but a test has been added
nevertheless.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>