### PR TITLE
Changes to default pending and default error handler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 
 [![License Apache 2](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fnats-io%2Fgo-nats.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fnats-io%2Fgo-nats?ref=badge_shield)
-[![Go Report Card](https://goreportcard.com/badge/github.com/nats-io/nats.go)](https://goreportcard.com/report/github.com/nats-io/nats.go) [![Build Status](https://travis-ci.org/nats-io/nats.go.svg?branch=master)](http://travis-ci.org/nats-io/nats.go) [![GoDoc](https://img.shields.io/badge/GoDoc-reference-007d9c)](https://pkg.go.dev/github.com/nats-io/nats.go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/nats-io/nats.go)](https://goreportcard.com/report/github.com/nats-io/nats.go) [![Build Status](https://travis-ci.com/nats-io/nats.go.svg?branch=master)](http://travis-ci.com/nats-io/nats.go) [![GoDoc](https://img.shields.io/badge/GoDoc-reference-007d9c)](https://pkg.go.dev/github.com/nats-io/nats.go)
  [![Coverage Status](https://coveralls.io/repos/nats-io/nats.go/badge.svg?branch=master)](https://coveralls.io/r/nats-io/nats.go?branch=master)
 
 ## Installation

--- a/enc_test.go
+++ b/enc_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -45,6 +45,10 @@ func TestPublishErrorAfterSubscribeDecodeError(t *testing.T) {
 	opts := options
 	nc, _ := opts.Connect()
 	defer nc.Close()
+
+	// Override default handler for test.
+	nc.SetErrorHandler(func(_ *Conn, _ *Subscription, _ error) {})
+
 	c, _ := NewEncodedConn(nc, JSON_ENCODER)
 
 	//Test message type

--- a/nats_test.go
+++ b/nats_test.go
@@ -2003,6 +2003,7 @@ func TestAuthErrorOnReconnect(t *testing.T) {
 		ReconnectJitter(0, 0),
 		MaxReconnects(-1),
 		DontRandomize(),
+		ErrorHandler(func(_ *Conn, _ *Subscription, _ error) {}),
 		DisconnectErrHandler(func(_ *Conn, e error) {
 			dch <- true
 		}),

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -129,6 +129,9 @@ func TestAuthFailAllowReconnect(t *testing.T) {
 		t.Fatalf("Should have connected ok: %v", err)
 	}
 	defer nc.Close()
+
+	// Override default handler for test.
+	nc.SetErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, _ error) {})
 
 	// Stop the server
 	ts.Shutdown()

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -212,6 +212,9 @@ func TestPublishDoesNotFailOnSlowConsumer(t *testing.T) {
 	defer s.Shutdown()
 	nc := NewDefaultConnection(t)
 	defer nc.Close()
+
+	// Override default handler for test.
+	nc.SetErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, _ error) {})
 
 	sub, err := nc.SubscribeSync("foo")
 	if err != nil {

--- a/test/drain_test.go
+++ b/test/drain_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 The NATS Authors
+// Copyright 2018-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -412,6 +412,9 @@ func TestDrainConnLastError(t *testing.T) {
 		t.Fatalf("Failed to create default connection: %v", err)
 	}
 	defer nc.Close()
+
+	// Override default handler for test.
+	nc.SetErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, _ error) {})
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -919,17 +919,17 @@ func TestChanSubscriberPendingLimits(t *testing.T) {
 			case 0:
 				sub, err = nc.ChanSubscribe("foo", ch)
 				if err := sub.SetPendingLimits(pending, -1); err == nil {
-					t.Fatalf("Unexpected error setting pending limits: %v", err)
+					t.Fatalf("Expected an error setting pending limits")
 				}
 			case 1:
 				sub, err = nc.ChanQueueSubscribe("foo", "bar", ch)
 				if err := sub.SetPendingLimits(pending, -1); err == nil {
-					t.Fatalf("Unexpected error setting pending limits: %v", err)
+					t.Fatalf("Expected an error setting pending limits")
 				}
 			case 2:
 				sub, err = nc.QueueSubscribeSyncWithChan("foo", "bar", ch)
 				if err := sub.SetPendingLimits(pending, -1); err == nil {
-					t.Fatalf("Unexpected error setting pending limits: %v", err)
+					t.Fatalf("Expected an error setting pending limits")
 				}
 			}
 			if err != nil {
@@ -1038,6 +1038,9 @@ func TestUnsubscribeChanOnSubscriber(t *testing.T) {
 
 	nc := NewDefaultConnection(t)
 	defer nc.Close()
+
+	// Override default handler for test.
+	nc.SetErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, _ error) {})
 
 	// Create our own channel.
 	ch := make(chan *nats.Msg, 8)


### PR DESCRIPTION
Slow consumer state still seems off, this is a first step trying to improve.
Increased the default number of pending messages limit but kept bytes the same.

Also introduced a default ErrHandler that will print out to stderr in case none has been set.

Someone needs to look deeper into why we are so imbalanced when receiving messages like queued up JetStream messages for a consumer.

Signed-off-by: Derek Collison <derek@nats.io>