### PR TITLE
Release v1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ When using or transitioning to Go modules support:
 ```bash
 # Go client latest or explicit version
 go get github.com/nats-io/nats.go/@latest
-go get github.com/nats-io/nats.go/@v1.10.0
+go get github.com/nats-io/nats.go/@v1.11.0
 
 # For latest NATS Server, add /v2 at the end
 go get github.com/nats-io/nats-server/v2


### PR DESCRIPTION
Simple change here in README.md. The version was already set to 1.11.0
in nats.go.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>