### PR TITLE
Add some validation for durable names

### DIFF
--- a/js.go
+++ b/js.go
@@ -689,6 +689,10 @@ type subOpts struct {
 
 func Durable(name string) SubOpt {
 	return subOptFn(func(opts *subOpts) error {
+		if strings.Contains(name, ".") {
+			return ErrInvalidDurableName
+		}
+
 		opts.cfg.Durable = name
 		return nil
 	})
@@ -1162,6 +1166,9 @@ func (js *js) AddConsumer(stream string, cfg *ConsumerConfig) (*ConsumerInfo, er
 
 	var ccSubj string
 	if cfg != nil && cfg.Durable != _EMPTY_ {
+		if strings.Contains(cfg.Durable, ".") {
+			return nil, ErrInvalidDurableName
+		}
 		ccSubj = fmt.Sprintf(JSApiDurableCreateT, stream, cfg.Durable)
 	} else {
 		ccSubj = fmt.Sprintf(JSApiConsumerCreateT, stream)

--- a/nats.go
+++ b/nats.go
@@ -133,6 +133,7 @@ var (
 	ErrNoStreamResponse             = errors.New("nats: no response from stream")
 	ErrNotJSMessage                 = errors.New("nats: not a jetstream message")
 	ErrInvalidStreamName            = errors.New("nats: invalid stream name")
+	ErrInvalidDurableName           = errors.New("nats: invalid durable name")
 	ErrNoMatchingStream             = errors.New("nats: no stream matches subject")
 	ErrSubjectMismatch              = errors.New("nats: subject does not match consumer")
 	ErrContextAndTimeout            = errors.New("nats: context and timeout can not both be set")

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -475,6 +475,11 @@ func TestJetStreamSubscribe(t *testing.T) {
 			t.Fatalf("Timeout waiting for messages")
 		}
 	}
+
+	// Prevent invalid durable names
+	if _, err := js.SubscribeSync("baz", nats.Durable("test.durable")); err != nats.ErrInvalidDurableName {
+		t.Fatalf("Expected invalid durable name error")
+	}
 }
 
 func TestAckForNonJetStream(t *testing.T) {
@@ -562,6 +567,10 @@ func TestJetStreamManagement(t *testing.T) {
 	}
 	if ci == nil || ci.Name != "dlc" || ci.Stream != "foo" {
 		t.Fatalf("ConsumerInfo is not correct %+v", ci)
+	}
+
+	if _, err = js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "test.durable"}); err != nats.ErrInvalidDurableName {
+		t.Fatalf("Expected invalid durable name error")
 	}
 
 	// Check info calls.


### PR DESCRIPTION
In case a Durable name includes a dot, then it would not be able to be created since it will not match against the `$JS.API.CONSUMER.CREATE.*` subject from the JetStream API and return a `jetstream not enabled` error.
With this change, we try to detect this in the client first and error in case an invalid durable name has been used.

Signed-off-by: Waldemar Quevedo <wally@synadia.com>