### PR TITLE
Use GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,0 +1,4 @@
+---
+name: Blank Issue
+about: Create an issue with a blank template.
+---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: NATS Slack
+    url: https://slack.nats.io
+    about: Please ask and answer questions in our Slack server here.

--- a/.github/ISSUE_TEMPLATE/defect.md
+++ b/.github/ISSUE_TEMPLATE/defect.md
@@ -1,0 +1,23 @@
+---
+name: Bug Report
+about: Report a bug found in the NATS Go library
+labels: bug
+---
+
+## Defect
+
+Make sure that these boxes are checked before submitting your issue -- thank you!
+
+ - [ ] Included nats.go version
+ - [ ] Included a [Minimal, Complete, and Verifiable example] (https://stackoverflow.com/help/mcve)
+
+#### Versions of `nats.go` and the `nats-server` if one was involved:
+
+#### OS/Container environment:
+
+#### Steps or code to reproduce the issue:
+
+#### Expected result:
+
+#### Actual result:
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Request a feature for the NATS Go library
+labels: feature
+---
+
+## Feature Request
+
+#### Use Case:
+
+#### Proposed Change:
+
+#### Who Benefits From The Change(s)?
+
+#### Alternative Approaches
+


### PR DESCRIPTION
I've adapted this PR from https://github.com/nats-io/nats-server/pull/1364.

This allows users to select a specific type of issue that they want to report, rather than using the same template to choose either a defect or feature request. A similar change was just merged into the Rust client. When you click "Open Issue", users are presented with [this menu](https://github.com/nats-io/nats.rs/issues/new/choose) before taking them to a specialized issue template. This reduces friction for reporters as they can spend less work reading and cutting irrelevant parts of the template.

This also automatically assigns the bug and enhancement labels to relevant issues opened through this form, and it also provides an "escape hatch" for users to skip the template with a blank issue if they feel the choices are inappropriate for the information that they wish to convey.

Finally, there is a link to our Slack server on the issue menu which may guide some question-related issues to chat where they can be answered with lower effort.