### PR TITLE
js: Handle 503 status when JS API unavailable in pull mode

### DIFF
--- a/js.go
+++ b/js.go
@@ -395,8 +395,8 @@ type SequencePair struct {
 	Stream   uint64 `json:"stream_seq"`
 }
 
-// NextRequest is for getting next messages for pull based consumers from JetStream.
-type NextRequest struct {
+// nextRequest is for getting next messages for pull based consumers from JetStream.
+type nextRequest struct {
 	Expires *time.Time `json:"expires,omitempty"`
 	Batch   int        `json:"batch,omitempty"`
 	NoWait  bool       `json:"no_wait,omitempty"`
@@ -822,7 +822,7 @@ func (sub *Subscription) Poll() error {
 	js := sub.jsi.js
 	sub.mu.Unlock()
 
-	req, _ := json.Marshal(&NextRequest{Batch: batch})
+	req, _ := json.Marshal(&nextRequest{Batch: batch})
 	reqNext := js.apiSubj(fmt.Sprintf(apiRequestNextT, stream, consumer))
 	return nc.PublishRequest(reqNext, reply, req)
 }

--- a/nats.go
+++ b/nats.go
@@ -3715,6 +3715,7 @@ func (s *Subscription) processNextMsgDelivered(msg *Msg) error {
 	s.mu.Lock()
 	nc := s.conn
 	max := s.max
+	jsi := s.jsi
 
 	// Update some stats.
 	s.delivered++
@@ -3735,6 +3736,12 @@ func (s *Subscription) processNextMsgDelivered(msg *Msg) error {
 			nc.removeSub(s)
 			nc.mu.Unlock()
 		}
+	}
+
+	// In case this is a JetStream message and in pull mode
+	// then check whether it is an JS API error.
+	if jsi != nil && jsi.pull > 0 && len(msg.Data) == 0 && msg.Header.Get(statusHdr) == noResponders {
+		return ErrNoResponders
 	}
 
 	return nil


### PR DESCRIPTION
The result of a `Poll()` publish request could be a 503 message from the API which when processed by the SubscribeSync iterator will result in an empty message.  This adds similar handling as in `Request` to make these special messages errors instead of being passed to the user.

Signed-off-by: Waldemar Quevedo <wally@synadia.com>