### PR TITLE
Add optional JSOpts to management API

### DIFF
--- a/js.go
+++ b/js.go
@@ -899,8 +899,14 @@ func (sub *Subscription) Poll() error {
 }
 
 func (js *js) getConsumerInfo(stream, consumer string) (*ConsumerInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), js.opts.wait)
+	defer cancel()
+	return js.getConsumerInfoContext(ctx, stream, consumer)
+}
+
+func (js *js) getConsumerInfoContext(ctx context.Context, stream, consumer string) (*ConsumerInfo, error) {
 	ccInfoSubj := fmt.Sprintf(apiConsumerInfoT, stream, consumer)
-	resp, err := js.nc.Request(js.apiSubj(ccInfoSubj), nil, js.opts.wait)
+	resp, err := js.nc.RequestWithContext(ctx, js.apiSubj(ccInfoSubj), nil)
 	if err != nil {
 		if err == ErrNoResponders {
 			err = ErrJetStreamNotEnabled

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -1130,7 +1130,7 @@ func TestJetStreamManagement(t *testing.T) {
 		var names []string
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
-		for name := range js.ConsumerNames(ctx, "foo") {
+		for name := range js.ConsumerNames("foo", nats.Context(ctx)) {
 			names = append(names, name)
 		}
 		if got, want := len(names), 1; got != want {
@@ -1162,7 +1162,7 @@ func TestJetStreamManagement(t *testing.T) {
 		var names []string
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
-		for name := range js.StreamNames(ctx) {
+		for name := range js.StreamNames(nats.Context(ctx)) {
 			names = append(names, name)
 		}
 		if got, want := len(names), 1; got != want {


### PR DESCRIPTION
This changes the management APIs to receive options.

```diff
-	AddStream(cfg *StreamConfig) (*StreamInfo, error)
+	AddStream(cfg *StreamConfig, opts ...JSOpt) (*StreamInfo, error)
```

This also updates calls that accepted a timeout to accept a context instead. The context is created from the old timeout value.

```diff
-	r, err := js.nc.Request(usSubj, req, js.opts.wait)
+	r, err := js.nc.RequestWithContext(o.ctx, usSubj, req)
```