### PR TITLE
[FIXED] Randomize discovered server URLs if allowed

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -2431,8 +2431,15 @@ func (nc *Conn) processInfo(info string) error {
 		}
 		nc.addURLToPool(fmt.Sprintf("%s://%s", nc.connScheme(), curl), true, saveTLS)
 	}
-	if hasNew && !nc.initc && nc.Opts.DiscoveredServersCB != nil {
-		nc.ach.push(func() { nc.Opts.DiscoveredServersCB(nc) })
+	if hasNew {
+		// If randomization is allowed, randomize the pool now that we have
+		// added all new URLs.
+		if !nc.Opts.NoRandomize {
+			nc.shufflePool()
+		}
+		if !nc.initc && nc.Opts.DiscoveredServersCB != nil {
+			nc.ach.push(func() { nc.Opts.DiscoveredServersCB(nc) })
+		}
 	}
 
 	return nil

--- a/nats_test.go
+++ b/nats_test.go
@@ -1118,29 +1118,29 @@ func TestAsyncINFO(t *testing.T) {
 	for _, srv := range c.srvPool {
 		urlsAfterPoolSetup = append(urlsAfterPoolSetup, srv.url.Host)
 	}
-	checkPoolOrderDidNotChange := func() {
+	checkNewURLsAddedRandomly := func() {
+		t.Helper()
+		var ok bool
 		for i := 0; i < len(urlsAfterPoolSetup); i++ {
 			if c.srvPool[i].url.Host != urlsAfterPoolSetup[i] {
-				stackFatalf(t, "Pool should have %q at index %q, has %q", urlsAfterPoolSetup[i], i, c.srvPool[i].url.Host)
+				ok = true
+				break
 			}
+		}
+		if !ok {
+			t.Fatalf("New URLs were not added randmonly: %q", c.Servers())
 		}
 	}
 	// Add new urls
-	newURLs := []string{
-		"localhost:6222",
-		"localhost:7222",
-		"localhost:8222\", \"localhost:9222",
-		"localhost:10222\", \"localhost:11222\", \"localhost:12222,",
+	newURLs := "\"impA:4222\", \"impB:4222\", \"impC:4222\", " +
+		"\"impD:4222\", \"impE:4222\", \"impF:4222\", \"impG:4222\", " +
+		"\"impH:4222\", \"impI:4222\", \"impJ:4222\""
+	info = []byte("INFO {\"connect_urls\":[" + newURLs + "]}\r\n")
+	err = c.parse(info)
+	if err != nil || c.ps.state != OP_START {
+		t.Fatalf("Unexpected: %d : %v\n", c.ps.state, err)
 	}
-	for _, newURL := range newURLs {
-		info = []byte("INFO {\"connect_urls\":[\"" + newURL + "]}\r\n")
-		err = c.parse(info)
-		if err != nil || c.ps.state != OP_START {
-			t.Fatalf("Unexpected: %d : %v\n", c.ps.state, err)
-		}
-		// Check that pool order does not change up to the new addition(s).
-		checkPoolOrderDidNotChange()
-	}
+	checkNewURLsAddedRandomly()
 }
 
 func TestConnServers(t *testing.T) {

--- a/nats_test.go
+++ b/nats_test.go
@@ -1141,6 +1141,10 @@ func TestAsyncINFO(t *testing.T) {
 		t.Fatalf("Unexpected: %d : %v\n", c.ps.state, err)
 	}
 	checkNewURLsAddedRandomly()
+	// Check that we have not moved the first URL
+	if u := c.srvPool[0].url.Host; u != urlsAfterPoolSetup[0] {
+		t.Fatalf("Expected first URL to be %q, got %q", urlsAfterPoolSetup[0], u)
+	}
 }
 
 func TestConnServers(t *testing.T) {


### PR DESCRIPTION
After adding discovered URLs from the INFO, reshuffle the pool
if option allows

Resolves #565

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>