### PR TITLE
js: Remove DirectOnly JS Option

### DIFF
--- a/js.go
+++ b/js.go
@@ -128,8 +128,6 @@ type jsOpts struct {
 	pre string
 	// Amount of time to wait for API requests.
 	wait time.Duration
-	// Signals only direct access and no API access.
-	direct bool
 }
 
 const defaultRequestWait = 5 * time.Second
@@ -148,10 +146,6 @@ func (nc *Conn) JetStream(opts ...JSOpt) (JetStreamContext, error) {
 		if err := opt.configureJSContext(js.opts); err != nil {
 			return nil, err
 		}
-	}
-
-	if js.opts.direct {
-		return js, nil
 	}
 
 	if _, err := js.AccountInfo(); err != nil {
@@ -183,14 +177,6 @@ func APIPrefix(pre string) JSOpt {
 		if !strings.HasSuffix(js.pre, ".") {
 			js.pre = js.pre + "."
 		}
-		return nil
-	})
-}
-
-// DirectOnly makes a JetStream context avoid using the JetStream API altogether.
-func DirectOnly() JSOpt {
-	return jsOptFn(func(js *jsOpts) error {
-		js.direct = true
 		return nil
 	})
 }
@@ -462,13 +448,7 @@ func (jsi *jsSub) unsubscribe(drainMode bool) error {
 		// consumers when using drain mode.
 		return nil
 	}
-
-	// Skip if in direct mode as well.
 	js := jsi.js
-	if js.opts.direct {
-		return nil
-	}
-
 	return js.DeleteConsumer(jsi.stream, jsi.consumer)
 }
 
@@ -547,66 +527,53 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, opts []
 		attached     bool
 		stream       = o.stream
 		consumer     = o.consumer
-		requiresAPI  = (stream == _EMPTY_ && consumer == _EMPTY_) && o.cfg.DeliverSubject == _EMPTY_
 	)
 
