### PR TITLE
[FIXED] JetStream: queue name cannot contain "." when used as durable

### DIFF
--- a/jsm.go
+++ b/jsm.go
@@ -239,8 +239,8 @@ func (js *js) AddConsumer(stream string, cfg *ConsumerConfig, opts ...JSOpt) (*C
 
 	var ccSubj string
 	if cfg != nil && cfg.Durable != _EMPTY_ {
-		if strings.Contains(cfg.Durable, ".") {
-			return nil, ErrInvalidDurableName
+		if err := checkDurName(cfg.Durable); err != nil {
+			return nil, err
 		}
 		ccSubj = fmt.Sprintf(apiDurableCreateT, stream, cfg.Durable)
 	} else {

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -350,6 +350,13 @@ func TestJetStreamSubscribe(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
+	// Check that Queue subscribe without durable name requires queue name
+	// to not have "." in the name.
+	_, err = js.QueueSubscribeSync("foo", "bar.baz")
+	if err != nats.ErrInvalidDurableName {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
 	msg := []byte("Hello JS")
 
 	// Basic publish like NATS core.


### PR DESCRIPTION
When calling `js.QueueSubscribe[Sync](subject, queue_name)`, if
no durable name is provided, the queue name is used as the durable
name, so the same restriction applies

Resolves #840

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>