### PR TITLE
Add in support for optional cluster info for streams and consumers.

### DIFF
--- a/js.go
+++ b/js.go
@@ -390,6 +390,7 @@ type ConsumerInfo struct {
 	NumRedelivered int            `json:"num_redelivered"`
 	NumWaiting     int            `json:"num_waiting"`
 	NumPending     uint64         `json:"num_pending"`
+	Cluster        *ClusterInfo   `json:"cluster,omitempty"`
 }
 
 // SequencePair includes the consumer and stream sequence info from a JetStream consumer.

--- a/jsm.go
+++ b/jsm.go
@@ -335,6 +335,7 @@ type StreamInfo struct {
 	Config  StreamConfig `json:"config"`
 	Created time.Time    `json:"created"`
 	State   StreamState  `json:"state"`
+	Cluster *ClusterInfo `json:"cluster,omitempty"`
 }
 
 // StreamStats is information about the given stream.
@@ -346,6 +347,22 @@ type StreamState struct {
 	LastSeq   uint64    `json:"last_seq"`
 	LastTime  time.Time `json:"last_ts"`
 	Consumers int       `json:"consumer_count"`
+}
+
+// ClusterInfo shows information about the underlying set of servers
+// that make up the stream or consumer.
+type ClusterInfo struct {
+	Name     string      `json:"name,omitempty"`
+	Leader   string      `json:"leader,omitempty"`
+	Replicas []*PeerInfo `json:"replicas,omitempty"`
+}
+
+// PeerInfo shows information about all the peers in the cluster that
+// are supporting the stream or consumer.
+type PeerInfo struct {
+	Name    string        `json:"name"`
+	Current bool          `json:"current"`
+	Active  time.Duration `json:"active"`
 }
 
 // UpdateStream updates a Stream.


### PR DESCRIPTION
Once this lands will update server tests to use this vs full blown JS cluster setup here.

Signed-off-by: Derek Collison <derek@nats.io>