### PR TITLE
In-process connections

### DIFF
--- a/nats_test.go
+++ b/nats_test.go
@@ -2883,3 +2883,25 @@ func TestRespInbox(t *testing.T) {
 		t.Fatalf("Error: %s", resp.Data)
 	}
 }
+
+func TestInProcessConn(t *testing.T) {
+	s := RunServerOnPort(-1)
+	defer s.Shutdown()
+
+	nc, err := Connect("", InProcessServer(s))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer nc.Close()
+
+	// Status should be connected.
+	if nc.Status() != CONNECTED {
+		t.Fatal("should be status CONNECTED")
+	}
+
+	// The server should respond to a request.
+	if _, err := nc.RTT(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR is an extension of the work from nats-io/nats-server#2360 by allowing a client to use an in-process connection to the NATS server, rather than a TCP connection. Much of the justification is in the other PR, but this lets us do something like:

```
natsServer, err = natsserver.NewServer(&server.Options{
	ServerName: "monolith",
	DontListen: true,
	JetStream: true,
})
if err != nil {
	panic(err)
}

go natsServer.Start()

if !natsServer.ReadyForConnections(time.Second * 10) {
	panic("not ready in time")
}

nc, err := natsclient.Connect("", natsclient.InProcessServer(natsServer))
if err != nil {
	panic(err)
}
```