### PR TITLE
Fixed NATS Server dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ language: go
 go:
 - 1.15.x
 - 1.14.x
-env:
-- GO111MODULE=off
 go_import_path: github.com/nats-io/nats.go
 install:
 - go get -t ./...
-- go get github.com/nats-io/nats-server
 - go get github.com/mattn/goveralls
 - go get github.com/wadey/gocovmerge
 - go get -u honnef.co/go/tools/cmd/staticcheck


### PR DESCRIPTION
Since we don't vendor in this repo, we need to use go.mod, so removing GO111MODULE=off and the go get for the nats-server (which would pull tip)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>