### PR TITLE
Fix jetstream removeSub logic

### DIFF
--- a/js.go
+++ b/js.go
@@ -1838,7 +1838,7 @@ func (sub *Subscription) scheduleFlowControlResponse(reply string) {
 func (sub *Subscription) activityCheck() {
 	sub.mu.Lock()
 	jsi := sub.jsi
-	if jsi == nil {
+	if jsi == nil || sub.closed {
 		sub.mu.Unlock()
 		return
 	}
@@ -1847,10 +1847,9 @@ func (sub *Subscription) activityCheck() {
 	jsi.hbc.Reset(jsi.hbi)
 	jsi.active = false
 	nc := sub.conn
-	closed := sub.closed
 	sub.mu.Unlock()
 
-	if !active && !closed {
+	if !active {
 		nc.mu.Lock()
 		if errCB := nc.Opts.AsyncErrorCB; errCB != nil {
 			nc.ach.push(func() { errCB(nc, sub, ErrConsumerNotActive) })


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>

When `removeSub` calls `jsi.hbc.Stop()` it is possible that the timer has already expired
https://github.com/nats-io/nats.go/blob/main/nats.go#L3919

from `timer.Stop()`
```
For a timer created with AfterFunc(d, f), if t.Stop returns false, then the timer has already expired 
and the function f has been started in its own goroutine; Stop does not wait for f to complete before 
returning. If the caller needs to know whether f is completed, it must coordinate with f explicitly.
```

This PR checks to see if `sub.closed == true` and returns