### PR TITLE
[ADDED] Stringer for connection status

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -196,6 +196,26 @@ const (
 	DRAINING_PUBS
 )
 
+func (s Status) String() string {
+	switch s {
+	case DISCONNECTED:
+		return "DISCONNECTED"
+	case CONNECTED:
+		return "CONNECTED"
+	case CLOSED:
+		return "CLOSED"
+	case RECONNECTING:
+		return "RECONNECTING"
+	case CONNECTING:
+		return "CONNECTING"
+	case DRAINING_SUBS:
+		return "DRAINING_SUBS"
+	case DRAINING_PUBS:
+		return "DRAINING_PUBS"
+	}
+	return "unknown status"
+}
+
 // ConnHandler is used for asynchronous events such as
 // disconnected and closed connections.
 type ConnHandler func(*Conn)

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -49,7 +49,7 @@ func TestConnectionStatus(t *testing.T) {
 	nc := NewDefaultConnection(t)
 	defer nc.Close()
 
-	if nc.Status() != nats.CONNECTED || fmt.Sprintf("%s", nc.Status()) != "CONNECTED"{
+	if nc.Status() != nats.CONNECTED || fmt.Sprintf("%s", nc.Status()) != "CONNECTED" {
 		t.Fatal("Should have status set to CONNECTED")
 	}
 

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -49,7 +49,7 @@ func TestConnectionStatus(t *testing.T) {
 	nc := NewDefaultConnection(t)
 	defer nc.Close()
 
-	if nc.Status() != nats.CONNECTED || fmt.Sprintf("%s", nc.Status()) != "CONNECTED" {
+	if nc.Status() != nats.CONNECTED || nc.Status().String() != "CONNECTED" {
 		t.Fatal("Should have status set to CONNECTED")
 	}
 
@@ -57,7 +57,7 @@ func TestConnectionStatus(t *testing.T) {
 		t.Fatal("Should have status set to CONNECTED")
 	}
 	nc.Close()
-	if nc.Status() != nats.CLOSED || fmt.Sprintf("%s", nc.Status()) != "CLOSED" {
+	if nc.Status() != nats.CLOSED || nc.Status().String() != "CLOSED" {
 		t.Fatal("Should have status set to CLOSED")
 	}
 	if !nc.IsClosed() {

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -49,14 +49,15 @@ func TestConnectionStatus(t *testing.T) {
 	nc := NewDefaultConnection(t)
 	defer nc.Close()
 
-	if nc.Status() != nats.CONNECTED {
+	if nc.Status() != nats.CONNECTED || fmt.Sprintf("%s", nc.Status()) != "CONNECTED"{
 		t.Fatal("Should have status set to CONNECTED")
 	}
+
 	if !nc.IsConnected() {
 		t.Fatal("Should have status set to CONNECTED")
 	}
 	nc.Close()
-	if nc.Status() != nats.CLOSED {
+	if nc.Status() != nats.CLOSED || fmt.Sprintf("%s", nc.Status()) != "CLOSED" {
 		t.Fatal("Should have status set to CLOSED")
 	}
 	if !nc.IsClosed() {


### PR DESCRIPTION
This change updates the connection status by implementing the Stringer interface, enabling users to log out the connection status in a human readable format.

I've updated an existing tests to verify the string output. It's not exhaustive, but covers the same cases the existing test exercises. If you'd rather I add a separate test that covers each permutation then let me know and I can update the pull request.