### PR TITLE
add a helper to determine if headers is supported

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -4303,6 +4303,13 @@ func (nc *Conn) MaxPayload() int64 {
 	return nc.info.MaxPayload
 }
 
+// HeadersSupported will return if the server supports headers
+func (nc *Conn) HeadersSupported() bool {
+	nc.mu.RLock()
+	defer nc.mu.RUnlock()
+	return nc.info.Headers
+}
+
 // AuthRequired will return if the connected server requires authorization.
 func (nc *Conn) AuthRequired() bool {
 	nc.mu.RLock()


### PR DESCRIPTION
functions like Publish will return an error when headers
are not supported, users who wish to support old and new
servers will need a way to find out if they can use headers
without parsing errors each time

Signed-off-by: R.I.Pienaar <rip@devco.net>