### PR TITLE
js: Remove PushDirect option

### DIFF
--- a/js.go
+++ b/js.go
@@ -674,6 +674,7 @@ type subOpts struct {
 	cfg *ConsumerConfig
 }
 
+// Durable defines the consumer name for JetStream durable subscribers.
 func Durable(name string) SubOpt {
 	return subOptFn(func(opts *subOpts) error {
 		if strings.Contains(name, ".") {
@@ -685,6 +686,8 @@ func Durable(name string) SubOpt {
 	})
 }
 
+// Pull defines the batch size of messages that will be received
+// when using pull based JetStream consumers.
 func Pull(batchSize int) SubOpt {
 	return subOptFn(func(opts *subOpts) error {
 		if batchSize == 0 {
@@ -707,13 +710,7 @@ func PullDirect(stream, consumer string, batchSize int) SubOpt {
 	})
 }
 
-func PushDirect(deliverSubject string) SubOpt {
-	return subOptFn(func(opts *subOpts) error {
-		opts.cfg.DeliverSubject = deliverSubject
-		return nil
-	})
-}
-
+// ManualAck disables auto ack functionality for async subscriptions.
 func ManualAck() SubOpt {
 	return subOptFn(func(opts *subOpts) error {
 		opts.mack = true

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -1111,27 +1111,6 @@ func TestJetStreamImportDirectOnly(t *testing.T) {
 		t.Fatalf("Expected to receive %d messages, but got %d", n, msgs)
 	}
 
-	// Do push based direct consumer.
-	sub, err = js.SubscribeSync("ORDERS", nats.PushDirect("p.d"))
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	waitForPending(t, toSend)
-
-	// Ack the messages from the push consumer.
-	for i := 0; i < toSend; i++ {
-		m, err := sub.NextMsg(100 * time.Millisecond)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-
-		// Test that can expect an ack of the ack.
-		err = m.AckSync()
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-	}
-
 	// Do push based consumer using a regular NATS subscription on the import subject.
 	sub, err = nc.SubscribeSync("p.d3")
 	if err != nil {


### PR DESCRIPTION
Now that Ack can be used by non JetStream subscriptions, to subscriber directly it is only needed to use a regular subscription.

Signed-off-by: Waldemar Quevedo <wally@synadia.com>