### PR TITLE
js: Add EnableFlowControl option for push consumers

### DIFF
--- a/js.go
+++ b/js.go
@@ -415,6 +415,7 @@ type ConsumerConfig struct {
 	SampleFrequency string        `json:"sample_freq,omitempty"`
 	MaxWaiting      int           `json:"max_waiting,omitempty"`
 	MaxAckPending   int           `json:"max_ack_pending,omitempty"`
+	FlowControl     bool          `json:"flow_control,omitempty"`
 }
 
 // ConsumerInfo is the info from a JetStream consumer.
@@ -868,6 +869,14 @@ func RateLimit(n uint64) SubOpt {
 func BindStream(name string) SubOpt {
 	return subOptFn(func(opts *subOpts) error {
 		opts.stream = name
+		return nil
+	})
+}
+
+// EnableFlowControl enables flow control for a push based consumer.
+func EnableFlowControl() SubOpt {
+	return subOptFn(func(opts *subOpts) error {
+		opts.cfg.FlowControl = true
 		return nil
 	})
 }


### PR DESCRIPTION
This adds support to add opt-in flow control for the users when using push consumers (https://github.com/nats-io/nats-server/pull/1966).

```go
sub, err := js.SubscribeSync("foo", nats.AckWait(100*time.Millisecond), nats.EnableFlowControl())
```
```go
sub, err := js.Subscribe("foo", func(msg *nats.Msg) {}, nats.EnableFlowControl())
```

~~Opening PR as draft since a few questions~~

- In this PR, we are automatically handling the flow control for the user by detecting `100` status and responding automatically? ~~Should this be the default or an opt-in behavior like `nats.AutoFlowControl()` and let the user manually process the flow control messages?~~

✅  **A: Never surface to users and automatically handle when enabled**
 
- Currently the default so that flow control logic kicks is [4MB](https://github.com/nats-io/nats-server/blob/9813ae3f794a7833b7e1e0104ea0e9c148b5d316/server/consumer.go#L236) and FlowControl in the consumer request is a [bool](https://github.com/nats-io/nats-server/blob/9813ae3f794a7833b7e1e0104ea0e9c148b5d316/server/consumer.go#L65).  ~~In case it is later possible to add `flow_control_max_pending` to change the default?~~

 ✅ **A: Server will decide for now, no option for custom flow control needed**

Signed-off-by: Waldemar Quevedo <wally@synadia.com>