### PR TITLE
[IMPROVED] Subscribe returns error if consumer config does not match

### DIFF
--- a/test/js_test.go
+++ b/test/js_test.go
@@ -18,6 +18,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"github.com/nats-io/nuid"
 	"io/ioutil"
 	"net"
 	"os"
@@ -2819,7 +2820,7 @@ func TestJetStreamPullSubscribe_AckPending(t *testing.T) {
 	expectedPending(1, 7)
 	meta = getMetadata(msg)
 	if meta.Sequence.Stream != prevSeq {
-		t.Errorf("Expected to get message at seq=%v, got seq=%v", prevSeq, meta.Stream)
+		t.Errorf("Expected to get message at seq=%v, got seq=%v", prevSeq, meta.Sequence.Stream)
 	}
 	if string(msg.Data) != prevPayload {
 		t.Errorf("Expected: %q, got: %q", string(prevPayload), string(msg.Data))
@@ -2837,7 +2838,7 @@ func TestJetStreamPullSubscribe_AckPending(t *testing.T) {
 	expectedPending(0, 7)
 	meta = getMetadata(msg)
 	if meta.Sequence.Stream != prevSeq {
-		t.Errorf("Expected to get message at seq=%v, got seq=%v", prevSeq, meta.Stream)
+		t.Errorf("Expected to get message at seq=%v, got seq=%v", prevSeq, meta.Sequence.Stream)
 	}
 	if string(msg.Data) != prevPayload {
 		t.Errorf("Expected: %q, got: %q", string(prevPayload), string(msg.Data))
@@ -3593,6 +3594,134 @@ func TestJetStreamSubscribe_RateLimit(t *testing.T) {
 
 	if len(recvd) >= int(rl) {
 		t.Errorf("Expected applied rate limit to push consumer, got %v msgs in %v", recvd, duration)
+	}
+}
+
+func TestJetStreamSubscribe_ConfigCantChange(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer s.Shutdown()
+
+	if config := s.JetStreamConfig(); config != nil {
+		defer os.RemoveAll(config.StoreDir)
+	}
+
+	nc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer nc.Close()
+
+	js, err := nc.JetStream()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Create the stream using our client API.
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	for _, test := range []struct {
+		name   string
+		first  nats.SubOpt
+		second nats.SubOpt
+	}{
+		{"description", nats.Description("a"), nats.Description("b")},
+		{"deliver policy", nats.DeliverAll(), nats.DeliverLast()},
+		{"optional start sequence", nats.StartSequence(1), nats.StartSequence(10)},
+		{"optional start time", nats.StartTime(time.Now()), nats.StartTime(time.Now().Add(-2 * time.Hour))},
+		{"ack wait", nats.AckWait(10 * time.Second), nats.AckWait(15 * time.Second)},
+		{"max deliver", nats.MaxDeliver(3), nats.MaxDeliver(5)},
+		{"replay policy", nats.ReplayOriginal(), nats.ReplayInstant()},
+		{"max waiting", nats.PullMaxWaiting(10), nats.PullMaxWaiting(20)},
+		{"max ack pending", nats.MaxAckPending(10), nats.MaxAckPending(20)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			durName := nuid.Next()
+			sub, err := js.PullSubscribe("foo", durName, test.first)
+			if err != nil {
+				t.Fatalf("Error on subscribe: %v", err)
+			}
+			// Once it is created, options can't be changed.
+			_, err = js.PullSubscribe("foo", durName, test.second)
+			if err == nil || !strings.Contains(err.Error(), test.name) {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			sub.Unsubscribe()
+		})
+	}
+
+	for _, test := range []struct {
+		name string
+		cc   *nats.ConsumerConfig
+		opt  nats.SubOpt
+	}{
+		{"ack policy", &nats.ConsumerConfig{AckPolicy: nats.AckAllPolicy}, nats.AckNone()},
+		{"rate limit", &nats.ConsumerConfig{RateLimit: 10}, nats.RateLimit(100)},
+		{"flow control", &nats.ConsumerConfig{FlowControl: false}, nats.EnableFlowControl()},
+		{"heartbeat", &nats.ConsumerConfig{Heartbeat: 10 * time.Second}, nats.IdleHeartbeat(20 * time.Second)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			durName := nuid.Next()
+
+			cc := test.cc
+			cc.Durable = durName
+			cc.DeliverSubject = nuid.Next()
+			if _, err := js.AddConsumer("TEST", cc); err != nil {
+				t.Fatalf("Error creating consumer: %v", err)
+			}
+
+			sub, err := js.SubscribeSync("foo", nats.Durable(durName), test.opt)
+			if err == nil || !strings.Contains(err.Error(), test.name) {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			sub.Unsubscribe()
+		})
+	}
+
+	// Verify that we don't fail if user did not set it.
+	for _, test := range []struct {
+		name string
+		opt  nats.SubOpt
+	}{
+		{"description", nats.Description("a")},
+		{"deliver policy", nats.DeliverAll()},
+		{"optional start sequence", nats.StartSequence(10)},
+		{"optional start time", nats.StartTime(time.Now())},
+		{"ack wait", nats.AckWait(10 * time.Second)},
+		{"max deliver", nats.MaxDeliver(3)},
+		{"replay policy", nats.ReplayOriginal()},
+		{"max waiting", nats.PullMaxWaiting(10)},
+		{"max ack pending", nats.MaxAckPending(10)},
+	} {
+		t.Run(test.name+" not set", func(t *testing.T) {
+			durName := nuid.Next()
+			sub, err := js.PullSubscribe("foo", durName, test.opt)
+			if err != nil {
+				t.Fatalf("Error on subscribe: %v", err)
+			}
+			// If not explicitly asked by the user, we are ok
+			_, err = js.PullSubscribe("foo", durName)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			sub.Unsubscribe()
+		})
+	}
+
+	// Check that binding to a durable (without specifying durable option) works
+	if _, err := js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:        "BindDurable",
+		DeliverSubject: "bar",
+	}); err != nil {
+		t.Fatalf("Failed to create consumer: %v", err)
+	}
+	if _, err := js.SubscribeSync("foo", nats.Bind("TEST", "BindDurable")); err != nil {
+		t.Fatalf("Error on subscribe: %v", err)
 	}
 }
 


### PR DESCRIPTION
This is done to alert the user that consumer config is not changed
as one would expect.

This change is more tricky than expected. We can't simply compare
user's consumer config with what is returned from the server.
For once, there are configurations that may not be set by the
user that were set when the consumer was created, that the lib
should not fail. Let's say the consumer is created with a description,
why fail the user if they don't pass the Description() option at all?

The Description() option was actually missing, but this is a good
example. But same could be say with for instance "optional start
sequence". This may be something that is set when the consumer
is first created (possibly outside of the app with CLI), but when
user calls js.Subscribe(), that option should not have to be
set to the value that was used when creating the consumer.

I had to add "not set" values for replay and deliver policy, similar
to ack policy.

I added an extensive test that checks proper error when trying
to make configuration changes, but also that if the options are
not set, then the lib does not fail the subscribe call.

Resolves #796

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>