### PR TITLE
Make Msg.Header fields case-preserving when accessed directly

### DIFF
--- a/test/headers_test.go
+++ b/test/headers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The NATS Authors
+// Copyright 2020-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,9 +14,13 @@
 package test
 
 import (
+	"fmt"
+	"net/http"
 	"reflect"
 	"testing"
 	"time"
+
+	"net/http/httptest"
 
 	natsserver "github.com/nats-io/nats-server/v2/test"
 	"github.com/nats-io/nats.go"
@@ -120,5 +124,223 @@ func TestNoHeaderSupport(t *testing.T) {
 
 	if _, err := nc.RequestMsg(m, time.Second); err != nats.ErrHeadersNotSupported {
 		t.Fatalf("Expected an error, got %v", err)
+	}
+}
+
+func TestMsgHeadersCasePreserving(t *testing.T) {
+	s := RunServerOnPort(-1)
+	defer s.Shutdown()
+
+	nc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		t.Fatalf("Error connecting to server: %v", err)
+	}
+	defer nc.Close()
+
+	subject := "headers.test"
+	sub, err := nc.SubscribeSync(subject)
+	if err != nil {
+		t.Fatalf("Could not subscribe to %q: %v", subject, err)
+	}
+	defer sub.Unsubscribe()
+
+	m := nats.NewMsg(subject)
+
+	// Avoid canonicalizing headers by creating headers manually.
+	//
+	// To not use canonical keys, Go recommends accessing the map directly.
+	// https://golang.org/pkg/net/http/#Header.Set
+	m.Header = http.Header{
+		"CorrelationID": []string{"123"},
+		"Msg-ID":        []string{"456"},
+		"X-NATS-Keys":   []string{"A", "B", "C"},
+		"X-Test-Keys":   []string{"D", "E", "F"},
+	}
+
+	// Users can opt-in to canonicalize an http.Header
+	// by using http.Header.Add()
+	m.Header.Add("Accept-Encoding", "json")
+	m.Header.Add("Authorization", "s3cr3t")
+
+	// Multi Value Header
+	m.Header.Set("X-Test", "First")
+	m.Header.Add("X-Test", "Second")
+	m.Header.Add("X-Test", "Third")
+	m.Data = []byte("Simple Headers")
+	nc.PublishMsg(m)
+
+	msg, err := sub.NextMsg(time.Second)
+	if err != nil {
+		t.Fatalf("Did not receive response: %v", err)
+	}
+
+	// Blank out the sub since its not present in the original.
+	msg.Sub = nil
+	if !reflect.DeepEqual(m, msg) {
+		t.Fatalf("Messages did not match! \n%+v\n%+v\n", m, msg)
+	}
+
+	for _, test := range []struct {
+		Header    string
+		Values    []string
+		Canonical bool
+	}{
+		{"Accept-Encoding", []string{"json"}, true},
+		{"Authorization", []string{"s3cr3t"}, true},
+		{"X-Test", []string{"First", "Second", "Third"}, true},
+		{"CorrelationID", []string{"123"}, false},
+		{"Msg-ID", []string{"456"}, false},
+		{"X-NATS-Keys", []string{"A", "B", "C"}, false},
+		{"X-Test-Keys", []string{"D", "E", "F"}, true},
+	} {
+		// Accessing directly will always work.
+		v, ok := msg.Header[test.Header]
+		if !ok {
+			t.Errorf("Expected %v to be present", test.Header)
+		}
+		if len(v) != len(test.Values) {
+			t.Errorf("Expected %v values in header, got: %v", len(test.Values), len(v))
+		}
+
+		for k, val := range test.Values {
+			hdr := msg.Header[test.Header]
+			vv := hdr[k]
+			if val != vv {
+				t.Errorf("Expected %v values in header, got: %v", val, vv)
+			}
+		}
+
+		// Only canonical version of headers can be fetched with Add/Get/Values.
+		// Need to access the map directly to get the non canonicalized version
+		// as per the Go docs of textproto package.
+		if !test.Canonical {
+			continue
+		}
+
+		if len(test.Values) > 1 {
+			if !reflect.DeepEqual(test.Values, msg.Header.Values(test.Header)) {
+				t.Fatalf("Headers did not match! \n%+v\n%+v\n", test.Values, msg.Header.Values(test.Header))
+			}
+		} else {
+			got := msg.Header.Get(test.Header)
+			expected := test.Values[0]
+			if got != expected {
+				t.Errorf("Expected %v, got:%v", expected, got)
+			}
+		}
+	}
+
+	// Validate that headers processed by HTTP requests are not changed by NATS through many hops.
+	errCh := make(chan error, 2)
+	msgCh := make(chan *nats.Msg, 1)
+	sub, err = nc.Subscribe("nats.svc.A", func(msg *nats.Msg) {
+		//lint:ignore SA1008 non canonical form test
+		hdr := msg.Header["x-trace-id"]
+		hdr = append(hdr, "A")
+		msg.Header["x-trace-id"] = hdr
+		msg.Header.Add("X-Result-A", "A")
+		msg.Subject = "nats.svc.B"
+		resp, err := nc.RequestMsg(msg, 2*time.Second)
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		resp.Subject = msg.Reply
+		err = nc.PublishMsg(resp)
+		if err != nil {
+			errCh <- err
+			return
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer sub.Unsubscribe()
+
+	sub, err = nc.Subscribe("nats.svc.B", func(msg *nats.Msg) {
+		//lint:ignore SA1008 non canonical form test
+		hdr := msg.Header["x-trace-id"]
+		hdr = append(hdr, "B")
+		msg.Header["x-trace-id"] = hdr
+		msg.Header.Add("X-Result-B", "B")
+		msg.Subject = msg.Reply
+		msg.Data = []byte("OK!")
+		err := nc.PublishMsg(msg)
+		if err != nil {
+			errCh <- err
+			return
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer sub.Unsubscribe()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		msg := nats.NewMsg("nats.svc.A")
+		msg.Header = r.Header.Clone()
+		msg.Header["x-trace-id"] = []string{"S"}
+		msg.Header["Result-ID"] = []string{"OK"}
+		resp, err := nc.RequestMsg(msg, 2*time.Second)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		msgCh <- resp
+
+		for k, v := range resp.Header {
+			w.Header()[k] = v
+		}
+
+		// Remove Date for testing.
+		w.Header()["Date"] = nil
+
+		w.WriteHeader(200)
+		fmt.Fprintln(w, string(resp.Data))
+	}))
+	defer ts.Close()
+
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := resp.Header.Get("X-Result-A")
+	if result != "A" {
+		t.Errorf("Unexpected header value, got: %+v", result)
+	}
+	result = resp.Header.Get("X-Result-B")
+	if result != "B" {
+		t.Errorf("Unexpected header value, got: %+v", result)
+	}
+
+	select {
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timeout waiting for message.")
+	case err = <-errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case msg = <-msgCh:
+	}
+	if len(msg.Header) != 6 {
+		t.Errorf("Wrong number of headers in NATS message, got: %v", len(msg.Header))
+	}
+
+	//lint:ignore SA1008 non canonical form test
+	v, ok := msg.Header["x-trace-id"]
+	if !ok {
+		t.Fatal("Missing headers in message")
+	}
+	if !reflect.DeepEqual(v, []string{"S", "A", "B"}) {
+		t.Fatal("Missing headers in message")
 	}
 }

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -169,6 +169,16 @@ func TestJetStreamPublish(t *testing.T) {
 	// Messages should have been rejected.
 	expect(0, 1)
 
+	// Using PublishMsg API and accessing directly the Header map.
+	msg2 := nats.NewMsg("foo")
+	msg2.Header[nats.ExpectedLastSeqHdr] = []string{"10"}
+	pa, err = js.PublishMsg(msg2)
+	if err == nil || !strings.Contains(err.Error(), "wrong last sequence") {
+		t.Fatalf("Expected an error, got %v", err)
+	}
+	// Messages should have been rejected.
+	expect(0, 1)
+
 	// Send in a stream with a msgId
 	pa, err = js.Publish("foo", msg, nats.MsgId("ZZZ"))
 	if err != nil {
@@ -207,6 +217,16 @@ func TestJetStreamPublish(t *testing.T) {
 		t.Fatalf("Unexpected publish error: %v", err)
 	}
 	expect(3, 3)
+
+	// JetStream Headers are case-sensitive right now,
+	// so this will not activate the check.
+	msg3 := nats.NewMsg("foo")
+	msg3.Header["nats-expected-last-sequence"] = []string{"4"}
+	pa, err = js.PublishMsg(msg3)
+	if err != nil {
+		t.Fatalf("Expected an error, got %v", err)
+	}
+	expect(4, 4)
 
 	// Now test context and timeouts.
 	// Both set should fail.
@@ -1714,6 +1734,9 @@ func testJetStreamManagement_GetMsg(t *testing.T, srvs ...*jsServer) {
 		msg := nats.NewMsg("foo.A")
 		data := fmt.Sprintf("A:%d", i)
 		msg.Data = []byte(data)
+		msg.Header = http.Header{
+			"X-NATS-Key": []string{"123"},
+		}
 		msg.Header.Add("X-Nats-Test-Data", data)
 		js.PublishMsg(msg)
 		js.Publish("foo.B", []byte(fmt.Sprintf("B:%d", i)))
@@ -1827,9 +1850,22 @@ func testJetStreamManagement_GetMsg(t *testing.T, srvs ...*jsServer) {
 		}
 		expectedMap := map[string][]string{
 			"X-Nats-Test-Data": {"A:1"},
+			"X-NATS-Key":       {"123"},
 		}
 		if !reflect.DeepEqual(streamMsg.Header, http.Header(expectedMap)) {
 			t.Errorf("Expected %v, got: %v", expectedMap, streamMsg.Header)
+		}
+
+		sub, err := js.SubscribeSync("foo.A", nats.StartSequence(4))
+		if err != nil {
+			t.Fatal(err)
+		}
+		msg, err := sub.NextMsg(2 * time.Second)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(msg.Header, http.Header(expectedMap)) {
+			t.Errorf("Expected %v, got: %v", expectedMap, msg.Header)
 		}
 	})
 }


### PR DESCRIPTION
There is an [issue](https://github.com/golang/go/issues/37834) with Go and the HTTP libraries in that responses handled by its HTTP clients become represented in 'canonical form' (`X-Foo-Bar`) sometimes unexpectedly causing integration issues with proxies, APIs, legacy apps and likely compatibility with http/2 headers to some degree which require headers in lowercase, (unlike http v1 ones that are case insensitive). As a workaround, the Go docs suggest to access the [Header map directly](https://golang.org/pkg/net/http/#Header.Set) to use the fields not in canonical form.

In this PR, it is avoided during the decoding of the headers calling `CanonicalMIMEHeaderKey` in order to be able to preserve the raw version of the headers when traversing over multiple hops without causing unexpected side effects or changing the format over the wire.

If users add headers via `Header.Add()` or `Header.Set()` for example, those methods already call `CanonicalMIMEHeaderKey` when creating the header so they will be presented in canonical form without changes.

Fixes #706 