### PR TITLE
Spelling fixes, mostly comments

### DIFF
--- a/.words
+++ b/.words
@@ -1,0 +1,144 @@
+1
+## ^^^ size estimate, just needs to be non-zero
+##
+## The .words file is used by gospel (v1.2+), which wraps the Hunspell libraries but populates the dictionary with identifiers from the Go source.
+## <https://github.com/kortschak/gospel>
+##
+## Comment lines are not actually parsed as comments, try to be careful ... but in practice they seem to work?
+##
+## We assume en_US hunspell dictionaries are installed and used.  The /AFFIXRULES are defined in en_US.aff (eg: /usr/share/hunspell/en_US.aff)
+##
+## words which are in the base dictionary can't have extra affix rules added to them, so we have to start with the affixed variant we want to add.
+##   thus creds rather than cred/S and so on
+## So we can't use receive/DRSZGBU, adding 'U', to allow unreceive and variants, we have to use unreceive as the stem.
+## We can't define our own affix or compound rules, to capture rfc\d{3,} or 0x[0-9A-Fa-f]{2}
+
+## People involved who are referenced in todo/fixmes
+derek
+dlc
+ivan
+
+## Legitimate spellings in non-US English dialects;
+## regular-if-rarer words just missing from the dictionary;
+## variants of words not covered by hunspell en_US rules.
+acknowledgement/SM
+arity
+deduplication/S
+demarshal/SDG
+durables
+iff
+observable/S
+redelivery/S
+retransmitting
+retry/SB
+unmarshal/SDG
+
+# I think that retry, being added as a symbol, is precluding the re-addition here with affix rules,
+# so "retry/SB" above is ignored
+retries
+retryable
+
+## Things gospel doesn't pick up, but doesn't yet; I've filed <https://github.com/kortschak/gospel/issues/9>
+## Eg, plurals of non-collection types, or wire-format encodings in a struct field's tag
+AsyncSubscriptions
+ChanSubscriptions
+PubAckFutures
+SubOpts
+SyncSubscriptions
+no_wait
+
+## Conceptual nouns not actually in the source, describing state
+SlowConsumer
+
+## Symbols from elsewhere referred to in comments but not referenced in the code, so not currently surfaced by gospel as acceptable
+AppendInt
+ReadMIMEHeader
+
+## The rest
+
+clientProtoZero
+jetstream
+v1
+v2
+
+ack/SGD
+auth
+authToken
+chans
+creds
+config/S
+cseq
+impl
+msgh
+msgId
+mux/S
+nack
+ptr
+puback
+scanf
+stderr
+stdout
+structs
+tm
+todo
+unsub/S
+
+## The spelling tokenizer doesn't take "permessage-deflate" as allowing for ... "permessage-deflate",
+## which is an RFC7692 registered extension.  We have to explicitly list "permessage".
+permessage
+permessage-deflate
+urlA
+urlB
+websocket
+ws
+wss
+
+NKey
+pList
+
+backend/S
+backoff/S
+decompressor/CGS
+inflight
+inlined
+lookups
+reconnection/MS
+redeliver/ADGS
+responder/S
+rewrap/S
+rollup/S
+unreceive/DRSZGB
+variadic
+wakeup/S
+whitespace
+wrap/AS
+
+omitempty
+
+apache
+html
+ietf
+www
+
+sum256
+32bit/S
+64bit/S
+64k
+128k
+512k
+
+hacky
+handroll/D
+
+rfc6455
+rfc7692
+0x00
+0xff
+20x
+40x
+50x
+
+ErrXXX
+
+atlanta
+eu

