### PR TITLE
js: Add support for FlowControl and Heartbeats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/golang/protobuf v1.4.2
-	github.com/nats-io/nats-server/v2 v2.2.1-0.20210327180151-03aee09847d0
+	github.com/nats-io/nats-server/v2 v2.2.1-0.20210326232401-9f753a247545
 	github.com/nats-io/nkeys v0.3.0
 	github.com/nats-io/nuid v1.0.1
 	google.golang.org/protobuf v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/nats-io/nats-server/v2 v2.1.8-0.20200929001935-7f44d075f7ad/go.mod h1
 github.com/nats-io/nats-server/v2 v2.1.8-0.20201129161730-ebe63db3e3ed/go.mod h1:XD0zHR/jTXdZvWaQfS5mQgsXj6x12kMjKLyAk/cOGgY=
 github.com/nats-io/nats-server/v2 v2.1.8-0.20210205154825-f7ab27f7dad4/go.mod h1:kauGd7hB5517KeSqspW2U1Mz/jhPbTrE8eOXzUPk1m0=
 github.com/nats-io/nats-server/v2 v2.1.8-0.20210227190344-51550e242af8/go.mod h1:/QQ/dpqFavkNhVnjvMILSQ3cj5hlmhB66adlgNbjuoA=
-github.com/nats-io/nats-server/v2 v2.2.1-0.20210327180151-03aee09847d0 h1:ybeT5VFA73CVQb4rCL+48+up91xWheriSBbJ3M2Pzps=
-github.com/nats-io/nats-server/v2 v2.2.1-0.20210327180151-03aee09847d0/go.mod h1:eKlAaGmSQHZMFQA6x56AaP5/Bl9N3mWF4awyT2TTpzc=
+github.com/nats-io/nats-server/v2 v2.2.1-0.20210326232401-9f753a247545 h1:8xNPhr7nW0+4W+bwHziYzQLqoN+Z7Rko19Doe+8XW3w=
+github.com/nats-io/nats-server/v2 v2.2.1-0.20210326232401-9f753a247545/go.mod h1:eKlAaGmSQHZMFQA6x56AaP5/Bl9N3mWF4awyT2TTpzc=
 github.com/nats-io/nats.go v1.10.0/go.mod h1:AjGArbfyR50+afOUotNX2Xs5SYHf+CoOa5HH1eEl2HE=
 github.com/nats-io/nats.go v1.10.1-0.20200531124210-96f2130e4d55/go.mod h1:ARiFsjW9DVxk48WJbO3OSZ2DG8fjkMi7ecLmXoY/n9I=
 github.com/nats-io/nats.go v1.10.1-0.20200606002146-fc6fed82929a/go.mod h1:8eAIv96Mo9QW6Or40jUHejS7e4VwZ3VRYD6Sf0BTDp4=

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -905,6 +905,303 @@ func TestJetStreamAckPending_Push(t *testing.T) {
 	}
 }
 
