### PR TITLE
js: Renaming of msg metadata fields

### DIFF
--- a/js.go
+++ b/js.go
@@ -1715,13 +1715,12 @@ func (m *Msg) InProgress(opts ...AckOpt) error {
 }
 
 // MsgMetadata is the JetStream metadata associated with received messages.
-type MsgMetaData struct {
-	Consumer   uint64
-	Stream     uint64
-	Delivered  uint64
-	Pending    uint64
-	Timestamp  time.Time
-	StreamName string
+type MsgMetadata struct {
+	Sequence     SequencePair
+	NumDelivered uint64
+	NumPending   uint64
+	Timestamp    time.Time
+	Stream       string
 }
 
 func getMetadataFields(subject string) ([]string, error) {
@@ -1743,9 +1742,9 @@ func getMetadataFields(subject string) ([]string, error) {
 	return tokens, nil
 }
 
-// MetaData retrieves the metadata from a JetStream message. This method will
+// Metadata retrieves the metadata from a JetStream message. This method will
 // return an error for non-JetStream Msgs.
-func (m *Msg) MetaData() (*MsgMetaData, error) {
+func (m *Msg) Metadata() (*MsgMetadata, error) {
 	if _, _, err := m.checkReply(); err != nil {
 		return nil, err
 	}
@@ -1755,15 +1754,14 @@ func (m *Msg) MetaData() (*MsgMetaData, error) {
 		return nil, err
 	}
 
-	meta := &MsgMetaData{
-		Delivered:  uint64(parseNum(tokens[4])),
-		Stream:     uint64(parseNum(tokens[5])),
-		Consumer:   uint64(parseNum(tokens[6])),
-		Timestamp:  time.Unix(0, parseNum(tokens[7])),
-		Pending:    uint64(parseNum(tokens[8])),
-		StreamName: tokens[2],
+	meta := &MsgMetadata{
+		NumDelivered: uint64(parseNum(tokens[4])),
+		NumPending:   uint64(parseNum(tokens[8])),
+		Timestamp:    time.Unix(0, parseNum(tokens[7])),
+		Stream:       tokens[2],
 	}
-
+	meta.Sequence.Stream = uint64(parseNum(tokens[5]))
+	meta.Sequence.Consumer = uint64(parseNum(tokens[6]))
 	return meta, nil
 }
 

--- a/norace_test.go
+++ b/norace_test.go
@@ -158,12 +158,12 @@ func TestNoRaceJetStreamConsumerSlowConsumer(t *testing.T) {
 		if received >= toSend {
 			done <- true
 		}
-		meta, err := m.MetaData()
+		meta, err := m.Metadata()
 		if err != nil {
 			t.Fatalf("could not get message metadata: %s", err)
 		}
-		if meta.Stream != received {
-			t.Errorf("Missed a sequence, was expecting %d but got %d, last error: '%v'", received, meta.Stream, nc.LastError())
+		if meta.Sequence.Stream != received {
+			t.Errorf("Missed a sequence, was expecting %d but got %d, last error: '%v'", received, meta.Sequence.Stream, nc.LastError())
 			nc.Close()
 		}
 		m.Ack()


### PR DESCRIPTION
This renames the `msg.MetaData` into `msg.Metadata` since a closed form compound word ([more commonly used as well](https://github.com/search?l=Golang&o=desc&q=%22Metadata%22&s=&type=Code)) plus other changes to the metadata fields from a message:

- `meta.Delivered` to `meta.NumDelivered` similar to `NumRedelivered` field in `sub.ConsumerInfo`: https://github.com/nats-io/nats.go/blob/1b16e34671b1b5add561c0b6ede3453009c837d0/js.go#L781
- `meta.Pending` to `meta.NumPending` as in `sub.ConsumerInfo`: https://github.com/nats-io/nats.go/blob/1b16e34671b1b5add561c0b6ede3453009c837d0/js.go#L783
- `meta.Stream` and `meta.Consumer` to `meta.StreamSeq` and `meta.ConsumerSeq` respectively
- `meta.StreamName` changes to `meta.Stream`

Signed-off-by: Waldemar Quevedo <wally@synadia.com>
