### PR TITLE
Fixed tests to run on Windows + some cleanup

### DIFF
--- a/js_test.go
+++ b/js_test.go
@@ -81,6 +81,7 @@ func createConfFile(t *testing.T, content []byte) string {
 }
 
 func shutdownJSServerAndRemoveStorage(t *testing.T, s *server.Server) {
+	t.Helper()
 	var sd string
 	if config := s.JetStreamConfig(); config != nil {
 		sd = config.StoreDir

--- a/js_test.go
+++ b/js_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The NATS Authors
+// Copyright 2012-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -35,6 +35,25 @@ import (
 	natsserver "github.com/nats-io/nats-server/v2/test"
 )
 
+func client(t *testing.T, s *server.Server, opts ...Option) *Conn {
+	t.Helper()
+	nc, err := Connect(s.ClientURL(), opts...)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	return nc
+}
+
+func jsClient(t *testing.T, s *server.Server, opts ...Option) (*Conn, JetStreamContext) {
+	t.Helper()
+	nc := client(t, s, opts...)
+	js, err := nc.JetStream(MaxWait(10 * time.Second))
+	if err != nil {
+		t.Fatalf("Unexpected error getting JetStream context: %v", err)
+	}
+	return nc, js
+}
+
 func RunBasicJetStreamServer() *server.Server {
 	opts := natsserver.DefaultTestOptions
 	opts.Port = -1
@@ -61,26 +80,29 @@ func createConfFile(t *testing.T, content []byte) string {
 	return fName
 }
 
+func shutdownJSServerAndRemoveStorage(t *testing.T, s *server.Server) {
+	var sd string
+	if config := s.JetStreamConfig(); config != nil {
+		sd = config.StoreDir
+	}
+	s.Shutdown()
+	if sd != _EMPTY_ {
+		if err := os.RemoveAll(sd); err != nil {
+			t.Fatalf("Unable to remove storage %q: %v", sd, err)
+		}
+	}
+	s.WaitForShutdown()
+}
+
 // Need access to internals for loss testing.
 func TestJetStreamOrderedConsumer(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
+	var err error
 	_, err = js.AddStream(&StreamConfig{
 		Name:     "OBJECT",
 		Subjects: []string{"a"},
@@ -270,22 +292,12 @@ func TestJetStreamOrderedConsumer(t *testing.T) {
 
 func TestJetStreamOrderedConsumerWithErrors(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	// For capturing errors.
 	errCh := make(chan error, 1)
@@ -379,22 +391,12 @@ func TestJetStreamOrderedConsumerWithErrors(t *testing.T) {
 
 func TestJetStreamOrderedConsumerWithAutoUnsub(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	_, err = js.AddStream(&StreamConfig{
 		Name:     "OBJECT",
@@ -473,15 +475,9 @@ func TestJetStreamOrderedConsumerWithAutoUnsub(t *testing.T) {
 	// server had properly processed the auto-unsub after the
 	// reset of the ordered consumer. Use a different connection
 	// to send.
-	nc2, err := Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc2, js2 := jsClient(t, s)
 	defer nc2.Close()
-	js2, err := nc2.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+
 	js2.Publish("a", []byte("should not be received"))
 
 	newInMsgs := nc.Stats().InMsgs
@@ -494,22 +490,12 @@ func TestJetStreamOrderedConsumerWithAutoUnsub(t *testing.T) {
 // One should win and the others should share the delivery subject with the first one who wins.
 func TestJetStreamConcurrentQueueDurablePushConsumers(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	// Create stream.
 	_, err = js.AddStream(&StreamConfig{
@@ -572,11 +558,7 @@ func TestJetStreamConcurrentQueueDurablePushConsumers(t *testing.T) {
 
 func TestJetStreamSubscribeReconnect(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
-
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	rch := make(chan struct{}, 1)
 	nc, err := Connect(s.ClientURL(),
@@ -658,22 +640,12 @@ func TestJetStreamSubscribeReconnect(t *testing.T) {
 
 func TestJetStreamAckTokens(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	// Create the stream using our client API.
 	_, err = js.AddStream(&StreamConfig{
@@ -830,22 +802,12 @@ func TestJetStreamAckTokens(t *testing.T) {
 
 func TestJetStreamFlowControlStalled(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	_, err = js.AddStream(&StreamConfig{
 		Name:     "TEST",
@@ -893,7 +855,7 @@ func TestJetStreamFlowControlStalled(t *testing.T) {
 
 func TestJetStreamTracing(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, err := Connect(s.ClientURL())
 	if err != nil {
@@ -930,22 +892,12 @@ func TestJetStreamTracing(t *testing.T) {
 
 func TestJetStreamExpiredPullRequests(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	_, err = js.AddStream(&StreamConfig{
 		Name:     "TEST",

--- a/nats_test.go
+++ b/nats_test.go
@@ -137,10 +137,6 @@ func TestExpandPath(t *testing.T) {
 			{path: "/Foo/Bar", userProfile: `C:\Foo\Bar`, wantPath: "/Foo/Bar"},
 			{path: "Foo/Bar", userProfile: `C:\Foo\Bar`, wantPath: "Foo/Bar"},
 			{path: "~/Fizz", userProfile: `C:\Foo\Bar`, wantPath: `C:\Foo\Bar\Fizz`},
-			// That one would fail because expandPath(), if not finding `~` returns
-			// the given path, which since ${HOMEDRIVE}${HOMEPATH} is not set,
-			// would return `\Fizz` but test expects `C:\Foo\Bar\Fizz`?
-			// {path: `${HOMEDRIVE}${HOMEPATH}\Fizz`, userProfile: `C:\Foo\Bar`, wantPath: `C:\Foo\Bar\Fizz`},
 
 			// Missing USERPROFILE.
 			{path: "~/Fizz", homeDrive: "X:", homePath: `\Foo\Bar`, wantPath: `X:\Foo\Bar\Fizz`},

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -1483,6 +1483,9 @@ func (d *lowWriteBufferDialer) Dial(network, address string) (net.Conn, error) {
 }
 
 func TestCustomFlusherTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
 	s := RunDefaultServer()
 	defer s.Shutdown()
 

--- a/test/drain_test.go
+++ b/test/drain_test.go
@@ -58,7 +58,7 @@ func TestDrain(t *testing.T) {
 	select {
 	case <-done:
 		break
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		r := atomic.LoadInt32(&received)
 		if r != expected {
 			t.Fatalf("Did not receive all messages: %d of %d", r, expected)

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -3762,12 +3762,8 @@ func withJSCluster(t *testing.T, clusterName string, size int, tfn func(t *testi
 		// Ensure that they get shutdown and remove their state.
 		for _, node := range nodes {
 			node.restart.Lock()
-			if config := node.JetStreamConfig(); config != nil {
-				os.RemoveAll(config.StoreDir)
-			}
+			shutdownJSServerAndRemoveStorage(t, node.Server)
 			node.restart.Unlock()
-			node.Shutdown()
-			node.WaitForShutdown()
 		}
 	}()
 	tfn(t, nodes...)

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func shutdownJSServerAndRemoveStorage(t *testing.T, s *server.Server) {
+	t.Helper()
 	var sd string
 	if config := s.JetStreamConfig(); config != nil {
 		sd = config.StoreDir

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The NATS Authors
+// Copyright 2020-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -35,35 +35,28 @@ import (
 	natsserver "github.com/nats-io/nats-server/v2/test"
 )
 
-func getConnAndJS(t *testing.T, s *server.Server) (*nats.Conn, nats.JetStreamContext) {
-	t.Helper()
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+func shutdownJSServerAndRemoveStorage(t *testing.T, s *server.Server) {
+	var sd string
+	if config := s.JetStreamConfig(); config != nil {
+		sd = config.StoreDir
 	}
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Got error during initialization %v", err)
+	s.Shutdown()
+	if sd != "" {
+		if err := os.RemoveAll(sd); err != nil {
+			t.Fatalf("Unable to remove storage %q: %v", sd, err)
+		}
 	}
-	return nc, js
+	s.WaitForShutdown()
 }
 
 func TestJetStreamNotEnabled(t *testing.T) {
 	s := RunServerOnPort(-1)
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Got error during initialization %v", err)
-	}
-	if _, err = js.AccountInfo(); err != nats.ErrJetStreamNotEnabled {
+	if _, err := js.AccountInfo(); err != nats.ErrJetStreamNotEnabled {
 		t.Fatalf("Did not get the proper error, got %v", err)
 	}
 }
@@ -86,41 +79,24 @@ func TestJetStreamNotAccountEnabled(t *testing.T) {
 	defer os.Remove(conf)
 
 	s, _ := RunServerWithConfig(conf)
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Got error during initialization %v", err)
-	}
-	if _, err = js.AccountInfo(); err != nats.ErrJetStreamNotEnabled {
+	if _, err := js.AccountInfo(); err != nats.ErrJetStreamNotEnabled {
 		t.Fatalf("Did not get the proper error, got %v", err)
 	}
 }
 
 func TestJetStreamPublish(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	// Make sure we get a proper failure when no stream is present.
 	_, err = js.Publish("foo", []byte("Hello JS"))
@@ -297,22 +273,12 @@ func TestJetStreamPublish(t *testing.T) {
 
 func TestJetStreamSubscribe(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	expectConsumers := func(t *testing.T, expected int) {
 		t.Helper()
@@ -812,7 +778,7 @@ func TestJetStreamSubscribe(t *testing.T) {
 
 	time.Sleep(150 * time.Millisecond)
 
-	nc, js = getConnAndJS(t, s)
+	nc, js = jsClient(t, s)
 	defer nc.Close()
 
 	if ci, err := js.ConsumerInfo("TEST", name); err == nil {
@@ -822,23 +788,12 @@ func TestJetStreamSubscribe(t *testing.T) {
 
 func TestJetStreamAckPending_Pull(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	_, err = js.AddStream(&nats.StreamConfig{
 		Name:     "TEST",
@@ -885,22 +840,12 @@ func TestJetStreamAckPending_Pull(t *testing.T) {
 
 func TestJetStreamAckPending_Push(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	_, err = js.AddStream(&nats.StreamConfig{
 		Name:     "TEST",
@@ -1046,11 +991,7 @@ func TestJetStreamAckPending_Push(t *testing.T) {
 
 func TestJetStream_Drain(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
-
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	ctx, done := context.WithTimeout(context.Background(), 10*time.Second)
 
@@ -1139,7 +1080,7 @@ func TestJetStream_Drain(t *testing.T) {
 
 func TestAckForNonJetStream(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, err := nats.Connect(s.ClientURL())
 	if err != nil {
@@ -1172,22 +1113,10 @@ func TestJetStreamManagement(t *testing.T) {
 	defer os.Remove(conf)
 
 	s, _ := RunServerWithConfig(conf)
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL(), nats.UserInfo("foo", ""))
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s, nats.UserInfo("foo", ""))
 	defer nc.Close()
-
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
 
 	// Create the stream using our client API.
 	var si *nats.StreamInfo
@@ -1208,6 +1137,7 @@ func TestJetStreamManagement(t *testing.T) {
 		js.Publish("foo", []byte("hi"))
 	}
 
+	var err error
 	t.Run("stream not found", func(t *testing.T) {
 		si, err = js.StreamInfo("bar")
 		if !errors.Is(err, nats.ErrStreamNotFound) {
@@ -1495,17 +1425,10 @@ func TestJetStreamManagement_GetMsg(t *testing.T) {
 
 func testJetStreamManagement_GetMsg(t *testing.T, srvs ...*jsServer) {
 	s := srvs[0]
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s.Server)
 	defer nc.Close()
 
-	// constructor
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	_, err = js.AddStream(&nats.StreamConfig{
 		Name:     "foo",
@@ -1657,22 +1580,12 @@ func testJetStreamManagement_GetMsg(t *testing.T, srvs ...*jsServer) {
 
 func TestJetStreamManagement_DeleteMsg(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	_, err = js.AddStream(&nats.StreamConfig{
 		Name:     "foo",
@@ -1795,23 +1708,13 @@ func TestJetStreamImport(t *testing.T) {
 	defer os.Remove(conf)
 
 	s, _ := RunServerWithConfig(conf)
-	defer s.Shutdown()
-
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	// Create a stream using JSM.
-	ncm, err := nats.Connect(s.ClientURL(), nats.UserInfo("dlc", "foo"))
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	ncm, jsm := jsClient(t, s, nats.UserInfo("dlc", "foo"))
 	defer ncm.Close()
 
-	jsm, err := ncm.JetStream()
-	if err != nil {
-		t.Fatal(err)
-	}
+	var err error
 
 	_, err = jsm.AddStream(&nats.StreamConfig{
 		Name:     "TEST",
@@ -1906,23 +1809,13 @@ func TestJetStreamImportDirectOnly(t *testing.T) {
 	defer os.Remove(conf)
 
 	s, _ := RunServerWithConfig(conf)
-	defer s.Shutdown()
-
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	// Create a stream using JSM.
-	ncm, err := nats.Connect(s.ClientURL(), nats.UserInfo("dlc", "foo"))
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	ncm, jsm := jsClient(t, s, nats.UserInfo("dlc", "foo"))
 	defer ncm.Close()
 
-	jsm, err := ncm.JetStream()
-	if err != nil {
-		t.Fatal(err)
-	}
+	var err error
 
 	// Create a stream using the server directly.
 	_, err = jsm.AddStream(&nats.StreamConfig{Name: "ORDERS"})
@@ -1964,16 +1857,8 @@ func TestJetStreamImportDirectOnly(t *testing.T) {
 		t.Fatalf("push consumer create failed: %v", err)
 	}
 
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
-
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
 
 	// Now make sure we can send to the stream from another account.
 	toSend := 100
@@ -2098,21 +1983,12 @@ func TestJetStreamCrossAccountMirrorsAndSources(t *testing.T) {
 	defer os.Remove(conf)
 
 	s, _ := RunServerWithConfig(conf)
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc1, err := nats.Connect(s.ClientURL(), nats.UserInfo("rip", "pass"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	nc1, js1 := jsClient(t, s, nats.UserInfo("rip", "pass"))
 	defer nc1.Close()
-	js1, err := nc1.JetStream()
-	if err != nil {
-		t.Fatal(err)
-	}
+
+	var err error
 
 	_, err = js1.AddStream(&nats.StreamConfig{
 		Name:     "TEST",
@@ -2135,15 +2011,8 @@ func TestJetStreamCrossAccountMirrorsAndSources(t *testing.T) {
 		}
 	}
 
-	nc2, err := nats.Connect(s.ClientURL(), nats.UserInfo("dlc", "pass"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	nc2, js2 := jsClient(t, s, nats.UserInfo("dlc", "pass"))
 	defer nc2.Close()
-	js2, err := nc2.JetStream()
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	checkMsgCount := func(t *testing.T, stream string) {
 		t.Helper()
@@ -2222,22 +2091,12 @@ func TestJetStreamCrossAccountMirrorsAndSources(t *testing.T) {
 
 func TestJetStreamAutoMaxAckPending(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL(), nats.SyncQueueLen(500))
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s, nats.SyncQueueLen(500))
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	_, err = js.AddStream(&nats.StreamConfig{Name: "foo"})
 	if err != nil {
@@ -2297,27 +2156,17 @@ func TestJetStreamAutoMaxAckPending(t *testing.T) {
 
 func TestJetStreamInterfaces(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	defer nc.Close()
-
-	var js nats.JetStream
 	var jsm nats.JetStreamManager
 	var jsctx nats.JetStreamContext
 
 	// JetStream that can publish/subscribe but cannot manage streams.
-	js, err = nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
+	defer nc.Close()
+
+	var err error
+
 	js.Publish("foo", []byte("hello"))
 
 	// JetStream context that can manage streams/consumers but cannot produce messages.
@@ -2344,22 +2193,12 @@ func TestJetStreamInterfaces(t *testing.T) {
 
 func TestJetStreamSubscribe_DeliverPolicy(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	// Create the stream using our client API.
 	_, err = js.AddStream(&nats.StreamConfig{
@@ -2378,6 +2217,7 @@ func TestJetStreamSubscribe_DeliverPolicy(t *testing.T) {
 			publishTime = time.Now()
 		}
 		js.Publish("foo", []byte(payload))
+		time.Sleep(15 * time.Millisecond)
 	}
 
 	for _, test := range []struct {
@@ -2403,7 +2243,11 @@ func TestJetStreamSubscribe_DeliverPolicy(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			timeout := 2 * time.Second
+			if test.expected == 0 {
+				timeout = 250 * time.Millisecond
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
 
 			got := 0
@@ -2445,22 +2289,12 @@ func TestJetStreamSubscribe_DeliverPolicy(t *testing.T) {
 
 func TestJetStreamSubscribe_AckPolicy(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	// Create the stream using our client API.
 	_, err = js.AddStream(&nats.StreamConfig{
@@ -2839,22 +2673,12 @@ func TestJetStreamSubscribe_AckPolicy(t *testing.T) {
 
 func TestJetStreamPullSubscribe_AckPending(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	// Create the stream using our client API.
 	_, err = js.AddStream(&nats.StreamConfig{
@@ -3055,22 +2879,12 @@ func TestJetStreamPullSubscribe_AckPending(t *testing.T) {
 
 func TestJetStreamSubscribe_AckDup(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	// Create the stream using our client API.
 	_, err = js.AddStream(&nats.StreamConfig{
@@ -3127,22 +2941,12 @@ func TestJetStreamSubscribe_AckDup(t *testing.T) {
 
 func TestJetStreamSubscribe_AckDupInProgress(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	// Create the stream using our client API.
 	_, err = js.AddStream(&nats.StreamConfig{
@@ -3194,22 +2998,12 @@ func TestJetStreamSubscribe_AckDupInProgress(t *testing.T) {
 
 func TestJetStream_Unsubscribe(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	_, err = js.AddStream(&nats.StreamConfig{
 		Name:     "foo",
@@ -3341,22 +3135,13 @@ func TestJetStream_Unsubscribe(t *testing.T) {
 
 func TestJetStream_UnsubscribeCloseDrain(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
-
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	serverURL := s.ClientURL()
-	mc, err := nats.Connect(serverURL)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	mc, jsm := jsClient(t, s)
 	defer mc.Close()
-	jsm, err := mc.JetStream()
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
+
+	var err error
 
 	_, err = jsm.AddStream(&nats.StreamConfig{
 		Name:     "foo",
@@ -3408,15 +3193,8 @@ func TestJetStream_UnsubscribeCloseDrain(t *testing.T) {
 	jsm.Publish("foo.C", []byte("C.1"))
 
 	t.Run("conn close does not delete any consumer", func(t *testing.T) {
-		nc, err := nats.Connect(serverURL)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-
-		js, err := nc.JetStream()
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
+		nc, js := jsClient(t, s)
+		defer nc.Close()
 
 		if _, err := js.SubscribeSync("foo.A"); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
@@ -3448,16 +3226,8 @@ func TestJetStream_UnsubscribeCloseDrain(t *testing.T) {
 	jsm.Publish("foo.C", []byte("C.2"))
 
 	t.Run("reattached durables consumers cannot be deleted with unsubscribe", func(t *testing.T) {
-		nc, err := nats.Connect(serverURL)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
+		nc, js := jsClient(t, s)
 		defer nc.Close()
-
-		js, err := nc.JetStream()
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
 
 		fetchConsumers(t, 2)
 
@@ -3523,11 +3293,7 @@ func TestJetStream_UnsubscribeDeleteNoPermissions(t *testing.T) {
 	defer os.Remove(conf)
 
 	s, _ := RunServerWithConfig(conf)
-	defer s.Shutdown()
-
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	errCh := make(chan error, 2)
 	nc, err := nats.Connect(s.ClientURL(), nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
@@ -3576,22 +3342,12 @@ func TestJetStream_UnsubscribeDeleteNoPermissions(t *testing.T) {
 
 func TestJetStreamSubscribe_ReplayPolicy(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	// Create the stream using our client API.
 	_, err = js.AddStream(&nats.StreamConfig{
@@ -3662,22 +3418,12 @@ func TestJetStreamSubscribe_ReplayPolicy(t *testing.T) {
 
 func TestJetStreamSubscribe_RateLimit(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	// Create the stream using our client API.
 	_, err = js.AddStream(&nats.StreamConfig{
@@ -3743,22 +3489,12 @@ func TestJetStreamSubscribe_RateLimit(t *testing.T) {
 
 func TestJetStreamSubscribe_ConfigCantChange(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	// Create the stream using our client API.
 	_, err = js.AddStream(&nats.StreamConfig{
@@ -4013,14 +3749,7 @@ func withJSServer(t *testing.T, tfn func(t *testing.T, srvs ...*jsServer)) {
 	opts.LameDuckDuration = 3 * time.Second
 	opts.LameDuckGracePeriod = 2 * time.Second
 	s := &jsServer{Server: RunServerWithOptions(opts), myopts: &opts}
-
-	defer func() {
-		if config := s.JetStreamConfig(); config != nil {
-			os.RemoveAll(config.StoreDir)
-		}
-		s.Shutdown()
-		s.WaitForShutdown()
-	}()
+	defer shutdownJSServerAndRemoveStorage(t, s.Server)
 	tfn(t, s)
 }
 
@@ -4133,16 +3862,10 @@ func TestJetStream_ClusterPlacement(t *testing.T) {
 		cluster := "PLC1"
 		withJSCluster(t, cluster, size, func(t *testing.T, nodes ...*jsServer) {
 			srvA := nodes[0]
-			nc, err := nats.Connect(srvA.ClientURL())
-			if err != nil {
-				t.Error(err)
-			}
+			nc, js := jsClient(t, srvA.Server)
 			defer nc.Close()
 
-			js, err := nc.JetStream()
-			if err != nil {
-				t.Fatal(err)
-			}
+			var err error
 
 			stream := &nats.StreamConfig{
 				Name: "TEST",
@@ -4162,16 +3885,10 @@ func TestJetStream_ClusterPlacement(t *testing.T) {
 		cluster := "PLC2"
 		withJSCluster(t, cluster, size, func(t *testing.T, nodes ...*jsServer) {
 			srvA := nodes[0]
-			nc, err := nats.Connect(srvA.ClientURL())
-			if err != nil {
-				t.Error(err)
-			}
+			nc, js := jsClient(t, srvA.Server)
 			defer nc.Close()
 
-			js, err := nc.JetStream()
-			if err != nil {
-				t.Fatal(err)
-			}
+			var err error
 
 			stream := &nats.StreamConfig{
 				Name: "TEST",
@@ -4192,16 +3909,10 @@ func TestJetStream_ClusterPlacement(t *testing.T) {
 		cluster := "PLC3"
 		withJSCluster(t, cluster, size, func(t *testing.T, nodes ...*jsServer) {
 			srvA := nodes[0]
-			nc, err := nats.Connect(srvA.ClientURL())
-			if err != nil {
-				t.Error(err)
-			}
+			nc, js := jsClient(t, srvA.Server)
 			defer nc.Close()
 
-			js, err := nc.JetStream()
-			if err != nil {
-				t.Fatal(err)
-			}
+			var err error
 
 			stream := &nats.StreamConfig{
 				Name: "TEST",
@@ -4228,16 +3939,10 @@ func TestJetStreamStreamMirror(t *testing.T) {
 
 func testJetStreamMirror_Source(t *testing.T, nodes ...*jsServer) {
 	srvA := nodes[0]
-	nc, err := nats.Connect(srvA.ClientURL())
-	if err != nil {
-		t.Error(err)
-	}
+	nc, js := jsClient(t, srvA.Server)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatal(err)
-	}
+	var err error
 
 	_, err = js.AddStream(&nats.StreamConfig{
 		Name: "origin",
@@ -4758,20 +4463,12 @@ func testJetStream_ClusterMultipleQueueSubscribe(t *testing.T, subject string, s
 
 func testJetStream_ClusterMultiplePullSubscribe(t *testing.T, subject string, srvs ...*jsServer) {
 	srv := srvs[0]
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatal(err)
-	}
+	nc, js := jsClient(t, srv.Server)
 	defer nc.Close()
 
 	var wg sync.WaitGroup
 	ctx, done := context.WithTimeout(context.Background(), 2*time.Second)
 	defer done()
-
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	size := 5
 	subs := make([]*nats.Subscription, size)
@@ -5284,16 +4981,10 @@ func TestJetStreamPullSubscribeOptions(t *testing.T) {
 
 func testJetStreamFetchOptions(t *testing.T, srvs ...*jsServer) {
 	srv := srvs[0]
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Error(err)
-	}
+	nc, js := jsClient(t, srv.Server)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatal(err)
-	}
+	var err error
 
 	subject := "WQ"
 	_, err = js.AddStream(&nats.StreamConfig{
@@ -5537,22 +5228,10 @@ func testJetStreamFetchOptions(t *testing.T, srvs ...*jsServer) {
 
 func TestJetStreamPublishAsync(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
-
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
 
 	// Make sure we get a proper failure when no stream is present.
 	paf, err := js.PublishAsync("foo", []byte("Hello JS"))
@@ -5667,11 +5346,7 @@ func TestJetStreamPublishAsyncPerf(t *testing.T) {
 	t.SkipNow()
 
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
-
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, err := nats.Connect(s.ClientURL())
 	if err != nil {
@@ -5726,22 +5401,10 @@ func TestJetStreamPublishAsyncPerf(t *testing.T) {
 
 func TestJetStreamBindConsumer(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
-
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
 
 	if _, err := js.AddStream(nil); err == nil {
 		t.Fatalf("Unexpected success")
@@ -5926,11 +5589,7 @@ func TestJetStreamDomain(t *testing.T) {
 	defer os.Remove(conf)
 
 	s, _ := RunServerWithConfig(conf)
-	defer s.Shutdown()
-
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, err := nats.Connect(s.ClientURL())
 	if err != nil {
@@ -6047,22 +5706,13 @@ func TestJetStreamMaxMsgsPerSubject(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			s := RunBasicJetStreamServer()
-			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
-			}
+			defer shutdownJSServerAndRemoveStorage(t, s)
 
 			// Client for API requests.
-			nc, err := nats.Connect(s.ClientURL())
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
+			nc, js := jsClient(t, s)
 			defer nc.Close()
-			js, err := nc.JetStream()
-			if err != nil {
-				t.Fatalf("Got error during initialization %v", err)
-			}
+
+			var err error
 
 			_, err = js.AddStream(c.mconfig)
 			if err != nil {
@@ -6110,11 +5760,7 @@ func TestJetStreamMaxMsgsPerSubject(t *testing.T) {
 
 func TestJetStreamDrainFailsToDeleteConsumer(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
-
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	errCh := make(chan error, 1)
 	nc, err := nats.Connect(s.ClientURL(), nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
@@ -6180,23 +5826,10 @@ func TestJetStreamDomainInPubAck(t *testing.T) {
 	defer os.Remove(conf)
 
 	s, _ := RunServerWithConfig(conf)
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	// Client for API requests.
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Got error during initialization %v", err)
-	}
 
 	cfg := &nats.StreamConfig{
 		Name:     "TEST",
@@ -6218,22 +5851,10 @@ func TestJetStreamDomainInPubAck(t *testing.T) {
 
 func TestJetStreamStreamAndConsumerDescription(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
-
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
 
 	streamDesc := "stream description"
 	si, err := js.AddStream(&nats.StreamConfig{
@@ -6264,22 +5885,10 @@ func TestJetStreamStreamAndConsumerDescription(t *testing.T) {
 
 func TestJetStreamMsgSubjectRewrite(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
-
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
 
 	if _, err := js.AddStream(&nats.StreamConfig{
 		Name:     "TEST",
@@ -6321,16 +5930,10 @@ func TestJetStreamPullSubscribeFetchContext(t *testing.T) {
 
 func testJetStreamFetchContext(t *testing.T, srvs ...*jsServer) {
 	srv := srvs[0]
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Error(err)
-	}
+	nc, js := jsClient(t, srv.Server)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatal(err)
-	}
+	var err error
 
 	subject := "WQ"
 	_, err = js.AddStream(&nats.StreamConfig{
@@ -6582,22 +6185,12 @@ func testJetStreamFetchContext(t *testing.T, srvs ...*jsServer) {
 
 func TestJetStreamSubscribeContextCancel(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer s.Shutdown()
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
-
-	nc, err := nats.Connect(s.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	var err error
 
 	// Create the stream using our client API.
 	_, err = js.AddStream(&nats.StreamConfig{

--- a/test/norace_test.go
+++ b/test/norace_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestNoRaceObjectContextOpt(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer shutdown(s)
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, js := jsClient(t, s)
 	defer nc.Close()
@@ -61,7 +61,7 @@ func TestNoRaceObjectContextOpt(t *testing.T) {
 	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
 	time.AfterFunc(100*time.Millisecond, cancel)
 
-	time.AfterFunc(20*time.Millisecond, func() { shutdown(s) })
+	time.AfterFunc(20*time.Millisecond, func() { shutdownJSServerAndRemoveStorage(t, s) })
 	start = time.Now()
 	_, err = obs.GetBytes("BLOB", nats.Context(ctx))
 	expectErr(t, err)
@@ -84,7 +84,7 @@ func (sr *slow) Read(p []byte) (n int, err error) {
 
 func TestNoRaceObjectDoublePut(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer shutdown(s)
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, js := jsClient(t, s)
 	defer nc.Close()

--- a/test/object_test.go
+++ b/test/object_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The NATS Authors
+// Copyright 2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -21,6 +21,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -29,7 +30,7 @@ import (
 
 func TestObjectBasics(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer shutdown(s)
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, js := jsClient(t, s)
 	defer nc.Close()
@@ -114,7 +115,7 @@ func TestObjectBasics(t *testing.T) {
 
 func TestDefaultObjectStatus(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer shutdown(s)
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, js := jsClient(t, s)
 	defer nc.Close()
@@ -141,8 +142,15 @@ func TestDefaultObjectStatus(t *testing.T) {
 }
 
 func TestObjectFileBasics(t *testing.T) {
+	// The filename is likely to be something like C:\xxx and we don't allow
+	// the '\' or ':' characters. We could translate the tmpFile.Name() from
+	// C:\foo\bar to C:/foo/bar (since Windows is OK with that), however,
+	// that would still fail on key validation because `:` is not allowed.
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
 	s := RunBasicJetStreamServer()
-	defer shutdown(s)
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, js := jsClient(t, s)
 	defer nc.Close()
@@ -184,7 +192,7 @@ func TestObjectFileBasics(t *testing.T) {
 
 func TestObjectMulti(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer shutdown(s)
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, js := jsClient(t, s)
 	defer nc.Close()
@@ -230,7 +238,7 @@ func TestObjectMulti(t *testing.T) {
 
 func TestObjectDeleteMarkers(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer shutdown(s)
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, js := jsClient(t, s)
 	defer nc.Close()
@@ -262,7 +270,7 @@ func TestObjectDeleteMarkers(t *testing.T) {
 
 func TestObjectMultiWithDelete(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer shutdown(s)
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, js := jsClient(t, s)
 	defer nc.Close()
@@ -303,7 +311,7 @@ func TestObjectMultiWithDelete(t *testing.T) {
 
 func TestObjectNames(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer shutdown(s)
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, js := jsClient(t, s)
 	defer nc.Close()
@@ -333,7 +341,7 @@ func TestObjectNames(t *testing.T) {
 
 func TestObjectMetadata(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer shutdown(s)
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, js := jsClient(t, s)
 	defer nc.Close()
@@ -370,7 +378,7 @@ func TestObjectMetadata(t *testing.T) {
 
 func TestObjectWatch(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer shutdown(s)
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, js := jsClient(t, s)
 	defer nc.Close()
@@ -450,7 +458,7 @@ func TestObjectWatch(t *testing.T) {
 
 func TestObjectLinks(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer shutdown(s)
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, js := jsClient(t, s)
 	defer nc.Close()
@@ -504,7 +512,7 @@ func TestObjectLinks(t *testing.T) {
 // Right now no history, just make sure we are cleaning up after ourselves.
 func TestObjectHistory(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer shutdown(s)
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, js := jsClient(t, s)
 	defer nc.Close()
@@ -529,7 +537,7 @@ func TestObjectHistory(t *testing.T) {
 
 func TestObjectList(t *testing.T) {
 	s := RunBasicJetStreamServer()
-	defer shutdown(s)
+	defer shutdownJSServerAndRemoveStorage(t, s)
 
 	nc, js := jsClient(t, s)
 	defer nc.Close()

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -365,17 +365,16 @@ func TestCloseSubRelease(t *testing.T) {
 	sub, _ := nc.SubscribeSync("foo")
 	start := time.Now()
 	go func() {
-		time.Sleep(5 * time.Millisecond)
+		time.Sleep(15 * time.Millisecond)
 		nc.Close()
 	}()
-	_, err := sub.NextMsg(50 * time.Millisecond)
-	if err == nil {
+	if _, err := sub.NextMsg(time.Second); err == nil {
 		t.Fatalf("Expected an error from NextMsg")
 	}
 	elapsed := time.Since(start)
 
 	// On Windows, the minimum waitTime is at least 15ms.
-	if elapsed > 20*time.Millisecond {
+	if elapsed > 50*time.Millisecond {
 		t.Fatalf("Too much time has elapsed to release NextMsg: %dms",
 			(elapsed / time.Millisecond))
 	}


### PR DESCRIPTION
- JS Servers need a special sequence on shutdown. Most of the time
the store was attempted to be removed before the server was shutdown,
which on Windows would result in an error and the next test may
recover the previous state.
- Made use of the jsClient() helper to remove typical connect+jetstream
code.
- Added some nats.Timeout() during connect so that Windows connect
to a server that is not running is faster than the default 2sec, which
may cause tests to run very long or simply fail.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>