### PR TITLE
[ADDED] tls in example clients

### DIFF
--- a/examples/nats-pub/main.go
+++ b/examples/nats-pub/main.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/examples/nats-pub/main.go
+++ b/examples/nats-pub/main.go
@@ -26,7 +26,7 @@ import (
 // nats-pub -s demo.nats.io:4443 <subject> <msg> (TLS version)
 
 func usage() {
-	log.Printf("Usage: nats-pub [-s server] [-creds file] [-tlscert file] [-tlskey file] [-tlsrootca file] <subject> <msg>\n")
+	log.Printf("Usage: nats-pub [-s server] [-creds file] [-tlscert file] [-tlskey file] [-tlscacert file] <subject> <msg>\n")
 	flag.PrintDefaults()
 }
 
@@ -40,7 +40,7 @@ func main() {
 	var userCreds = flag.String("creds", "", "User Credentials File")
 	var tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
 	var tlsClientKey = flag.String("tlskey", "", "Private key file for client certificate")
-	var tlsRootCA = flag.String("tlsrootca", "", "Root CA file for server verification")
+	var tlsCACert = flag.String("tlscacert", "", "CA certificate to verify peer against")
 	var reply = flag.String("reply", "", "Sets a specific reply subject")
 	var showHelp = flag.Bool("h", false, "Show help message")
 
@@ -70,9 +70,9 @@ func main() {
 		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
 	}
 
-	// Use specific root certificate
-	if *tlsRootCA != "" {
-		opts = append(opts, nats.RootCAs(*tlsRootCA))
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
 	}
 
 	// Connect to NATS

--- a/examples/nats-pub/main.go
+++ b/examples/nats-pub/main.go
@@ -26,7 +26,7 @@ import (
 // nats-pub -s demo.nats.io:4443 <subject> <msg> (TLS version)
 
 func usage() {
-	log.Printf("Usage: nats-pub [-s server] [-creds file] <subject> <msg>\n")
+	log.Printf("Usage: nats-pub [-s server] [-creds file] [-tlscert file] [-tlskey file] [-tlsrootca file] <subject> <msg>\n")
 	flag.PrintDefaults()
 }
 
@@ -38,8 +38,11 @@ func showUsageAndExit(exitcode int) {
 func main() {
 	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
 	var userCreds = flag.String("creds", "", "User Credentials File")
-	var showHelp = flag.Bool("h", false, "Show help message")
+	var tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+	var tlsClientKey = flag.String("tlskey", "", "Private key file for client certificate")
+	var tlsRootCA = flag.String("tlsrootca", "", "Root CA file for server verification")
 	var reply = flag.String("reply", "", "Sets a specific reply subject")
+	var showHelp = flag.Bool("h", false, "Show help message")
 
 	log.SetFlags(0)
 	flag.Usage = usage
@@ -60,6 +63,16 @@ func main() {
 	// Use UserCredentials
 	if *userCreds != "" {
 		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific root certificate
+	if *tlsRootCA != "" {
+		opts = append(opts, nats.RootCAs(*tlsRootCA))
 	}
 
 	// Connect to NATS

--- a/examples/nats-sub/main.go
+++ b/examples/nats-sub/main.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/examples/nats-sub/main.go
+++ b/examples/nats-sub/main.go
@@ -28,7 +28,7 @@ import (
 // nats-sub -s demo.nats.io:4443 <subject> (TLS version)
 
 func usage() {
-	log.Printf("Usage: nats-sub [-s server] [-creds file] [-tlscert file] [-tlskey file] [-tlsrootca file] [-t] <subject>\n")
+	log.Printf("Usage: nats-sub [-s server] [-creds file] [-tlscert file] [-tlskey file] [-tlscacert file] [-t] <subject>\n")
 	flag.PrintDefaults()
 }
 
@@ -46,7 +46,7 @@ func main() {
 	var userCreds = flag.String("creds", "", "User Credentials File")
 	var tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
 	var tlsClientKey = flag.String("tlskey", "", "Private key file for client certificate")
-	var tlsRootCA = flag.String("tlsrootca", "", "Root CA file for server verification")
+	var tlsCACert = flag.String("tlscacert", "", "CA certificate to verify peer against")
 	var showTime = flag.Bool("t", false, "Display timestamps")
 	var showHelp = flag.Bool("h", false, "Show help message")
 
@@ -77,9 +77,9 @@ func main() {
 		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
 	}
 
-	// Use specific root certificate
-	if *tlsRootCA != "" {
-		opts = append(opts, nats.RootCAs(*tlsRootCA))
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
 	}
 
 	// Connect to NATS

--- a/examples/nats-sub/main.go
+++ b/examples/nats-sub/main.go
@@ -28,7 +28,7 @@ import (
 // nats-sub -s demo.nats.io:4443 <subject> (TLS version)
 
 func usage() {
-	log.Printf("Usage: nats-sub [-s server] [-creds file] [-t] <subject>\n")
+	log.Printf("Usage: nats-sub [-s server] [-creds file] [-tlscert file] [-tlskey file] [-tlsrootca file] [-t] <subject>\n")
 	flag.PrintDefaults()
 }
 
@@ -44,6 +44,9 @@ func printMsg(m *nats.Msg, i int) {
 func main() {
 	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
 	var userCreds = flag.String("creds", "", "User Credentials File")
+	var tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+	var tlsClientKey = flag.String("tlskey", "", "Private key file for client certificate")
+	var tlsRootCA = flag.String("tlsrootca", "", "Root CA file for server verification")
 	var showTime = flag.Bool("t", false, "Display timestamps")
 	var showHelp = flag.Bool("h", false, "Show help message")
 
@@ -67,6 +70,16 @@ func main() {
 	// Use UserCredentials
 	if *userCreds != "" {
 		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific root certificate
+	if *tlsRootCA != "" {
+		opts = append(opts, nats.RootCAs(*tlsRootCA))
 	}
 
 	// Connect to NATS


### PR DESCRIPTION
Added 3 new optional flags to the pub & sub examples. In order to easily test a client connection with a tls enabled nats-server:
- tlscert <file>
- tlskey <file>
- tlsrootca <file>