### PR TITLE
[ADDED] RetryOnFailedConnect option

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,21 @@ nc.QueueSubscribe("foo", "job_workers", func(_ *Msg) {
 
 ```go
 
+// Normally, the library will return an error when trying to connect and
+// there is no server running. The RetryOnFailedConnect option will set
+// the connection in reconnecting state if it failed to connect right away.
+nc, err := nats.Connect(nats.DefaultURL,
+    nats.RetryOnFailedConnect(true),
+    nats.MaxReconnects(10),
+    nats.ReconnectWait(time.Second),
+    nats.ReconnectHandler(func(_ *nats.Conn) {
+        // Note that this will be invoked for the first asynchronous connect.
+    }))
+if err != nil {
+    // Should not return an error even if it can't connect, but you still
+    // need to check in case there are some configuration errors.
+}
+
 // Flush connection to server, returns when all messages have been processed.
 nc.Flush()
 fmt.Println("All clear!")

--- a/norace_test.go
+++ b/norace_test.go
@@ -33,6 +33,7 @@ func TestNoRaceParseStateReconnectFunctionality(t *testing.T) {
 	opts.DisconnectedCB = func(_ *Conn) {
 		dch <- true
 	}
+	opts.NoCallbacksAfterClientClose = true
 
 	nc, errc := opts.Connect()
 	if errc != nil {
@@ -94,4 +95,5 @@ func TestNoRaceParseStateReconnectFunctionality(t *testing.T) {
 		t.Fatalf("Reconnect count incorrect: %d vs %d\n",
 			reconnectedCount, expectedReconnectCount)
 	}
+	nc.Close()
 }


### PR DESCRIPTION
Normally, nats.Connect() would fail if there is no server available
when this call is executed. With this new option, if no connection
can be made, this call will return no error and will trigger code
similar to the reconnect code. Therefore, MaxReconnect and ReconnectWait
options are used as if the library had been disconnected and is trying
to reconnect.
Note that subscription and publish calls will also behave as if the
library was in reconnection mode, which means that the calls are
buffered and produce no error until the reconnect buffer size is
full.
Obviously, since the connection is not connected, Flush or Request/Reply
calls would timeout.

If the ReconnectHandler is set, it will be invoked if the library
connects asynchronously.

Unrelated: fixed a test that had a t.skip()...

Resolves #195

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>