### PR TITLE
Disable manual acks in case auto ack is enabled in async subs

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -542,6 +542,7 @@ type jsSub struct {
 	stream   string
 	deliver  string
 	pull     int
+	mack     bool
 }
 
 // Msg is a structure used by Subscribers and PublishMsg().


### PR DESCRIPTION
Adds a check so that `m.Ack()` cannot be used within an async callback unless the `nats.ManualAck()` option was used.

Fixes #634 

Signed-off-by: Waldemar Quevedo <wally@synadia.com>