### PR TITLE
js: Add more SubOpts: AckWait, MaxDeliver, MacAckPending

### DIFF
--- a/js.go
+++ b/js.go
@@ -332,13 +332,21 @@ func ExpectLastMsgId(id string) PubOpt {
 // MaxWait sets the maximum amount of time we will wait for a response.
 type MaxWait time.Duration
 
-func (ttl MaxWait) configurePublish(opts *pubOpts) error {
+func (ttl MaxWait) configureJSContext(js *js) error {
+	js.wait = time.Duration(ttl)
+	return nil
+}
+
+// AckWait sets the maximum amount of time we will wait for an ack.
+type AckWait time.Duration
+
+func (ttl AckWait) configurePublish(opts *pubOpts) error {
 	opts.ttl = time.Duration(ttl)
 	return nil
 }
 
-func (ttl MaxWait) configureJSContext(js *js) error {
-	js.wait = time.Duration(ttl)
+func (ttl AckWait) configureSubscribe(opts *subOpts) error {
+	opts.cfg.AckWait = time.Duration(ttl)
 	return nil
 }
 
@@ -794,13 +802,6 @@ func AckAll() SubOpt {
 func AckExplicit() SubOpt {
 	return subOptFn(func(opts *subOpts) error {
 		opts.cfg.AckPolicy = AckExplicitPolicy
-		return nil
-	})
-}
-
-func AckWait(d time.Duration) SubOpt {
-	return subOptFn(func(opts *subOpts) error {
-		opts.cfg.AckWait = d
 		return nil
 	})
 }

--- a/js.go
+++ b/js.go
@@ -812,13 +812,6 @@ func MaxDeliver(n int) SubOpt {
 	})
 }
 
-func FilterSubject(s string) SubOpt {
-	return subOptFn(func(opts *subOpts) error {
-		opts.cfg.FilterSubject = s
-		return nil
-	})
-}
-
 func PlaybackInstant() SubOpt {
 	return subOptFn(func(opts *subOpts) error {
 		opts.cfg.ReplayPolicy = ReplayInstant
@@ -847,7 +840,7 @@ func SampleFrequency(s string) SubOpt {
 	})
 }
 
-func MaxWaiting(n int) SubOpt {
+func PullMaxWaiting(n int) SubOpt {
 	return subOptFn(func(opts *subOpts) error {
 		opts.cfg.MaxWaiting = n
 		return nil

--- a/js.go
+++ b/js.go
@@ -495,6 +495,11 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, opts []
 		return nil, ErrPullModeNotAllowed
 	}
 
+	badPullAck := o.cfg.AckPolicy == AckNonePolicy || o.cfg.AckPolicy == AckAllPolicy
+	if isPullMode && badPullAck {
+		return nil, fmt.Errorf("invalid ack mode for pull consumers: %s", o.cfg.AckPolicy)
+	}
+
 	var (
 		err          error
 		shouldCreate bool
@@ -809,41 +814,6 @@ func AckExplicit() SubOpt {
 func MaxDeliver(n int) SubOpt {
 	return subOptFn(func(opts *subOpts) error {
 		opts.cfg.MaxDeliver = n
-		return nil
-	})
-}
-
-func PlaybackInstant() SubOpt {
-	return subOptFn(func(opts *subOpts) error {
-		opts.cfg.ReplayPolicy = ReplayInstant
-		return nil
-	})
-}
-
-func PlaybackOriginal() SubOpt {
-	return subOptFn(func(opts *subOpts) error {
-		opts.cfg.ReplayPolicy = ReplayOriginal
-		return nil
-	})
-}
-
-func RateLimit(n uint64) SubOpt {
-	return subOptFn(func(opts *subOpts) error {
-		opts.cfg.RateLimit = n
-		return nil
-	})
-}
-
-func SampleFrequency(s string) SubOpt {
-	return subOptFn(func(opts *subOpts) error {
-		opts.cfg.SampleFrequency = s
-		return nil
-	})
-}
-
-func PullMaxWaiting(n int) SubOpt {
-	return subOptFn(func(opts *subOpts) error {
-		opts.cfg.MaxWaiting = n
 		return nil
 	})
 }

--- a/js.go
+++ b/js.go
@@ -686,18 +686,6 @@ type subOpts struct {
 	cfg *ConsumerConfig
 }
 
-// Durable defines the consumer name for JetStream durable subscribers.
-func Durable(name string) SubOpt {
-	return subOptFn(func(opts *subOpts) error {
-		if strings.Contains(name, ".") {
-			return ErrInvalidDurableName
-		}
-
-		opts.cfg.Durable = name
-		return nil
-	})
-}
-
 // Pull defines the batch size of messages that will be received
 // when using pull based JetStream consumers.
 func Pull(batchSize int) SubOpt {
@@ -726,6 +714,18 @@ func PullDirect(stream, consumer string, batchSize int) SubOpt {
 func ManualAck() SubOpt {
 	return subOptFn(func(opts *subOpts) error {
 		opts.mack = true
+		return nil
+	})
+}
+
+// Durable defines the consumer name for JetStream durable subscribers.
+func Durable(name string) SubOpt {
+	return subOptFn(func(opts *subOpts) error {
+		if strings.Contains(name, ".") {
+			return ErrInvalidDurableName
+		}
+
+		opts.cfg.Durable = name
 		return nil
 	})
 }
@@ -794,6 +794,69 @@ func AckAll() SubOpt {
 func AckExplicit() SubOpt {
 	return subOptFn(func(opts *subOpts) error {
 		opts.cfg.AckPolicy = AckExplicitPolicy
+		return nil
+	})
+}
+
+func AckWait(d time.Duration) SubOpt {
+	return subOptFn(func(opts *subOpts) error {
+		opts.cfg.AckWait = d
+		return nil
+	})
+}
+
+func MaxDeliver(n int) SubOpt {
+	return subOptFn(func(opts *subOpts) error {
+		opts.cfg.MaxDeliver = n
+		return nil
+	})
+}
+
+func FilterSubject(s string) SubOpt {
+	return subOptFn(func(opts *subOpts) error {
+		opts.cfg.FilterSubject = s
+		return nil
+	})
+}
+
+func PlaybackInstant() SubOpt {
+	return subOptFn(func(opts *subOpts) error {
+		opts.cfg.ReplayPolicy = ReplayInstant
+		return nil
+	})
+}
+
+func PlaybackOriginal() SubOpt {
+	return subOptFn(func(opts *subOpts) error {
+		opts.cfg.ReplayPolicy = ReplayOriginal
+		return nil
+	})
+}
+
+func RateLimit(n uint64) SubOpt {
+	return subOptFn(func(opts *subOpts) error {
+		opts.cfg.RateLimit = n
+		return nil
+	})
+}
+
+func SampleFrequency(s string) SubOpt {
+	return subOptFn(func(opts *subOpts) error {
+		opts.cfg.SampleFrequency = s
+		return nil
+	})
+}
+
+func MaxWaiting(n int) SubOpt {
+	return subOptFn(func(opts *subOpts) error {
+		opts.cfg.MaxWaiting = n
+		return nil
+	})
+}
+
+func MaxAckPending(n int) SubOpt {
+	return subOptFn(func(opts *subOpts) error {
+		opts.cfg.MaxAckPending = n
 		return nil
 	})
 }

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -211,7 +211,7 @@ func TestJetStreamPublish(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	_, err = js.Publish("foo", msg, nats.MaxWait(time.Second), nats.Context(ctx))
+	_, err = js.Publish("foo", msg, nats.AckWait(time.Second), nats.Context(ctx))
 	if err != nats.ErrContextAndTimeout {
 		t.Fatalf("Expected %q, got %q", nats.ErrContextAndTimeout, err)
 	}
@@ -220,7 +220,7 @@ func TestJetStreamPublish(t *testing.T) {
 	sub, _ := nc.SubscribeSync("baz")
 	defer sub.Unsubscribe()
 
-	_, err = js.Publish("baz", msg, nats.MaxWait(time.Nanosecond))
+	_, err = js.Publish("baz", msg, nats.AckWait(time.Nanosecond))
 	if err != nats.ErrTimeout {
 		t.Fatalf("Expected %q, got %q", nats.ErrTimeout, err)
 	}
@@ -1776,7 +1776,7 @@ func TestJetStreamSubscribe_AckPolicy(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 		}
 
-		err = msg.AckSync(nats.MaxWait(2 * time.Second))
+		err = msg.AckSync(nats.AckWait(2 * time.Second))
 		if err != nats.ErrInvalidJSAck {
 			t.Errorf("Unexpected error: %v", err)
 		}

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -562,6 +562,347 @@ func TestJetStreamSubscribe(t *testing.T) {
 	if _, err := js.SubscribeSync("baz", nats.Durable("test.durable")); err != nats.ErrInvalidDurableName {
 		t.Fatalf("Expected invalid durable name error")
 	}
+
+	ackWait := 1 * time.Millisecond
+	sub, err = js.SubscribeSync("bar", nats.Durable("ack-wait"), nats.AckWait(ackWait))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	_, err = sub.NextMsg(1 * time.Second)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	info, err = sub.ConsumerInfo()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if info.Config.AckWait != ackWait {
+		t.Errorf("Expected %v, got %v", ackWait, info.Config.AckWait)
+	}
+}
+
+func TestJetStreamAckPending_Pull(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer s.Shutdown()
+
+	if config := s.JetStreamConfig(); config != nil {
+		defer os.RemoveAll(config.StoreDir)
+	}
+
+	nc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer nc.Close()
+
+	js, err := nc.JetStream()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	const totalMsgs = 3
+	for i := 0; i < totalMsgs; i++ {
+		if _, err := js.Publish("foo", []byte(fmt.Sprintf("msg %d", i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sub, err := js.SubscribeSync("foo",
+		nats.Durable("dname-pull-ack-wait"),
+		nats.AckWait(100*time.Millisecond),
+		nats.MaxDeliver(5),
+		nats.MaxAckPending(3),
+		nats.Pull(15),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub.Unsubscribe()
+
+	// 3 messages delivered 5 times.
+	expected := 15
+	timeout := time.Now().Add(2 * time.Second)
+	pending := 0
+	for time.Now().Before(timeout) {
+		if pending, _, _ = sub.Pending(); pending >= expected {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if pending < expected {
+		t.Errorf("Expected %v, got %v", expected, pending)
+	}
+
+	info, err := sub.ConsumerInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := info.NumRedelivered
+	expected = 3
+	if got < expected {
+		t.Errorf("Expected %v, got: %v", expected, got)
+	}
+
+	got = info.NumAckPending
+	expected = 3
+	if got < expected {
+		t.Errorf("Expected %v, got: %v", expected, got)
+	}
+
+	got = info.NumWaiting
+	expected = 0
+	if got != expected {
+		t.Errorf("Expected %v, got: %v", expected, got)
+	}
+
+	got = int(info.NumPending)
+	expected = 0
+	if got != expected {
+		t.Errorf("Expected %v, got: %v", expected, got)
+	}
+
+	got = info.Config.MaxAckPending
+	expected = 3
+	if got != expected {
+		t.Errorf("Expected %v, got %v", expected, pending)
+	}
+
+	got = info.Config.MaxDeliver
+	expected = 5
+	if got != expected {
+		t.Errorf("Expected %v, got %v", expected, pending)
+	}
+
+	acks := map[int]int{}
+
+	ackPending := 3
+	timeout = time.Now().Add(2 * time.Second)
+	for time.Now().Before(timeout) {
+		info, err := sub.ConsumerInfo()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := info.NumAckPending, ackPending; got > 0 && got != want {
+			t.Fatalf("unexpected num ack pending: got=%d, want=%d", got, want)
+		}
+
+		// Continue to ack all messages until no more pending.
+		pending, _, _ = sub.Pending()
+		if pending == 0 {
+			break
+		}
+
+		m, err := sub.NextMsg(100 * time.Millisecond)
+		if err != nil {
+			t.Fatalf("Error getting next message: %v", err)
+		}
+
+		if err := m.AckSync(); err != nil {
+			t.Fatalf("Error on ack message: %v", err)
+		}
+
+		meta, err := m.MetaData()
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		acks[int(meta.Stream)]++
+
+		if ackPending != 0 {
+			ackPending--
+		}
+		if int(meta.Pending) != ackPending {
+			t.Errorf("Expected %v, got %v", ackPending, meta.Pending)
+		}
+	}
+
+	got = len(acks)
+	expected = 3
+	if got != expected {
+		t.Errorf("Expected %v, got %v", expected, got)
+	}
+
+	expected = 5
+	for _, got := range acks {
+		if got != expected {
+			t.Errorf("Expected %v, got %v", expected, got)
+		}
+	}
+
+	_, err = sub.NextMsg(100 * time.Millisecond)
+	if err != nats.ErrTimeout {
+		t.Errorf("Expected timeout, got: %v", err)
+	}
+}
+
+func TestJetStreamAckPending_Push(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer s.Shutdown()
+
+	if config := s.JetStreamConfig(); config != nil {
+		defer os.RemoveAll(config.StoreDir)
+	}
+
+	nc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer nc.Close()
+
+	js, err := nc.JetStream()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	const totalMsgs = 3
+	for i := 0; i < totalMsgs; i++ {
+		if _, err := js.Publish("foo", []byte(fmt.Sprintf("msg %d", i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sub, err := js.SubscribeSync("foo",
+		nats.Durable("dname-wait"),
+		nats.AckWait(100*time.Millisecond),
+		nats.MaxDeliver(5),
+		nats.MaxAckPending(3),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub.Unsubscribe()
+
+	// 3 messages delivered 5 times.
+	expected := 15
+	timeout := time.Now().Add(2 * time.Second)
+	pending := 0
+	for time.Now().Before(timeout) {
+		if pending, _, _ = sub.Pending(); pending >= expected {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if pending < expected {
+		t.Errorf("Expected %v, got %v", expected, pending)
+	}
+
+	info, err := sub.ConsumerInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := info.NumRedelivered
+	expected = 3
+	if got < expected {
+		t.Errorf("Expected %v, got: %v", expected, got)
+	}
+
+	got = info.NumAckPending
+	expected = 3
+	if got < expected {
+		t.Errorf("Expected %v, got: %v", expected, got)
+	}
+
+	got = info.NumWaiting
+	expected = 0
+	if got != expected {
+		t.Errorf("Expected %v, got: %v", expected, got)
+	}
+
+	got = int(info.NumPending)
+	expected = 0
+	if got != expected {
+		t.Errorf("Expected %v, got: %v", expected, got)
+	}
+
+	got = info.Config.MaxAckPending
+	expected = 3
+	if got != expected {
+		t.Errorf("Expected %v, got %v", expected, pending)
+	}
+
+	got = info.Config.MaxDeliver
+	expected = 5
+	if got != expected {
+		t.Errorf("Expected %v, got %v", expected, pending)
+	}
+
+	acks := map[int]int{}
+
+	ackPending := 3
+	timeout = time.Now().Add(2 * time.Second)
+	for time.Now().Before(timeout) {
+		info, err := sub.ConsumerInfo()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := info.NumAckPending, ackPending; got > 0 && got != want {
+			t.Fatalf("unexpected num ack pending: got=%d, want=%d", got, want)
+		}
+
+		// Continue to ack all messages until no more pending.
+		pending, _, _ = sub.Pending()
+		if pending == 0 {
+			break
+		}
+
+		m, err := sub.NextMsg(100 * time.Millisecond)
+		if err != nil {
+			t.Fatalf("Error getting next message: %v", err)
+		}
+
+		if err := m.AckSync(); err != nil {
+			t.Fatalf("Error on ack message: %v", err)
+		}
+
+		meta, err := m.MetaData()
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		acks[int(meta.Stream)]++
+
+		if ackPending != 0 {
+			ackPending--
+		}
+		if int(meta.Pending) != ackPending {
+			t.Errorf("Expected %v, got %v", ackPending, meta.Pending)
+		}
+	}
+
+	got = len(acks)
+	expected = 3
+	if got != expected {
+		t.Errorf("Expected %v, got %v", expected, got)
+	}
+
+	expected = 5
+	for _, got := range acks {
+		if got != expected {
+			t.Errorf("Expected %v, got %v", expected, got)
+		}
+	}
+
+	_, err = sub.NextMsg(100 * time.Millisecond)
+	if err != nats.ErrTimeout {
+		t.Errorf("Expected timeout, got: %v", err)
+	}
 }
 
 func TestJetStream_Drain(t *testing.T) {


### PR DESCRIPTION
This adds the following new options to Subscribe:

```go
js.SubscribeSync("foo",
	nats.Durable("test"),
	nats.AckWait(5*time.Millisecond),
	nats.MaxDeliver(5),
	nats.MaxAckPending(3),
)
```

This also updates so that `nats.AckWait` can be used to set the timeout to wait for the ack of a Publish or AckSync:

```go
js.Publish("baz", msg, nats.AckWait(5*time.Second))
msg.AckSync(nats.AckWait(2 * time.Second))
```
