### PR TITLE
Support setting a custom inbox prefix via nats.Options

### DIFF
--- a/context.go
+++ b/context.go
@@ -92,7 +92,7 @@ func (nc *Conn) requestWithContext(ctx context.Context, subj string, hdr, data [
 
 // oldRequestWithContext utilizes inbox and subscription per request.
 func (nc *Conn) oldRequestWithContext(ctx context.Context, subj string, hdr, data []byte) (*Msg, error) {
-	inbox := NewInbox()
+	inbox := nc.NewInbox()
 	ch := make(chan *Msg, RequestChanLen)
 
 	s, err := nc.subscribe(inbox, _EMPTY_, nil, ch, true, nil)

--- a/js.go
+++ b/js.go
@@ -538,7 +538,7 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, opts []
 		if o.cfg.DeliverSubject != _EMPTY_ {
 			deliver = o.cfg.DeliverSubject
 		} else {
-			deliver = NewInbox()
+			deliver = js.nc.NewInbox()
 		}
 	} else {
 		// Find the stream mapped to the subject.
@@ -572,11 +572,11 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, opts []
 			if ccfg.DeliverSubject != _EMPTY_ {
 				deliver = ccfg.DeliverSubject
 			} else {
-				deliver = NewInbox()
+				deliver = js.nc.NewInbox()
 			}
 		} else {
 			shouldCreate = true
-			deliver = NewInbox()
+			deliver = js.nc.NewInbox()
 			if !isPullMode {
 				cfg.DeliverSubject = deliver
 			}

--- a/nats.go
+++ b/nats.go
@@ -3087,7 +3087,7 @@ func (nc *Conn) createNewRequestAndSend(subj string, hdr, data []byte) (chan *Ms
 	// Create new literal Inbox and map to a chan msg.
 	mch := make(chan *Msg, RequestChanLen)
 	respInbox := nc.newRespInbox()
-	token := respInbox[len(nc.respSub):]
+	token := respInbox[len(nc.respSub)-1:]
 	nc.respMap[token] = mch
 	if nc.respMux == nil {
 		// Create the response subscription we will use for all new style responses.
@@ -3259,10 +3259,10 @@ func (nc *Conn) newRespInbox() string {
 	if nc.respMap == nil {
 		nc.initNewResp()
 	}
-	respInboxPrefixLen := len(nc.respSub)
+	respInboxPrefixLen := len(nc.respSub) - 1
 	var b strings.Builder
 	b.Grow(respInboxPrefixLen + replySuffixLen)
-	b.WriteString(nc.respSub)
+	b.WriteString(nc.respSub[:respInboxPrefixLen])
 	rn := nc.respRand.Int63()
 	for i, l := 0, rn; i < replySuffixLen; i++ {
 		b.WriteByte(rdigits[l%base])

--- a/nats_test.go
+++ b/nats_test.go
@@ -2573,7 +2573,7 @@ func TestMsg_RespondMsg(t *testing.T) {
 	}
 	defer nc.Close()
 
-	sub, err := nc.SubscribeSync(NewInbox())
+	sub, err := nc.SubscribeSync(nc.NewInbox())
 	if err != nil {
 		t.Fatalf("subscribe failed: %s", err)
 	}

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -116,6 +116,18 @@ func BenchmarkInboxCreation(b *testing.B) {
 	}
 }
 
+func BenchmarkConnInboxCreation(b *testing.B) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+	nc := NewDefaultConnection(b)
+	defer nc.Close()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		nc.NewInbox()
+	}
+}
+
 func BenchmarkNewInboxCreation(b *testing.B) {
 	s := RunDefaultServer()
 	defer s.Shutdown()

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -2362,7 +2362,7 @@ func TestJetStreamSubscribe_AckPolicy(t *testing.T) {
 	})
 
 	t.Run("non js sub ack", func(t *testing.T) {
-		inbox := nats.NewInbox()
+		inbox := nc.NewInbox()
 		_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
 			Durable:        "wq",
 			AckPolicy:      nats.AckExplicitPolicy,

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -690,7 +690,7 @@ func TestAsyncSubscriberStarvation(t *testing.T) {
 	// Kickoff
 	nc.Subscribe("start", func(m *nats.Msg) {
 		// Helper Response
-		response := nats.NewInbox()
+		response := nc.NewInbox()
 		nc.Subscribe(response, func(_ *nats.Msg) {
 			ch <- true
 		})
@@ -1559,7 +1559,7 @@ func TestAutoUnsubOnSyncSubCanStillRespond(t *testing.T) {
 		t.Fatalf("Error autounsub: %v", err)
 	}
 
-	inbox := nats.NewInbox()
+	inbox := nc.NewInbox()
 	if err = nc.PublishRequest(subj, inbox, nil); err != nil {
 		t.Fatalf("Error making request: %v", err)
 	}


### PR DESCRIPTION
## Description

This PR makes it possible to configure a custom inbox prefix.

Comments and critique welcome :-)

#### Use Case:

We @pascomnet are using a unique service identifier as part of every subject
including inboxes, without custom inbox prefix suppport we can't use the go
clients built in facilities for Requests, while e.g. the java client supports
this out of the box.

#### Proposed Change:

It can be done in a fully backwards compatible way (see pull request)

- Add a new InboxPrefix field to nats.Options
- Add a new function Conn.NewInbox.
- Deprecate the free function NewInbox() and direct people to use Conn.NewInbox function instead.

#### Who Benefits From The Change(s)?

Everyone who wants to use this feature :-)

#### Alternative Approaches

Do not use the builtin request/inbox client features, without reimplementing the
relevant nats.go parts this is a lot less efficient, a naive approach requires a
new subscription per request. In effect this is similar to old style requests.

### Benchmarks

Here is my benchmark environment:

```console
❯ cat /proc/cpuinfo | grep -i 'model name' | head -1
model name	: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz

❯ lsb_release -d
Description:	Ubuntu 20.10

❯ go version
go version go1.15.6 linux/amd64
```

Results on master:

```console
❯ go test -benchtime=10s -run=NONE -bench='Inbox' .
goos: linux
goarch: amd64
pkg: github.com/nats-io/nats.go/test
BenchmarkInboxCreation-12       	100000000	      120 ns/op
BenchmarkNewInboxCreation-12    	126825975	      102 ns/op
PASS
ok  	github.com/nats-io/nats.go/test	34.671s

```

Results from this PR:

```console
❯ go test -benchtime=10s -run=NONE -bench='Inbox' .
goos: linux
goarch: amd64
pkg: github.com/nats-io/nats.go/test
BenchmarkInboxCreation-12        	100000000	      103 ns/op
BenchmarkConnInboxCreation-12    	97371662	      123 ns/op
BenchmarkNewInboxCreation-12     	114624123	      110 ns/op
PASS
ok  	github.com/nats-io/nats.go/test	50.713s
```
