### PR TITLE
Add option for custom inbox prefix for requests

### DIFF
--- a/context.go
+++ b/context.go
@@ -92,7 +92,7 @@ func (nc *Conn) requestWithContext(ctx context.Context, subj string, hdr, data [
 
 // oldRequestWithContext utilizes inbox and subscription per request.
 func (nc *Conn) oldRequestWithContext(ctx context.Context, subj string, hdr, data []byte) (*Msg, error) {
-	inbox := NewInbox()
+	inbox := nc.buildCustomInbox(NewInbox())
 	ch := make(chan *Msg, RequestChanLen)
 
 	s, err := nc.subscribe(inbox, _EMPTY_, nil, ch, true, nil)

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -128,6 +128,21 @@ func BenchmarkNewInboxCreation(b *testing.B) {
 	}
 }
 
+func BenchmarkNewInboxCreationCustomPrefix(b *testing.B) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+	nc, err := nats.Connect("localhost", nats.CustomInboxPrefix("_"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer nc.Close()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		nc.NewRespInbox()
+	}
+}
+
 func BenchmarkRequest(b *testing.B) {
 	b.StopTimer()
 	s := RunDefaultServer()


### PR DESCRIPTION
Currently the prefix for inboxes requests is always the literal [_INBOX.](https://github.com/nats-io/nats.go/blob/47f4a4cfa7fba8c48e1bad2639d4725b4809c4a3/nats.go#L3190), but in some special cases there might be a need to change this subject.  In this PR a `nats.CustomInboxPrefix` option is introduced to change this prefix for a connection and be able to reuse`nc.Request` to make requests with a custom prefix:

```go
nats.Connect("demo.nats.io", nats.CustomInboxPrefix("my_inbox"))
```

Related issues:
- https://github.com/nats-io/nats.go/issues/331
- #678
- https://github.com/nats-io/nats.go/pull/360

Local Benchmarks

### custom inbox

Using a custom prefix is slightly slower but does not affect original logic and also has the same number of allocations:

```
NATS @ ~/repos/nats-dev/src/github.com/nats-io/nats.go/test (custom-inbox) $ go test -run=NewInbox -bench=Inbox -benchmem  -v
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats.go/test
cpu: Intel(R) Core(TM) i5-8210Y CPU @ 1.60GHz
BenchmarkInboxCreation
BenchmarkInboxCreation-4                  	11320990	        91.38 ns/op	      56 B/op	       2 allocs/op
BenchmarkNewInboxCreation
BenchmarkNewInboxCreation-4               	11165302	        89.74 ns/op	      48 B/op	       1 allocs/op
BenchmarkNewInboxCreationCustomPrefix
BenchmarkNewInboxCreationCustomPrefix-4   	 7951897	       144.3 ns/op	      96 B/op	       2 allocs/op
PASS
ok  	github.com/nats-io/nats.go/test	3.873s

NATS @ ~/repos/nats-dev/src/github.com/nats-io/nats.go/test (custom-inbox) $ go test -run=NewInbox -bench=Request -benchmem  -v
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats.go/test
cpu: Intel(R) Core(TM) i5-8210Y CPU @ 1.60GHz
BenchmarkRequest
BenchmarkRequest-4      	    9106	    130985 ns/op	     889 B/op	      22 allocs/op
BenchmarkOldRequest
BenchmarkOldRequest-4   	    8110	    145507 ns/op	    2753 B/op	      53 allocs/op
PASS
ok  	github.com/nats-io/nats.go/test	4.469s
```

### latest

```
NATS @ ~/repos/nats-dev/src/github.com/nats-io/nats.go/test (master) $ go test -run=NewInbox -bench=Inbox -benchmem  -v
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats.go/test
cpu: Intel(R) Core(TM) i5-8210Y CPU @ 1.60GHz
BenchmarkInboxCreation
BenchmarkInboxCreation-4      	11373039	        91.77 ns/op	      56 B/op	       2 allocs/op
BenchmarkNewInboxCreation
BenchmarkNewInboxCreation-4   	11550328	        86.65 ns/op	      48 B/op	       1 allocs/op
PASS
ok  	github.com/nats-io/nats.go/test	2.427s

NATS @ ~/repos/nats-dev/src/github.com/nats-io/nats.go/test (master) $ go test -run=NewInbox -bench=Request -benchmem  -v
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats.go/test
cpu: Intel(R) Core(TM) i5-8210Y CPU @ 1.60GHz
BenchmarkRequest
BenchmarkRequest-4      	    7808	    135410 ns/op	     896 B/op	      22 allocs/op
BenchmarkOldRequest
BenchmarkOldRequest-4   	    8374	    146854 ns/op	    2757 B/op	      53 allocs/op
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>