### PR TITLE
Add support for status line plus description

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -884,7 +884,7 @@ func DiscoveredServersHandler(cb ConnHandler) Option {
 	}
 }
 
-// ErrorHandler is an Option to set the async error  handler.
+// ErrorHandler is an Option to set the async error handler.
 func ErrorHandler(cb ErrHandler) Option {
 	return func(o *Options) error {
 		o.AsyncErrorCB = cb
@@ -2769,7 +2769,9 @@ const (
 	crlf         = "\r\n"
 	hdrPreEnd    = len(hdrLine) - len(crlf)
 	statusHdr    = "Status"
+	descrHdr     = "Description"
 	noResponders = "503"
+	statusLen    = 3 // e.g. 20x, 40x, 50x
 )
 
 // decodeHeadersMsg will decode and headers.
@@ -2785,7 +2787,16 @@ func decodeHeadersMsg(data []byte) (http.Header, error) {
 	}
 	// Check if we have an inlined status.
 	if len(l) > hdrPreEnd {
-		mh.Add(statusHdr, strings.TrimLeft(l[hdrPreEnd:], " "))
+		var description string
+		status := strings.TrimSpace(l[hdrPreEnd:])
+		if len(status) != statusLen {
+			description = strings.TrimSpace(status[statusLen:])
+			status = status[:statusLen]
+		}
+		mh.Add(statusHdr, status)
+		if len(description) > 0 {
+			mh.Add(descrHdr, description)
+		}
 	}
 	return http.Header(mh), nil
 }

--- a/nats_test.go
+++ b/nats_test.go
@@ -31,6 +31,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2446,6 +2447,22 @@ func TestHeaderParser(t *testing.T) {
 	shouldErr("NATS/1.0\r\n")
 	shouldErr("NATS/1.0\r\nk1:v1")
 	shouldErr("NATS/1.0\r\nk1:v1\r\n")
+
+	// Check that we can do inline status and descriptions
+	checkStatus := func(hdr string, status int, description string) {
+		t.Helper()
+		hdrs, err := decodeHeadersMsg([]byte(hdr + "\r\n\r\n"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if code, err := strconv.Atoi(hdrs.Get(statusHdr)); err != nil || code != status {
+			t.Fatalf("Expected status of %d, got %s", status, hdrs.Get(statusHdr))
+		}
+	}
+
+	checkStatus("NATS/1.0 503", 503, "")
+	checkStatus("NATS/1.0 503 No Responders", 503, "No Responders")
+	checkStatus("NATS/1.0  404   No Messages", 404, "No Messages")
 }
 
 func TestLameDuckMode(t *testing.T) {

--- a/nats_test.go
+++ b/nats_test.go
@@ -2458,6 +2458,11 @@ func TestHeaderParser(t *testing.T) {
 		if code, err := strconv.Atoi(hdrs.Get(statusHdr)); err != nil || code != status {
 			t.Fatalf("Expected status of %d, got %s", status, hdrs.Get(statusHdr))
 		}
+		if len(description) > 0 {
+			if descr := hdrs.Get(descrHdr); err != nil || descr != description {
+				t.Fatalf("Expected description of %q, got %q", description, descr)
+			}
+		}
 	}
 
 	checkStatus("NATS/1.0 503", 503, "")


### PR DESCRIPTION
Not sure if this is the right approach. The server will use inline status and descriptions for efficiency and originally we promote these to Status. Added in support for Description. Note the Go does not do this per se on HTTP.

https://golang.org/pkg/net/http/#Response

Signed-off-by: Derek Collison <derek@nats.io>