+func TestJetStreamPushFlowControlHeartbeats_SubscribeSync(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer s.Shutdown()
+
+	if config := s.JetStreamConfig(); config != nil {
+		defer os.RemoveAll(config.StoreDir)
+	}
+
+	errHandler := nats.ErrorHandler(func(c *nats.Conn, sub *nats.Subscription, err error) {
+		t.Logf("WARN: %s", err)
+	})
+
+	nc, err := nats.Connect(s.ClientURL(), errHandler)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer nc.Close()
+
+	js, err := nc.JetStream()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Burst and try to hit the flow control limit of the server.
+	const totalMsgs = 16536
+	payload := strings.Repeat("A", 1024)
+	for i := 0; i < totalMsgs; i++ {
+		if _, err := js.Publish("foo", []byte(fmt.Sprintf("i:%d/", i)+payload)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	hbTimer := 500 * time.Millisecond
+	sub, err := js.SubscribeSync("foo",
+		nats.AckWait(30*time.Second),
+		nats.MaxDeliver(1),
+		nats.EnableFlowControl(),
+		nats.IdleHeartbeat(hbTimer),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub.Unsubscribe()
+
+	info, err := sub.ConsumerInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Config.FlowControl {
+		t.Fatal("Expected Flow Control to be enabled")
+	}
+	if info.Config.Heartbeat != hbTimer {
+		t.Errorf("Expected %v, got: %v", hbTimer, info.Config.Heartbeat)
+	}
+
+	m, err := sub.NextMsg(1 * time.Second)
+	if err != nil {
+		t.Fatalf("Error getting next message: %v", err)
+	}
+	meta, err := m.MetaData()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Pending > totalMsgs {
+		t.Logf("WARN: More pending messages than expected (%v), got: %v", totalMsgs, meta.Pending)
+	}
+	err = m.Ack()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recvd := 1
+	timeout := time.Now().Add(10 * time.Second)
+	for time.Now().Before(timeout) {
+		m, err := sub.NextMsg(1 * time.Second)
+		if err != nil {
+			t.Fatalf("Error getting next message: %v", err)
+		}
+		if len(m.Data) == 0 {
+			t.Fatalf("Unexpected empty message: %+v", m)
+		}
+
+		if err := m.Ack(); err != nil {
+			t.Fatalf("Error on ack message: %v", err)
+		}
+		recvd++
+
+		if recvd == totalMsgs {
+			break
+		}
+	}
+
+	t.Run("idle heartbeats", func(t *testing.T) {
+		// Delay to get a few heartbeats.
+		time.Sleep(2 * time.Second)
+
+		timeout = time.Now().Add(5 * time.Second)
+		for time.Now().Before(timeout) {
+			msg, err := sub.NextMsg(200 * time.Millisecond)
+			if err != nil {
+				if err == nats.ErrTimeout {
+					// If timeout, ok to stop checking for the test.
+					break
+				}
+				t.Fatal(err)
+			}
+			if len(msg.Data) == 0 {
+				t.Fatalf("Unexpected empty message: %+v", m)
+			}
+
+			recvd++
+			meta, err := msg.MetaData()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if meta.Pending == 0 {
+				break
+			}
+		}
+		if recvd > totalMsgs {
+			t.Logf("WARN: Received more messages than expected (%v), got: %v", totalMsgs, recvd)
+		}
+	})
+
+	t.Run("with context", func(t *testing.T) {
+		sub, err := js.SubscribeSync("foo",
+			nats.AckWait(100*time.Millisecond),
+			nats.Durable("bar"),
+			nats.EnableFlowControl(),
+			nats.IdleHeartbeat(hbTimer),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer sub.Unsubscribe()
+
+		info, err = sub.ConsumerInfo()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !info.Config.FlowControl {
+			t.Fatal("Expected Flow Control to be enabled")
+		}
+
+		recvd = 0
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		for {
+			select {
+			case <-ctx.Done():
+				t.Fatal(ctx.Err())
+			default:
+			}
+
+			m, err := sub.NextMsgWithContext(ctx)
+			if err != nil {
+				t.Fatalf("Error getting next message: %v", err)
+			}
+			if len(m.Data) == 0 {
+				t.Fatalf("Unexpected empty message: %+v", m)
+			}
+
+			if err := m.Ack(); err != nil {
+				t.Fatalf("Error on ack message: %v", err)
+			}
+			recvd++
+
+			if recvd >= totalMsgs {
+				break
+			}
+		}
+
+		// Delay to get a few heartbeats.
+		time.Sleep(2 * time.Second)
+		for {
+			select {
+			case <-ctx.Done():
+				if ctx.Err() == context.DeadlineExceeded {
+					return
+				}
+			default:
+			}
+
+			msg, err := sub.NextMsgWithContext(ctx)
+			if err != nil {
+				if err == context.DeadlineExceeded {
+					break
+				}
+				t.Fatal(err)
+			}
+			if len(msg.Data) == 0 {
+				t.Fatalf("Unexpected empty message: %+v", m)
+			}
+
+			meta, err := msg.MetaData()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if meta.Pending == 0 {
+				break
+			}
+		}
+	})
+}
+
+func TestJetStreamPushFlowControlHeartbeats_SubscribeAsync(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer s.Shutdown()
+
+	if config := s.JetStreamConfig(); config != nil {
+		defer os.RemoveAll(config.StoreDir)
+	}
+
+	nc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer nc.Close()
+
+	js, err := nc.JetStream()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Burst and try to hit the flow control limit of the server.
+	const totalMsgs = 16536
+	payload := strings.Repeat("A", 1024)
+	for i := 0; i < totalMsgs; i++ {
+		if _, err := js.Publish("foo", []byte(payload)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	recvd := make(chan *nats.Msg, totalMsgs)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	errCh := make(chan error)
+	hbTimer := 200 * time.Millisecond
+	sub, err := js.Subscribe("foo", func(msg *nats.Msg) {
+		if len(msg.Data) == 0 {
+			errCh <- fmt.Errorf("Unexpected empty message: %+v", msg)
+		}
+		recvd <- msg
+
+		if len(recvd) == totalMsgs {
+			cancel()
+		}
+	}, nats.EnableFlowControl(), nats.IdleHeartbeat(hbTimer))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub.Unsubscribe()
+
+	info, err := sub.ConsumerInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Config.FlowControl {
+		t.Fatal("Expected Flow Control to be enabled")
+	}
+	if info.Config.Heartbeat != hbTimer {
+		t.Errorf("Expected %v, got: %v", hbTimer, info.Config.Heartbeat)
+	}
+
+	<-ctx.Done()
+
+	got := len(recvd)
+	expected := totalMsgs
+	if got != expected {
+		t.Errorf("Expected %v, got: %v", expected, got)
+	}
+
+	// Wait for a couple of heartbeats to arrive and confirm there is no error.
+	select {
+	case <-time.After(1 * time.Second):
+	case err := <-errCh:
+		t.Fatal(err)
+	}
+}
+
 func TestJetStream_Drain(t *testing.T) {
 	s := RunBasicJetStreamServer()
 	defer s.Shutdown()
@@ -4039,6 +4336,14 @@ func testJetStream_ClusterReconnectDurableQueueSubscriber(t *testing.T, subject 
 				srvA.Restart()
 			}
 		}),
+		nats.ErrorHandler(func(_ *nats.Conn, sub *nats.Subscription, err error) {
+			t.Logf("WARN: Got error %v", err)
+			if info, ok := err.(*nats.ErrConsumerSequenceMismatch); ok {
+				t.Logf("WARN: %+v", info)
+			}
+			// Take out this QueueSubscriber from the group.
+			sub.Drain()
+		}),
 	)
 	if err != nil {
 		t.Error(err)
@@ -4094,7 +4399,7 @@ func testJetStream_ClusterReconnectDurableQueueSubscriber(t *testing.T, subject 
 					}
 				}
 			}
-		}, nats.Durable(dname), nats.AckWait(5*time.Second), nats.ManualAck())
+		}, nats.Durable(dname), nats.AckWait(5*time.Second), nats.ManualAck(), nats.IdleHeartbeat(100*time.Millisecond))
 
 		if err != nil && (err != nats.ErrTimeout && err != context.DeadlineExceeded) {
 			t.Error(err)
@@ -4146,12 +4451,15 @@ func testJetStream_ClusterReconnectDurableQueueSubscriber(t *testing.T, subject 
 
 	<-ctx.Done()
 
+	// Wait a bit to get heartbeats.
+	time.Sleep(2 * time.Second)
+
 	// Drain to allow AckSync response to be received.
 	nc.Drain()
 
 	got := len(msgs)
 	if got != totalMsgs {
-		t.Logf("WARN: Expected %v, got: %v", totalMsgs, got)
+		t.Logf("WARN: Expected %v, got: %v (failed publishes: %v)", totalMsgs, got, failedPubs)
 	}
 	if got < totalMsgs-failedPubs {
 		t.Errorf("Expected %v, got: %v", totalMsgs-failedPubs, got)


### PR DESCRIPTION
This adds the following options to push based consumers:

```go
sub, err := js.Subscribe("foo", func(msg *nats.Msg) {}, nats.EnableFlowControl(), nats.IdleHeartbeat(2*time.Second))

sub, err := js.SubscribeSync("foo", nats.EnableFlowControl(), nats.IdleHeartbeat(2*time.Second))
```

When they are enabled, the client will automatically handle/skip the control messages sent by the server.  In case of push based consumers with Heartbeats, an asynchronous typed error will be dispatched so that the subscription could deleted and restarted from the given sequence:

```go
errHandler := nats.ErrorHandler(func(c *nats.Conn, sub *nats.Subscription, err error) {
	if info, ok := err.(*nats.ErrConsumerSequenceMismatch); ok {
		t.Logf("Subscription should be restarted from stream sequence at %+v", info.StreamResumeSequence)
	}
})
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>