### PR TITLE
js: Add sub.Pull() with options

### DIFF
--- a/js.go
+++ b/js.go
@@ -636,7 +636,7 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, opts []
 	// If we are pull based go ahead and fire off the first request to populate.
 	if isPullMode {
 		sub.jsi.pull = o.pull
-		sub.Poll()
+		sub.Pull()
 	}
 
 	return sub, nil
@@ -701,11 +701,43 @@ func Durable(name string) SubOpt {
 // Pull defines the batch size of messages that will be received
 // when using pull based JetStream consumers.
 func Pull(batchSize int) SubOpt {
-	return subOptFn(func(opts *subOpts) error {
-		if batchSize == 0 {
-			return errors.New("nats: batch size of 0 not valid")
-		}
-		opts.pull = batchSize
+	return BatchSize(batchSize)
+}
+
+// BatchSize defines the batch size of messages that will be received
+// when pulling from a consumer.
+type BatchSize int
+
+func (batchSize BatchSize) configureSubscribe(opts *subOpts) error {
+	if err := validateBatchSize(batchSize); err != nil {
+		return err
+	}
+
+	opts.pull = int(batchSize)
+	return nil
+}
+
+func (batchSize BatchSize) configurePull(opts *pullOpts) error {
+	if err := validateBatchSize(batchSize); err != nil {
+		return err
+	}
+
+	opts.batchSize = int(batchSize)
+	return nil
+}
+
+func validateBatchSize(batchSize BatchSize) error {
+	if batchSize == 0 {
+		return errors.New("nats: batch size of 0 not valid")
+	}
+
+	return nil
+}
+
+// PullNoWait defines whether to disable waiting when making a pull request.
+func PullNoWait() PullOpt {
+	return pullOptFn(func(opts *pullOpts) error {
+		opts.noWait = true
 		return nil
 	})
 }
@@ -819,19 +851,52 @@ func (sub *Subscription) ConsumerInfo() (*ConsumerInfo, error) {
 	return js.getConsumerInfo(stream, consumer)
 }
 
-func (sub *Subscription) Poll() error {
+type pullOpts struct {
+	batchSize int
+	noWait    bool
+}
+
+type PullOpt interface {
+	configurePull(opts *pullOpts) error
+}
+
+// pullOptFn is a function option used to configure pull consumers.
+type pullOptFn func(opts *pullOpts) error
+
+func (opt pullOptFn) configurePull(opts *pullOpts) error {
+	return opt(opts)
+}
+
+// Pull makes a request to be delivered a batch of messages
+// from a stream.
+func (sub *Subscription) Pull(opts ...PullOpt) error {
+	var o pullOpts
+	for _, opt := range opts {
+		if err := opt.configurePull(&o); err != nil {
+			return err
+		}
+	}
+
 	sub.mu.Lock()
 	if sub.jsi == nil || sub.jsi.deliver != _EMPTY_ || sub.jsi.pull == 0 {
 		sub.mu.Unlock()
 		return ErrTypeSubscription
 	}
-	batch := sub.jsi.pull
+
+	var batch int
+	if o.batchSize > 0 {
+		batch = o.batchSize
+	} else {
+		batch = sub.jsi.pull
+	}
+
 	nc, reply := sub.conn, sub.Subject
 	stream, consumer := sub.jsi.stream, sub.jsi.consumer
 	js := sub.jsi.js
 	sub.mu.Unlock()
 
-	req, _ := json.Marshal(&nextRequest{Batch: batch})
+	nr := &nextRequest{Batch: batch, NoWait: o.noWait}
+	req, _ := json.Marshal(nr)
 	reqNext := js.apiSubj(fmt.Sprintf(apiRequestNextT, stream, consumer))
 	return nc.PublishRequest(reqNext, reply, req)
 }

--- a/nats.go
+++ b/nats.go
@@ -3740,8 +3740,13 @@ func (s *Subscription) processNextMsgDelivered(msg *Msg) error {
 
 	// In case this is a JetStream message and in pull mode
 	// then check whether it is an JS API error.
-	if jsi != nil && jsi.pull > 0 && len(msg.Data) == 0 && msg.Header.Get(statusHdr) == noResponders {
-		return ErrNoResponders
+	if jsi != nil && jsi.pull > 0 && len(msg.Data) == 0 {
+		switch msg.Header.Get(statusHdr) {
+		case noResponders:
+			return ErrNoResponders
+		case "400", "404", "408", "409":
+			return errors.New(msg.Header.Get(descrHdr))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This renames `sub.Poll()` to `sub.Pull()` which takes options like `NoWait` and `BatchSize` to change how many messages to pull.

```go
// Pull with default batch size
sub.Pull()

// Pull without waiting (404 status msg if no messages)
sub.Pull(nats.PullNoWait())

// Pull to get 5 messages, if no messages then get 404 status
sub.Pull(nats.BatchSize(5), nats.PullNoWait())
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>
