### PR TITLE
Validate setting JetStream ApiPrefix

### DIFF
--- a/js.go
+++ b/js.go
@@ -183,6 +183,22 @@ func APIPrefix(pre string) JSOpt {
 		if !strings.HasSuffix(js.pre, ".") {
 			js.pre = js.pre + "."
 		}
+
+		toks := strings.Split(pre, ".")
+		for i, tok := range toks {
+			if tok == "" || tok == "*" {
+				return ErrJetStreamBadPre
+			}
+
+			if tok == ">" && i < len(toks)-1 {
+				return ErrBadSubject
+			} else if tok == ">" && i == len(toks)-1 {
+				js.pre = pre
+				return nil
+			}
+		}
+
+		js.pre = fmt.Sprintf("%s.", pre)
 		return nil
 	})
 }

--- a/nats_test.go
+++ b/nats_test.go
@@ -2599,3 +2599,61 @@ func TestMsg_RespondMsg(t *testing.T) {
 		t.Fatalf("did not get correct response: %q", resp.Data)
 	}
 }
+
+func TestJetStreamAPIPrefix(t *testing.T) {
+	cases := []struct {
+		prefix     string
+		wantPrefix string
+		wantErr    bool
+	}{
+		{
+			prefix:     "foo",
+			wantPrefix: "foo.",
+		},
+		{
+			prefix:     "foo.",
+			wantPrefix: "foo.",
+		},
+		{
+			prefix:     "foo.>",
+			wantPrefix: "foo.>",
+		},
+		{
+			prefix:     "foo.b*r.baz",
+			wantPrefix: "foo.b*r.baz.",
+		},
+		{
+			prefix:  "foo.*",
+			wantErr: true,
+		},
+		{
+			prefix:  "foo.*.bar",
+			wantErr: true,
+		},
+		{
+			prefix:  "foo.>.bar",
+			wantErr: true,
+		},
+		{
+			prefix:  ">",
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.prefix, func(t *testing.T) {
+			jsOpt := APIPrefix(c.prefix)
+
+			js := new(js)
+			if err := jsOpt.configureJSContext(js); err != nil && !c.wantErr {
+				t.Fatal(err)
+			} else if err == nil && c.wantErr {
+				t.Fatal("unexpected success")
+			}
+
+			if js.pre != c.wantPrefix {
+				t.Error("unexpected api prefix")
+				t.Fatalf("got=%s; want=%s", js.pre, c.wantPrefix)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a check to `nats.ApiPrefix` that prevents the prefix from containing wildcards. When @wallyqs and I were exploring the code, we found that we could end up with invalid API subjects like `foo.>.STREAM.NAMES`.

Also, this removes what appears to be outdated prefix TODOs.