### PR TITLE
Reworked PullSubscribe implementation

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -3154,7 +3154,8 @@ const (
 	lastConsumerSeqHdr = "Nats-Last-Consumer"
 	lastStreamSeqHdr   = "Nats-Last-Stream"
 	noResponders       = "503"
-	noMessages         = "404"
+	noMessagesSts      = "404"
+	reqTimeoutSts      = "408"
 	controlMsg         = "100"
 	statusLen          = 3 // e.g. 20x, 40x, 50x
 )
@@ -3825,6 +3826,12 @@ func (s *Subscription) Type() SubscriptionType {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Pull subscriptions are really a SyncSubscription and we want this
+	// type to be set internally for all delivered messages management, etc..
+	// So check when to return PullSubscription to the user.
+	if s.jsi != nil && s.jsi.pull {
+		return PullSubscription
+	}
 	return s.typ
 }
 

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -5790,7 +5790,7 @@ func testJetStreamFetchOptions(t *testing.T, srvs ...*jsServer) {
 		if err == nil {
 			t.Fatal("Unexpected success")
 		}
-		if err != nil && (err != nats.ErrTimeout && err != nats.ErrNoResponders) {
+		if err != nats.ErrBadSubscription {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 	})


### PR DESCRIPTION
Use a SyncSubscription instead. The only visible change from the
user is that calling Fetch() after Unsubscribe() returns ErrBadSubscription
instead of timeout or context deadline exceeded, which makes more
sense to me. This is the only test that I had to tweak.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>