### PR TITLE
More meaningful message when trying to ack message that was already acknowledged 

### DIFF
--- a/js.go
+++ b/js.go
@@ -2552,7 +2552,7 @@ func (m *Msg) ackReply(ackType []byte, sync bool, opts ...AckOpt) error {
 
 	// Skip if already acked.
 	if atomic.LoadUint32(&m.ackd) == 1 {
-		return ErrInvalidJSAck
+		return ErrMsgAlreadyAckd
 	}
 
 	m.Sub.mu.Lock()

--- a/nats.go
+++ b/nats.go
@@ -157,6 +157,7 @@ var (
 	ErrPullSubscribeRequired        = errors.New("nats: must use pull subscribe to bind to pull based consumer")
 	ErrConsumerNotActive            = errors.New("nats: consumer not active")
 	ErrMsgNotFound                  = errors.New("nats: message not found")
+	ErrMsgAlreadyAckd               = errors.New("nats: message was already acknowledged")
 )
 
 func init() {

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -2571,7 +2571,7 @@ func TestJetStreamSubscribe_AckPolicy(t *testing.T) {
 		}
 
 		err = msg.AckSync(nats.AckWait(2 * time.Second))
-		if err != nats.ErrInvalidJSAck {
+		if err != nats.ErrMsgAlreadyAckd {
 			t.Errorf("Unexpected error: %v", err)
 		}
 
@@ -3006,7 +3006,7 @@ func TestJetStreamSubscribe_AckDup(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		e := <-ch
-		if e != nats.ErrInvalidJSAck {
+		if e != nats.ErrMsgAlreadyAckd {
 			t.Errorf("Expected error: %v", e)
 		}
 	}


### PR DESCRIPTION
Relates to: https://github.com/nats-io/nats.go/issues/857

Introducing dedicated err for case when trying to ack msg that was already acknowledged.