### PR TITLE
Prepare for KV1.0 release

### DIFF
--- a/test/configs/kv_accounts.conf
+++ b/test/configs/kv_accounts.conf
@@ -1,0 +1,23 @@
+port: -1
+net: localhost
+
+jetstream: enabled
+
+accounts: {
+    A: {
+        users: [ {user: a, password: a} ]
+        jetstream: enabled
+        exports: [
+            {service: '$JS.API.>' }
+            {service: '$KV.CROSS.>'}
+        ]
+    },
+
+    O: {
+        users: [ {user: o, password: o} ]
+        imports: [
+	    {service: {account: A, subject: '$JS.API.>'}, to: 'fromA.>' }
+	    {service: {account: A, subject: '$KV.CROSS.>'}, to: 'X.cross.>' }
+        ]
+    }
+}


### PR DESCRIPTION
This closes the loop on supporting ADR-8:

 * We fix the bugs identified by @scottf where WatchOpts can confused Keys, History etc by now only accepting a context. 
 * We support arbitrary subject prefixes per bucket using BucketSubjectPrefix()
