### PR TITLE
[ADDED] `--nkey` flag to enable nkey authentication using go examples

### DIFF
--- a/examples/nats-bench/main.go
+++ b/examples/nats-bench/main.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 The NATS Authors
+// Copyright 2015-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -35,7 +35,7 @@ const (
 )
 
 func usage() {
-	log.Printf("Usage: nats-bench [-s server (%s)] [--tls] [-np NUM_PUBLISHERS] [-ns NUM_SUBSCRIBERS] [-n NUM_MSGS] [-ms MESSAGE_SIZE] [-csv csvfile] <subject>\n", nats.DefaultURL)
+	log.Printf("Usage: nats-bench [-s server (%s)] [--tls] [-np NUM_PUBLISHERS] [-ns NUM_SUBSCRIBERS] [-n NUM_MSGS] [-ms MESSAGE_SIZE] [-csv csvfile] [-creds file] [-nkey file] <subject>\n", nats.DefaultURL)
 	flag.PrintDefaults()
 }
 
@@ -55,6 +55,7 @@ func main() {
 	var msgSize = flag.Int("ms", DefaultMessageSize, "Size of the message.")
 	var csvFile = flag.String("csv", "", "Save bench data to csv file")
 	var userCreds = flag.String("creds", "", "User Credentials File")
+	var nkeyFile = flag.String("nkey", "", "NKey Seed File")
 	var showHelp = flag.Bool("h", false, "Show help message")
 
 	log.SetFlags(0)
@@ -77,9 +78,22 @@ func main() {
 	// Connect Options.
 	opts := []nats.Option{nats.Name("NATS Benchmark")}
 
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
 	// Use UserCredentials
 	if *userCreds != "" {
 		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
 	}
 
 	// Use TLS specified

--- a/examples/nats-echo/main.go
+++ b/examples/nats-echo/main.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 The NATS Authors
+// Copyright 2018-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -50,6 +50,7 @@ func printMsg(m *nats.Msg, i int) {
 func main() {
 	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
 	var userCreds = flag.String("creds", "", "User Credentials File")
+	var nkeyFile = flag.String("nkey", "", "NKey Seed File")
 	var showTime = flag.Bool("t", false, "Display timestamps")
 	var showHelp = flag.Bool("h", false, "Show help message")
 	var geoloc = flag.Bool("geo", false, "Display geo location of echo service")
@@ -76,9 +77,22 @@ func main() {
 	opts := []nats.Option{nats.Name("NATS Echo Service")}
 	opts = setupConnOptions(opts)
 
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
 	// Use UserCredentials
 	if *userCreds != "" {
 		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
 	}
 
 	// Connect to NATS

--- a/examples/nats-pub/main.go
+++ b/examples/nats-pub/main.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2020 The NATS Authors
+// Copyright 2012-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -26,7 +26,7 @@ import (
 // nats-pub -s demo.nats.io:4443 <subject> <msg> (TLS version)
 
 func usage() {
-	log.Printf("Usage: nats-pub [-s server] [-creds file] [-tlscert file] [-tlskey file] [-tlscacert file] <subject> <msg>\n")
+	log.Printf("Usage: nats-pub [-s server] [-creds file] [-nkey file] [-tlscert file] [-tlskey file] [-tlscacert file] <subject> <msg>\n")
 	flag.PrintDefaults()
 }
 
@@ -38,6 +38,7 @@ func showUsageAndExit(exitcode int) {
 func main() {
 	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
 	var userCreds = flag.String("creds", "", "User Credentials File")
+	var nkeyFile = flag.String("nkey", "", "NKey Seed File")
 	var tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
 	var tlsClientKey = flag.String("tlskey", "", "Private key file for client certificate")
 	var tlsCACert = flag.String("tlscacert", "", "CA certificate to verify peer against")
@@ -60,6 +61,10 @@ func main() {
 	// Connect Options.
 	opts := []nats.Option{nats.Name("NATS Sample Publisher")}
 
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
 	// Use UserCredentials
 	if *userCreds != "" {
 		opts = append(opts, nats.UserCredentials(*userCreds))
@@ -73,6 +78,15 @@ func main() {
 	// Use specific CA certificate
 	if *tlsCACert != "" {
 		opts = append(opts, nats.RootCAs(*tlsCACert))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
 	}
 
 	// Connect to NATS

--- a/examples/nats-qsub/main.go
+++ b/examples/nats-qsub/main.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -28,7 +28,7 @@ import (
 // nats-qsub -s demo.nats.io:4443 <subject> <queue> (TLS version)
 
 func usage() {
-	log.Printf("Usage: nats-qsub [-s server] [-creds file] [-t] <subject> <queue>\n")
+	log.Printf("Usage: nats-qsub [-s server] [-creds file] [-nkey file] [-t] <subject> <queue>\n")
 	flag.PrintDefaults()
 }
 
@@ -44,6 +44,7 @@ func printMsg(m *nats.Msg, i int) {
 func main() {
 	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
 	var userCreds = flag.String("creds", "", "User Credentials File")
+	var nkeyFile = flag.String("nkey", "", "NKey Seed File")
 	var showTime = flag.Bool("t", false, "Display timestamps")
 	var showHelp = flag.Bool("h", false, "Show help message")
 
@@ -64,9 +65,22 @@ func main() {
 	opts := []nats.Option{nats.Name("NATS Sample Queue Subscriber")}
 	opts = setupConnOptions(opts)
 
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
 	// Use UserCredentials
 	if *userCreds != "" {
 		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
 	}
 
 	// Connect to NATS

--- a/examples/nats-req/main.go
+++ b/examples/nats-req/main.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -27,7 +27,7 @@ import (
 // nats-req -s demo.nats.io:4443 <subject> <msg> (TLS version)
 
 func usage() {
-	log.Printf("Usage: nats-req [-s server] [-creds file] <subject> <msg>\n")
+	log.Printf("Usage: nats-req [-s server] [-creds file] [-nkey file] <subject> <msg>\n")
 	flag.PrintDefaults()
 }
 
@@ -39,6 +39,7 @@ func showUsageAndExit(exitcode int) {
 func main() {
 	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
 	var userCreds = flag.String("creds", "", "User Credentials File")
+	var nkeyFile = flag.String("nkey", "", "NKey Seed File")
 	var showHelp = flag.Bool("h", false, "Show help message")
 
 	log.SetFlags(0)
@@ -57,9 +58,22 @@ func main() {
 	// Connect Options.
 	opts := []nats.Option{nats.Name("NATS Sample Requestor")}
 
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
 	// Use UserCredentials
 	if *userCreds != "" {
 		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
 	}
 
 	// Connect to NATS

--- a/examples/nats-rply/main.go
+++ b/examples/nats-rply/main.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -28,7 +28,7 @@ import (
 // nats-rply -s demo.nats.io:4443 <subject> <response> (TLS version)
 
 func usage() {
-	log.Printf("Usage: nats-rply [-s server] [-creds file] [-t] [-q queue] <subject> <response>\n")
+	log.Printf("Usage: nats-rply [-s server] [-creds file] [-nkey file] [-t] [-q queue] <subject> <response>\n")
 	flag.PrintDefaults()
 }
 
@@ -44,6 +44,7 @@ func printMsg(m *nats.Msg, i int) {
 func main() {
 	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
 	var userCreds = flag.String("creds", "", "User Credentials File")
+	var nkeyFile = flag.String("nkey", "", "NKey Seed File")
 	var showTime = flag.Bool("t", false, "Display timestamps")
 	var queueName = flag.String("q", "NATS-RPLY-22", "Queue Group Name")
 	var showHelp = flag.Bool("h", false, "Show help message")
@@ -65,9 +66,22 @@ func main() {
 	opts := []nats.Option{nats.Name("NATS Sample Responder")}
 	opts = setupConnOptions(opts)
 
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
 	// Use UserCredentials
 	if *userCreds != "" {
 		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
 	}
 
 	// Connect to NATS


### PR DESCRIPTION
Was trying to clean-up #597 by resolving conflicts directly from GH but that did not work well.
Decided to copy the branch from that PR, do a rebase and resolve conflict and submit new PR.
Credit of changes goes to @aricart for the original PR #597.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>