--- a/context.go
+++ b/context.go
@@ -224,7 +224,7 @@ func (nc *Conn) FlushWithContext(ctx context.Context) error {
 
 // RequestWithContext will create an Inbox and perform a Request
 // using the provided cancellation context with the Inbox reply
-// for the data v. A response will be decoded into the vPtrResponse.
+// for the data v. A response will be decoded into the vPtr last parameter.
 func (c *EncodedConn) RequestWithContext(ctx context.Context, subject string, v interface{}, vPtr interface{}) error {
 	if ctx == nil {
 		return ErrInvalidContext

--- a/enc.go
+++ b/enc.go
@@ -130,7 +130,7 @@ func (c *EncodedConn) Request(subject string, v interface{}, vPtr interface{}, t
 
 // Handler is a specific callback used for Subscribe. It is generalized to
 // an interface{}, but we will discover its format and arguments at runtime
-// and perform the correct callback, including de-marshaling encoded data
+// and perform the correct callback, including demarshaling encoded data
 // back into the appropriate struct based on the signature of the Handler.
 //
 // Handlers are expected to have one of four signatures.

--- a/jsm.go
+++ b/jsm.go
@@ -884,7 +884,7 @@ func (js *js) DeleteMsg(name string, seq uint64, opts ...JSOpt) error {
 	return nil
 }
 
-// purgeRequest is optional request information to the purge API.
+// streamPurgeRequest is optional request information to the purge API.
 type streamPurgeRequest struct {
 	// Purge up to but not including sequence.
 	Sequence uint64 `json:"seq,omitempty"`
@@ -986,7 +986,7 @@ func (s *streamLister) Next() bool {
 		defer cancel()
 	}
 
-	slSubj := s.js.apiSubj(apiStreamList)
+	slSubj := s.js.apiSubj(apiStreamListT)
 	r, err := s.js.apiRequestWithContext(ctx, slSubj, req)
 	if err != nil {
 		s.err = err

--- a/nats.go
+++ b/nats.go
@@ -40,9 +40,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/nats-io/nats.go/util"
 	"github.com/nats-io/nkeys"
 	"github.com/nats-io/nuid"
+
+	"github.com/nats-io/nats.go/util"
 )
 
 // Default Constants
@@ -336,12 +337,10 @@ type Options struct {
 
 	// ReconnectJitter sets the upper bound for a random delay added to
 	// ReconnectWait during a reconnect when no TLS is used.
-	// Note that any jitter is capped with ReconnectJitterMax.
 	ReconnectJitter time.Duration
 
 	// ReconnectJitterTLS sets the upper bound for a random delay added to
 	// ReconnectWait during a reconnect when TLS is used.
-	// Note that any jitter is capped with ReconnectJitterMax.
 	ReconnectJitterTLS time.Duration
 
 	// Timeout sets the timeout for a Dial operation on a connection.
@@ -443,7 +442,7 @@ type Options struct {
 
 	// LameDuckModeHandler sets the callback to invoke when the server notifies
 	// the connection that it entered lame duck mode, that is, going to
-	// gradually disconnect all its connections before shuting down. This is
+	// gradually disconnect all its connections before shutting down. This is
 	// often used in deployments when upgrading NATS Servers.
 	LameDuckModeHandler ConnHandler
 
@@ -889,7 +888,7 @@ func PingInterval(t time.Duration) Option {
 }
 
 // MaxPingsOutstanding is an Option to set the maximum number of ping requests
-// that can go un-answered by the server before closing the connection.
+// that can go unanswered by the server before closing the connection.
 func MaxPingsOutstanding(max int) Option {
 	return func(o *Options) error {
 		o.MaxPingsOut = max
@@ -1111,7 +1110,7 @@ func NoCallbacksAfterClientClose() Option {
 
 // LameDuckModeHandler sets the callback to invoke when the server notifies
 // the connection that it entered lame duck mode, that is, going to
-// gradually disconnect all its connections before shuting down. This is
+// gradually disconnect all its connections before shutting down. This is
 // often used in deployments when upgrading NATS Servers.
 func LameDuckModeHandler(cb ConnHandler) Option {
 	return func(o *Options) error {
@@ -1254,7 +1253,7 @@ func (o Options) Connect() (*Conn, error) {
 		return nil, ErrNkeyButNoSigCB
 	}
 
-	// Allow custom Dialer for connecting using DialTimeout by default
+	// Allow custom Dialer for connecting using a timeout by default
 	if nc.Opts.Dialer == nil {
 		nc.Opts.Dialer = &net.Dialer{
 			Timeout: nc.Opts.Timeout,
@@ -1869,7 +1868,7 @@ func versionComponents(version string) (major, minor, patch int, err error) {
 	return major, minor, patch, err
 }
 
-// Check for mininum server requirement.
+// Check for minimum server requirement.
 func (nc *Conn) serverMinVersion(major, minor, patch int) bool {
 	smajor, sminor, spatch, _ := versionComponents(nc.ConnectedServerVersion())
 	if smajor < major || (smajor == major && sminor < minor) || (smajor == major && sminor == minor && spatch < patch) {
@@ -2275,7 +2274,7 @@ func parseControl(line string, c *control) {
 	}
 }
 
-// flushReconnectPending will push the pending items that were
+// flushReconnectPendingItems will push the pending items that were
 // gathered while we were in a RECONNECTING state to the socket.
 func (nc *Conn) flushReconnectPendingItems() error {
 	return nc.bw.flushPendingBuffer()
@@ -2811,13 +2810,13 @@ func (nc *Conn) processMsg(data []byte) {
 		if h != nil {
 			ctrlMsg, ctrlType = isJSControlMessage(m)
 			if ctrlMsg && ctrlType == jsCtrlHB {
-				// Check if the hearbeat has a "Consumer Stalled" header, if
+				// Check if the heartbeat has a "Consumer Stalled" header, if
 				// so, the value is the FC reply to send a nil message to.
 				// We will send it at the end of this function.
 				fcReply = m.Header.Get(consumerStalledHdr)
 			}
 		}
-		// Check for ordered consumer here. If checkOrdered returns true that means it detected a gap.
+		// Check for ordered consumer here. If checkOrderedMsgs returns true that means it detected a gap.
 		if !ctrlMsg && jsi.ordered && sub.checkOrderedMsgs(m) {
 			sub.mu.Unlock()
 			return
@@ -3163,7 +3162,7 @@ func checkAuthError(e string) error {
 }
 
 // processErr processes any error messages from the server and
-// sets the connection's lastError.
+// sets the connection's LastError.
 func (nc *Conn) processErr(ie string) {
 	// Trim, remove quotes
 	ne := normalizeErr(ie)
@@ -3370,7 +3369,7 @@ func (nc *Conn) PublishRequest(subj, reply string, data []byte) error {
 	return nc.publish(subj, reply, nil, data)
 }
 
-// Used for handrolled itoa
+// Used for handrolled Itoa
 const digits = "0123456789"
 
 // publish is the internal function to publish messages to a nats-server.
@@ -4703,7 +4702,7 @@ func (nc *Conn) close(status Status, doCBs bool, err error) {
 	nc.stopPingTimer()
 	nc.ptmr = nil
 
-	// Need to close and set tcp conn to nil if reconnect loop has stopped,
+	// Need to close and set TCP conn to nil if reconnect loop has stopped,
 	// otherwise we would incorrectly invoke Disconnect handler (if set)
 	// down below.
 	if nc.ar && nc.conn != nil {
@@ -4726,7 +4725,7 @@ func (nc *Conn) close(status Status, doCBs bool, err error) {
 			close(s.mch)
 		}
 		s.mch = nil
-		// Mark as invalid, for signaling to deliverMsgs
+		// Mark as invalid, for signaling to waitForMsgs
 		s.closed = true
 		// Mark connection closed in subscription
 		s.connClosed = true
@@ -4756,7 +4755,7 @@ func (nc *Conn) close(status Status, doCBs bool, err error) {
 		}
 	}
 	// If this is terminal, then we have to notify the asyncCB handler that
-	// it can exit once all async cbs have been dispatched.
+	// it can exit once all async callbacks have been dispatched.
 	if status == CLOSED {
 		nc.ach.close()
 	}

--- a/object.go
+++ b/object.go
@@ -454,7 +454,7 @@ func (info *ObjectInfo) isLink() bool {
 	return info.ObjectMeta.Opts != nil && info.ObjectMeta.Opts.Link != nil
 }
 
-// GetObject will pull the object from the underlying stream.
+// Get will pull the object from the underlying stream.
 func (obs *obs) Get(name string, opts ...ObjectOpt) (ObjectResult, error) {
 	// Grab meta info.
 	info, err := obs.GetInfo(name)

--- a/parser.go
+++ b/parser.go
@@ -532,7 +532,7 @@ func (nc *Conn) processHeaderMsgArgs(arg []byte) error {
 	return nil
 }
 
-// Ascii numbers 0-9
+// ASCII numbers 0-9
 const (
 	ascii_0 = 48
 	ascii_9 = 57

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats-server/v2/test"
+
 	"github.com/nats-io/nats.go"
 )
 
@@ -1398,7 +1399,7 @@ func TestUseCustomDialer(t *testing.T) {
 	}
 	defer nc3.Close()
 	if nc3.Opts.Dialer.Timeout != nats.DefaultTimeout {
-		t.Fatalf("Expected DialTimeout to be set to %v, got %v", nats.DefaultTimeout, nc.Opts.Dialer.Timeout)
+		t.Fatalf("Expected Dialer.Timeout to be set to %v, got %v", nats.DefaultTimeout, nc.Opts.Dialer.Timeout)
 	}
 
 	// Create custom dialer that return error on Dial().

--- a/ws.go
+++ b/ws.go
@@ -403,7 +403,7 @@ func (r *websocketReader) handleControlFrame(frameType wsOpCode, buf []byte, pos
 			}
 		}
 		r.nc.wsEnqueueCloseMsg(status, body)
-		// Return io.EOF so that readLoop will close the connection as ClientClosed
+		// Return io.EOF so that readLoop will close the connection as client closed
 		// after processing pending buffers.
 		return pos, io.EOF
 	case wsPingMessage:


### PR DESCRIPTION
The new `gospel` tool, <https://github.com/kortschak/gospel>, uses hunspell libraries but pre-registers as acceptable words every symbol from the Go source, massively reducing the noise and making comment spell-checking a tractable problem.  It recently gained support for a `.words` file located in the same directory as the `go.mod` file, to define local words.  With this, we can fix real issues too.

This PR reduces the complaints down to 4:
 1. A reference to `syncSubscribers` which I can't figure out
 2. A reference to a `pubArg`
 3. Two references to `splitArgs`.

I made two actual code changes:
 1. Fixing a **non-exported** const type for consistency with all the others: `apiStreamList` -> `apiStreamListT`.
 2. Changing an error message to refer to a field which exist

Lots of typo fixes; references to since-renamed fields; etc.

A reference to `PublishAsynMsg` might have been intended to be `PublishAsyncMsg` but that doesn't exist either, so I removed it.  Similarly, `SubjectIsDelivery` lived briefly but a stale reference was left in a comment, so I removed that.

To reproduce:

    go install github.com/kortschak/gospel@latest
    gospel .
