### PR TITLE
jetstream: Updates for JetStream DirectOnly support

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -538,6 +538,7 @@ type jsSub struct {
 	consumer string
 	stream   string
 	deliver  string
+	subject  string
 	pull     int
 }
 


### PR DESCRIPTION
In case of using JetStream without API access, when calling subscribe  it is needed to use PushDirect or PullDirect options.

In this PR, we add support so that instead of using explicit options on subscribe, the subject can be used instead.  

For example, given a set of imports like:

```hcl
# Push based
{ stream:  { subject: "p.d", account: JS } }

# Pull based
{ service: { subject: "$JS.API.CONSUMER.MSG.NEXT.ORDERS.dA1", account: JS }, to: "next.order" }
```

We can now create the subscriptions as follows:

```go
js, err := nc.JetStream(nats.DirectOnly())

// Push based
js.SubscribeSync("p.d")
// instead of: js.SubscribeSync("ORDERS", nats.PushDirect("p.d"))

// Pull based to subject
js.SubscribeSync("next.order", nats.Pull(batch))

// Pull using attach
sub, err = js.SubscribeSync("ORDERS", nats.Attach("ORDERS", "d1"), nats.Pull(batch))
// 
// can replace => js.SubscribeSync("ORDERS", nats.PullDirect("ORDERS", "d1", batch))
```

This also removes the PushDirect and PullDirect options since just calling subscribe would try to do the right thing.

Signed-off-by: Waldemar Quevedo <wally@synadia.com>