### PR TITLE
Add ability to check certificates for OCSP and verify connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	github.com/nats-io/nkeys v0.3.0
 	github.com/nats-io/nuid v1.0.1
+	golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b // indirect
 )

--- a/go_test.mod
+++ b/go_test.mod
@@ -8,4 +8,5 @@ require (
 	github.com/nats-io/nkeys v0.3.0
 	github.com/nats-io/nuid v1.0.1
 	google.golang.org/protobuf v1.23.0
+	golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b // indirect
 )


### PR DESCRIPTION
This adds the option `nats.EnforceOCSP()` which checks if a server certificate has `status_request` set. If so, then it checks for a valid OCSP response. If the response is invalid, then the TLS connection is aborted.

TODO:
- [ ] Add tests