### PR TITLE
[changed] JetStream function to not lookup account info & moved it

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -496,9 +496,6 @@ type Conn struct {
 	respMux   *Subscription        // A single response subscription
 	respMap   map[string]chan *Msg // Request map for the response msg channels
 	respRand  *rand.Rand           // Used for generating suffix
-
-	// JetStream Contexts last account check.
-	jsLastCheck time.Time
 }
 
 type natsReader struct {


### PR DESCRIPTION
The new function is JSAccountInfo

Signed-off-by: Matthias Hanel <mh@synadia.com>

This separates concerns into give me a jetstream object and check jetstream.
Moving that logic to the nats connection to avoid dependencies with the JetStream call.
In our meeting the group generally favored opt in over opt out. 

I'm clearly expecting ppl to either copy a sample anyway and there we add the call of course.
Or if they run into this, to just ask & find this new call.
it's also opt in because the main thing that the lookup does is provide a different error. 

I noticed that the unit test for the js object appears to be broken right now.  (at least for me, even without my change)
Deleted the checks so I could show you this sooner.

If that approach is not desirec, I'll revert and add an option to opt out of the lookup.