### PR TITLE
Assign jsSub during low level subscription

### DIFF
--- a/context.go
+++ b/context.go
@@ -96,7 +96,7 @@ func (nc *Conn) oldRequestWithContext(ctx context.Context, subj string, hdr, dat
 	inbox := NewInbox()
 	ch := make(chan *Msg, RequestChanLen)
 
-	s, err := nc.subscribe(inbox, _EMPTY_, nil, ch, true)
+	s, err := nc.subscribe(inbox, _EMPTY_, nil, ch, true, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/enc.go
+++ b/enc.go
@@ -234,7 +234,7 @@ func (c *EncodedConn) subscribe(subject, queue string, cb Handler) (*Subscriptio
 		cbValue.Call(oV)
 	}
 
-	return c.Conn.subscribe(subject, queue, natsCB, nil, false)
+	return c.Conn.subscribe(subject, queue, natsCB, nil, false, nil)
 }
 
 // FlushTimeout allows a Flush operation to have an associated timeout.

--- a/js.go
+++ b/js.go
@@ -491,11 +491,10 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, opts []
 		cb = func(m *Msg) { ocb(m); m.Ack() }
 	}
 
-	sub, err = js.nc.subscribe(deliver, queue, cb, ch, cb == nil)
+	sub, err = js.nc.subscribe(deliver, queue, cb, ch, cb == nil, &jsSub{js: js})
 	if err != nil {
 		return nil, err
 	}
-	sub.jsi = &jsSub{js: js}
 
 	// If we are creating or updating let's process that request.
 	if shouldCreate {

--- a/netchan.go
+++ b/netchan.go
@@ -107,5 +107,5 @@ func (c *EncodedConn) bindRecvChan(subject, queue string, channel interface{}) (
 		chVal.Send(oPtr)
 	}
 
-	return c.Conn.subscribe(subject, queue, cb, nil, false)
+	return c.Conn.subscribe(subject, queue, cb, nil, false, nil)
 }


### PR DESCRIPTION
Ivan pointed out that setting the jsSub portion of the low level sub after we called subscribe could cause some issues.

Signed-off-by: Derek Collison <derek@nats.io>