### PR TITLE
js: FlowControl + Heartbeats for Push Consumers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/golang/protobuf v1.4.2
-	github.com/nats-io/nats-server/v2 v2.2.1-0.20210330155036-61cbd74e213d
+	github.com/nats-io/nats-server/v2 v2.2.1-0.20210330214444-17836014f2f4
 	github.com/nats-io/nkeys v0.3.0
 	github.com/nats-io/nuid v1.0.1
 	google.golang.org/protobuf v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,9 @@ github.com/nats-io/nats-server/v2 v2.1.8-0.20200929001935-7f44d075f7ad/go.mod h1
 github.com/nats-io/nats-server/v2 v2.1.8-0.20201129161730-ebe63db3e3ed/go.mod h1:XD0zHR/jTXdZvWaQfS5mQgsXj6x12kMjKLyAk/cOGgY=
 github.com/nats-io/nats-server/v2 v2.1.8-0.20210205154825-f7ab27f7dad4/go.mod h1:kauGd7hB5517KeSqspW2U1Mz/jhPbTrE8eOXzUPk1m0=
 github.com/nats-io/nats-server/v2 v2.1.8-0.20210227190344-51550e242af8/go.mod h1:/QQ/dpqFavkNhVnjvMILSQ3cj5hlmhB66adlgNbjuoA=
-github.com/nats-io/nats-server/v2 v2.2.1-0.20210330155036-61cbd74e213d h1:Fi5DT3pdyqP280FPGdkQD+bDjfpR5orUhZ2hhVEU/JA=
-github.com/nats-io/nats-server/v2 v2.2.1-0.20210330155036-61cbd74e213d/go.mod h1:eKlAaGmSQHZMFQA6x56AaP5/Bl9N3mWF4awyT2TTpzc=
+github.com/nats-io/nats-server/v2 v2.2.1-0.20210327180151-03aee09847d0/go.mod h1:eKlAaGmSQHZMFQA6x56AaP5/Bl9N3mWF4awyT2TTpzc=
+github.com/nats-io/nats-server/v2 v2.2.1-0.20210330214444-17836014f2f4 h1:uzJcH/jX0wIozsFVK8mIZ/u5Cyi+85AaYYjB5VyqEk4=
+github.com/nats-io/nats-server/v2 v2.2.1-0.20210330214444-17836014f2f4/go.mod h1:c5ez2f0OGLNrlcHsoUpIf+436p9e2fXgBxryMfZN+Ak=
 github.com/nats-io/nats.go v1.10.0/go.mod h1:AjGArbfyR50+afOUotNX2Xs5SYHf+CoOa5HH1eEl2HE=
 github.com/nats-io/nats.go v1.10.1-0.20200531124210-96f2130e4d55/go.mod h1:ARiFsjW9DVxk48WJbO3OSZ2DG8fjkMi7ecLmXoY/n9I=
 github.com/nats-io/nats.go v1.10.1-0.20200606002146-fc6fed82929a/go.mod h1:8eAIv96Mo9QW6Or40jUHejS7e4VwZ3VRYD6Sf0BTDp4=
@@ -41,6 +42,7 @@ github.com/nats-io/nats.go v1.10.1-0.20201021145452-94be476ad6e0/go.mod h1:VU2zE
 github.com/nats-io/nats.go v1.10.1-0.20210127212649-5b4924938a9a/go.mod h1:Sa3kLIonafChP5IF0b55i9uvGR10I3hPETFbi4+9kOI=
 github.com/nats-io/nats.go v1.10.1-0.20210211000709-75ded9c77585/go.mod h1:uBWnCKg9luW1g7hgzPxUjHFRI40EuTSX7RCzgnc74Jk=
 github.com/nats-io/nats.go v1.10.1-0.20210228004050-ed743748acac/go.mod h1:hxFvLNbNmT6UppX5B5Tr/r3g+XSwGjJzFn6mxPNJEHc=
+github.com/nats-io/nats.go v1.10.1-0.20210330002604-882e98e18c99/go.mod h1:OieyGzlIObT5YMgJfjuZS4tXG7fUUdRH+hDqioUKbDw=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.4/go.mod h1:XdZpAbhgyyODYqjTawOnIOI7VlbKSarI9Gfy1tqEu/s=
 github.com/nats-io/nkeys v0.2.0/go.mod h1:XdZpAbhgyyODYqjTawOnIOI7VlbKSarI9Gfy1tqEu/s=


### PR DESCRIPTION
This adds the following options to push based consumers:

```go
sub, err := js.Subscribe("foo", func(msg *nats.Msg) {}, nats.EnableFlowControl(), nats.IdleHeartbeat(2*time.Second))

sub, err := js.SubscribeSync("foo", nats.EnableFlowControl(), nats.IdleHeartbeat(2*time.Second))

mch := make(chan *Msg, 512)
sub, err := js.ChanSubscribe("foo", mch, nats.EnableFlowControl(), nats.IdleHeartbeat(2*time.Second))
```

When they are enabled, the client will automatically handle/skip the control messages sent by the server.  In case of push based consumers with Heartbeats, an asynchronous typed error will be dispatched so that the subscription could deleted and restarted from the given sequence:

```go
errHandler := nats.ErrorHandler(func(c *nats.Conn, sub *nats.Subscription, err error) {
	if info, ok := err.(*nats.ErrConsumerSequenceMismatch); ok {
		t.Logf("Subscription should be restarted from stream sequence at %+v", info.StreamResumeSequence)
	}
})
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>