-	if js.opts.direct && requiresAPI {
-		return nil, ErrDirectModeRequired
+	// Find the stream mapped to the subject if not bound to a stream already.
+	if o.stream == _EMPTY_ {
+		stream, err = js.lookupStreamBySubject(subj)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		stream = o.stream
 	}
 
-	if js.opts.direct {
-		if o.cfg.DeliverSubject != _EMPTY_ {
-			deliver = o.cfg.DeliverSubject
+	// With an explicit durable name, then can lookup
+	// the consumer to which it should be attaching to.
+	var info *ConsumerInfo
+	consumer = o.cfg.Durable
+	if consumer != _EMPTY_ {
+		// Only create in case there is no consumer already.
+		info, err = js.ConsumerInfo(stream, consumer)
+		if err != nil && err.Error() != `consumer not found` {
+			return nil, err
+		}
+	}
+
+	if info != nil {
+		// Attach using the found consumer config.
+		ccfg = &info.Config
+		attached = true
+
+		// Make sure this new subject matches or is a subset.
+		if ccfg.FilterSubject != _EMPTY_ && subj != ccfg.FilterSubject {
+			return nil, ErrSubjectMismatch
+		}
+
+		if ccfg.DeliverSubject != _EMPTY_ {
+			deliver = ccfg.DeliverSubject
 		} else {
 			deliver = NewInbox()
 		}
 	} else {
-		// Find the stream mapped to the subject if not bound to a stream already.
-		if o.stream == _EMPTY_ {
-			stream, err = js.lookupStreamBySubject(subj)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			stream = o.stream
+		shouldCreate = true
+		deliver = NewInbox()
+		if !isPullMode {
+			cfg.DeliverSubject = deliver
 		}
-
-		// With an explicit durable name, then can lookup
-		// the consumer to which it should be attaching to.
-		var info *ConsumerInfo
-		consumer = o.cfg.Durable
-		if consumer != _EMPTY_ {
-			// Only create in case there is no consumer already.
-			info, err = js.ConsumerInfo(stream, consumer)
-			if err != nil && err.Error() != `consumer not found` {
-				return nil, err
-			}
-		}
-
-		if info != nil {
-			// Attach using the found consumer config.
-			ccfg = &info.Config
-			attached = true
-
-			// Make sure this new subject matches or is a subset.
-			if ccfg.FilterSubject != _EMPTY_ && subj != ccfg.FilterSubject {
-				return nil, ErrSubjectMismatch
-			}
-
-			if ccfg.DeliverSubject != _EMPTY_ {
-				deliver = ccfg.DeliverSubject
-			} else {
-				deliver = NewInbox()
-			}
-		} else {
-			shouldCreate = true
-			deliver = NewInbox()
-			if !isPullMode {
-				cfg.DeliverSubject = deliver
-			}
-			// Do filtering always, server will clear as needed.
-			cfg.FilterSubject = subj
-		}
+		// Do filtering always, server will clear as needed.
+		cfg.FilterSubject = subj
 	}
 
 	var sub *Subscription
@@ -686,11 +653,7 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, opts []
 	} else {
 		sub.jsi.stream = stream
 		sub.jsi.consumer = consumer
-		if js.opts.direct {
-			sub.jsi.deliver = o.cfg.DeliverSubject
-		} else {
-			sub.jsi.deliver = ccfg.DeliverSubject
-		}
+		sub.jsi.deliver = ccfg.DeliverSubject
 	}
 	sub.jsi.attached = attached
 
@@ -882,11 +845,6 @@ func (sub *Subscription) ConsumerInfo() (*ConsumerInfo, error) {
 
 	// Consumer info lookup should fail if in direct mode.
 	js := sub.jsi.js
-	if js.opts.direct {
-		sub.mu.Unlock()
-		return nil, ErrDirectModeRequired
-	}
-
 	stream, consumer := sub.jsi.stream, sub.jsi.consumer
 	sub.mu.Unlock()
 

--- a/nats.go
+++ b/nats.go
@@ -129,7 +129,6 @@ var (
 	ErrBadHeaderMsg                 = errors.New("nats: message could not decode headers")
 	ErrNoResponders                 = errors.New("nats: no responders available for request")
 	ErrNoContextOrTimeout           = errors.New("nats: no context or timeout given")
-	ErrDirectModeRequired           = errors.New("nats: direct access requires direct pull or push")
 	ErrPullModeNotAllowed           = errors.New("nats: pull based not supported")
 	ErrJetStreamNotEnabled          = errors.New("nats: jetstream not enabled")
 	ErrJetStreamBadPre              = errors.New("nats: jetstream api prefix not valid")

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -1568,6 +1568,8 @@ func TestJetStreamImportDirectOnly(t *testing.T) {
 				jetstream: enabled
 				users: [ {user: dlc, password: foo} ]
 				exports [
+					# For now have to expose the API to enable JS context across account.
+					{ service: "$JS.API.INFO" }
 					# For the stream publish.
 					{ service: "ORDERS" }
 					# For the pull based consumer. Response type needed for batchsize > 1
@@ -1582,6 +1584,7 @@ func TestJetStreamImportDirectOnly(t *testing.T) {
 			U: {
 				users: [ {user: rip, password: bar} ]
 				imports [
+					{ service: { subject: "$JS.API.INFO", account: JS } }
 					{ service: { subject: "ORDERS", account: JS } , to: "orders" }
 					{ service: { subject: "$JS.API.CONSUMER.MSG.NEXT.ORDERS.d1", account: JS } }
 					{ stream:  { subject: "p.d", account: JS } }
@@ -1649,22 +1652,17 @@ func TestJetStreamImportDirectOnly(t *testing.T) {
 	}
 	defer nc.Close()
 
-	js, err := nc.JetStream(nats.DirectOnly())
+	js, err := nc.JetStream()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// Now make sure we can send to the stream.
+	// Now make sure we can send to the stream from another account.
 	toSend := 100
 	for i := 0; i < toSend; i++ {
 		if _, err := js.Publish("orders", []byte(fmt.Sprintf("ORDER-%d", i+1))); err != nil {
 			t.Fatalf("Unexpected error publishing message %d: %v", i+1, err)
 		}
-	}
-
-	// Check for correct errors.
-	if _, err := js.SubscribeSync("ORDERS"); err != nats.ErrDirectModeRequired {
-		t.Fatalf("Expected an error of '%v', got '%v'", nats.ErrDirectModeRequired, err)
 	}
 
 	var sub *nats.Subscription
@@ -1701,6 +1699,17 @@ func TestJetStreamImportDirectOnly(t *testing.T) {
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
+	}
+
+	// Cannot subscribe with JS context from another account right now.
+	if _, err := js.SubscribeSync("ORDERS"); err != nats.ErrJetStreamNotEnabled {
+		t.Fatalf("Expected an error of '%v', got '%v'", nats.ErrJetStreamNotEnabled, err)
+	}
+	if _, err = js.SubscribeSync("ORDERS", nats.BindStream("ORDERS")); err != nats.ErrJetStreamNotEnabled {
+		t.Fatalf("Expected an error of '%v', got '%v'", nats.ErrJetStreamNotEnabled, err)
+	}
+	if _, err = js.PullSubscribe("ORDERS", nats.BindStream("ORDERS"), nats.Durable("d1")); err != nats.ErrJetStreamNotEnabled {
+		t.Fatalf("Expected an error of '%v', got '%v'", nats.ErrJetStreamNotEnabled, err)
 	}
 }
 


### PR DESCRIPTION
Removes the `nats.DirectOnly` option which was used to lock down the client not making API lookups.

Signed-off-by: Waldemar Quevedo <wally@synadia.com>