### PR TITLE
Increase object read deadline

### DIFF
--- a/object.go
+++ b/object.go
@@ -955,7 +955,7 @@ func (o *objResult) Read(p []byte) (n int, err error) {
 	}
 
 	r := o.r.(net.Conn)
-	r.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	r.SetReadDeadline(time.Now().Add(2 * time.Second))
 	n, err = r.Read(p)
 	if err, ok := err.(net.Error); ok && err.Timeout() {
 		if ctx := o.ctx; ctx != nil {

--- a/test/norace_test.go
+++ b/test/norace_test.go
@@ -64,7 +64,7 @@ func TestNoRaceObjectContextOpt(t *testing.T) {
 	start = time.Now()
 	_, err = obs.GetBytes("BLOB", nats.Context(ctx))
 	expectErr(t, err)
-	if delta := time.Since(start); delta > time.Second {
+	if delta := time.Since(start); delta > 2500*time.Millisecond {
 		t.Fatalf("Cancel took too long: %v", delta)
 	}
 }


### PR DESCRIPTION
Getting files from object stores far away would fail because of too low of a read deadline on the pipe.

Signed-off-by: Derek Collison <derek@nats.io>