### PR TITLE
[added] option to not create durable on subscribe

### DIFF
--- a/js.go
+++ b/js.go
@@ -187,7 +187,8 @@ func (nc *Conn) jetStream(opts ...JSOpt) (*js, error) {
 }
 
 // BindJetStream returns a JetStreamContext for messaging and stream management that will NOT create
-// underlying objects like stream or durable. It assumes they exist already.
+// underlying objects like stream or durable on Subscribe. It assumes they exist already and that
+// the JetStream context is bound to another account via an import with limited permissions for example.
 // This will also disable the use of ephemeral consumer.
 func (nc *Conn) BindJetStream(opts ...JSOpt) (JetStreamContext, error) {
 	js, err := nc.jetStream(opts...)

--- a/js.go
+++ b/js.go
@@ -190,6 +190,7 @@ func (nc *Conn) jetStream(opts ...JSOpt) (*js, error) {
 
 // BindJetStream returns a JetStreamContext for messaging and stream management that will NOT create
 // underlying objects like stream or durable. It assumes they exist already.
+// This will also disable the use of ephemeral consumer.
 func (nc *Conn) BindJetStream(opts ...JSOpt) (JetStreamContext, error) {
 	js, err := nc.jetStream(opts...)
 	if err != nil {
@@ -1054,7 +1055,7 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, isSync 
 	// Find the stream mapped to the subject if not bound to a stream already.
 	if o.stream == _EMPTY_ {
 		if js.bound {
-			return nil, fmt.Errorf("nats: a bound JS requires a stream name")
+			return nil, ErrBoundJetStreamStream
 		}
 		stream, err = js.lookupStreamBySubject(subj)
 		if err != nil {
@@ -1068,7 +1069,7 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, isSync 
 	// the consumer to which it should be attaching to.
 	consumer = o.cfg.Durable
 	if consumer == _EMPTY_ && js.bound {
-		return nil, fmt.Errorf("nats: a bound JS requires a durable name")
+		return nil, ErrBoundJetStreamDurable
 	} else if consumer != _EMPTY_ && !js.bound {
 		// Only create in case there is no consumer already.
 		info, err = js.ConsumerInfo(stream, consumer)

--- a/js.go
+++ b/js.go
@@ -169,8 +169,6 @@ const (
 	defaultAccountCheck = 20 * time.Second
 )
 
-// BindJetStream returns a JetStreamContext for messaging and stream management that will NOT create
-// underlying objects like stream or durable. It assumes they exist already.
 func (nc *Conn) jetStream(opts ...JSOpt) (*js, error) {
 	js := &js{
 		nc: nc,

--- a/nats.go
+++ b/nats.go
@@ -136,7 +136,7 @@ var (
 	ErrPullModeNotAllowed           = errors.New("nats: pull based not supported")
 	ErrJetStreamNotEnabled          = errors.New("nats: jetstream not enabled")
 	ErrBoundJetStreamStream         = errors.New("nats: a bound JS requires a stream name")
-	ErrBoundJetStreamDurable        = errors.New("nats: a bound JS requires a stream name")
+	ErrBoundJetStreamDurable        = errors.New("nats: a bound JS requires a durable name")
 	ErrJetStreamBadPre              = errors.New("nats: jetstream api prefix not valid")
 	ErrNoStreamResponse             = errors.New("nats: no response from stream")
 	ErrNotJSMessage                 = errors.New("nats: not a jetstream message")

--- a/nats.go
+++ b/nats.go
@@ -135,6 +135,8 @@ var (
 	ErrNoContextOrTimeout           = errors.New("nats: no context or timeout given")
 	ErrPullModeNotAllowed           = errors.New("nats: pull based not supported")
 	ErrJetStreamNotEnabled          = errors.New("nats: jetstream not enabled")
+	ErrBoundJetStreamStream         = errors.New("nats: a bound JS requires a stream name")
+	ErrBoundJetStreamDurable        = errors.New("nats: a bound JS requires a stream name")
 	ErrJetStreamBadPre              = errors.New("nats: jetstream api prefix not valid")
 	ErrNoStreamResponse             = errors.New("nats: no response from stream")
 	ErrNotJSMessage                 = errors.New("nats: not a jetstream message")

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -2364,7 +2364,7 @@ func TestJetStreamImportDirectOnly(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	} else if len(m) != 1 {
 		t.Fatalf("expected one message, got %d", len(m))
-	} else if err = m[0].Ack(); err != nil {
+	} else if err = m[0].AckSync(); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 }

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -2343,7 +2343,6 @@ func TestJetStreamImportDirectOnly(t *testing.T) {
 		}
 	}
 
-	// Cannot subscribe with JS context from another account right now.
 	if _, err := js.SubscribeSync("ORDERS"); err != nats.ErrBoundJetStreamStream {
 		t.Fatalf("Expected an error of '%v', got '%v'", nats.ErrBoundJetStreamStream, err)
 	}

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -2294,7 +2294,7 @@ func TestJetStreamImportDirectOnly(t *testing.T) {
 	}
 	defer nc.Close()
 
-	js, err := nc.JetStream()
+	js, err := nc.BindJetStream()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2344,14 +2344,14 @@ func TestJetStreamImportDirectOnly(t *testing.T) {
 	}
 
 	// Cannot subscribe with JS context from another account right now.
-	if _, err := js.SubscribeSync("ORDERS"); err != nats.ErrJetStreamNotEnabled {
-		t.Fatalf("Expected an error of '%v', got '%v'", nats.ErrJetStreamNotEnabled, err)
+	if _, err := js.SubscribeSync("ORDERS"); err != nats.ErrBoundJetStreamStream {
+		t.Fatalf("Expected an error of '%v', got '%v'", nats.ErrBoundJetStreamStream, err)
 	}
-	if _, err = js.SubscribeSync("ORDERS", nats.BindStream("ORDERS")); err != nats.ErrJetStreamNotEnabled {
-		t.Fatalf("Expected an error of '%v', got '%v'", nats.ErrJetStreamNotEnabled, err)
+	if _, err = js.SubscribeSync("ORDERS", nats.BindStream("ORDERS")); err != nats.ErrBoundJetStreamDurable {
+		t.Fatalf("Expected an error of '%v', got '%v'", nats.ErrBoundJetStreamDurable, err)
 	}
-	if _, err = js.PullSubscribe("ORDERS", "d1", nats.BindStream("ORDERS")); err != nats.ErrJetStreamNotEnabled {
-		t.Fatalf("Expected an error of '%v', got '%v'", nats.ErrJetStreamNotEnabled, err)
+	if _, err = js.PullSubscribe("ORDERS", "d1", nats.BindStream("ORDERS")); err != nil {
+		t.Fatalf("Expected no error, got '%v'", err)
 	}
 }
 

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -2252,7 +2252,7 @@ func TestJetStreamImportDirectOnly(t *testing.T) {
 	}
 	defer ncm.Close()
 
-	jsm, err := ncm.JetStream()
+	jsm, err := ncm.BindJetStream()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

When exporting/importing say the next subject, the consumer exists already and does not need to be created.
Thus the client should also not try to look it up.

We went down the road of a don't create durable option (1st commit) but altered it to have a dedicated JS create call.
We believe that using `BindJetStream` might be easier to explain