### PR TITLE
js: Use old request style for sub.Fetch(1)

### DIFF
--- a/js.go
+++ b/js.go
@@ -1004,7 +1004,7 @@ func (sub *Subscription) Fetch(batch int, opts ...PullOpt) ([]*Msg, error) {
 
 	// In case of only one message, then can already handle with built-in request functions.
 	if batch == 1 {
-		resp, err := nc.RequestWithContext(ctx, reqNext, req)
+		resp, err := nc.oldRequestWithContext(ctx, reqNext, nil, req)
 		if err != nil {
 			return nil, checkCtxErr(err)
 		}


### PR DESCRIPTION
In case of using multiple PullSubscribers concurrently under the same connection, some of the pull messages could have been missed when calling `sub.Fetch(1)`.  The reason was due to the special case added for when batch == 1 to use the global request handler, but due to the [subject rewriting of JetStream](https://github.com/nats-io/nats.go/blob/master/nats.go#L3032-L3034) messages happening then this meant that some of the replies were not being returned.  As a workaround, we just switch to an old style request for the case of batch == 1 as well.

Signed-off-by: Waldemar Quevedo <wally@synadia.com>