### PR TITLE
[FIXED] JetStream flow control may stall in some conditions

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -3864,9 +3864,15 @@ func (nc *Conn) removeSub(s *Subscription) {
 	s.mch = nil
 
 	// If JS subscription then stop HB timer.
-	if jsi := s.jsi; jsi != nil && jsi.hbc != nil {
-		jsi.hbc.Stop()
-		jsi.hbc = nil
+	if jsi := s.jsi; jsi != nil {
+		if jsi.hbc != nil {
+			jsi.hbc.Stop()
+			jsi.hbc = nil
+		}
+		if jsi.csfct != nil {
+			jsi.csfct.Stop()
+			jsi.csfct = nil
+		}
 	}
 
 	// Mark as invalid


### PR DESCRIPTION
Keep track of the "sequence" of incoming messages that are then compared with the number of delivered message.
However, ChanSubscription were broken: the FC would *always* be responded to when received, because pMsgs (and pBytes) would always be 0 for these type of subscriptions.

We now check for flow control on all incoming messages for ChanSubscription (and evaluate the "delivered" count based on the incoming sequence minus length of the user's channel). We also have a long-lived go routine to cover situations where the evaluation during the incoming message did not result in the target to send the FC, but then the user consumes enough messages to bring the "delivered" at or past the target. Without this go routine, the client would stall and have to wait for an heartbeat with the "fc stalled" header in order to be unblocked.

Alternatively, we could fail creation of ChanSubscription subscriptions if flow control is in use... 

Finally, this PR fixes some issues with the ordered consumer test:
- We send a "EOF" empty message which should not be counted as the number of chunks used to reconstitute the asset
- Some "message filters" that are removed as part of the execution of the filter's callback would not be put back for the following "sync" test (we test async then sync).

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>