### PR TITLE
Updates to KV Watcher.

### DIFF
--- a/go_test.mod
+++ b/go_test.mod
@@ -1,11 +1,20 @@
 module github.com/nats-io/nats.go
 
-go 1.16
+go 1.17
 
 require (
 	github.com/golang/protobuf v1.4.2
-	github.com/nats-io/nats-server/v2 v2.7.2-0.20220201004847-b23ed778684c
+	github.com/nats-io/nats-server/v2 v2.7.2
 	github.com/nats-io/nkeys v0.3.0
 	github.com/nats-io/nuid v1.0.1
 	google.golang.org/protobuf v1.23.0
+)
+
+require (
+	github.com/klauspost/compress v1.13.4 // indirect
+	github.com/minio/highwayhash v1.0.1 // indirect
+	github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296 // indirect
+	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
+	golang.org/x/sys v0.0.0-20220111092808-5a964db01320 // indirect
+	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
 )

--- a/go_test.sum
+++ b/go_test.sum
@@ -17,8 +17,8 @@ github.com/minio/highwayhash v1.0.1 h1:dZ6IIu8Z14VlC0VpfKofAhCy74wu/Qb5gcn52yWoz
 github.com/minio/highwayhash v1.0.1/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296 h1:vU9tpM3apjYlLLeY23zRWJ9Zktr5jp+mloR942LEOpY=
 github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
-github.com/nats-io/nats-server/v2 v2.7.2-0.20220201004847-b23ed778684c h1:TfLMCHvaj2YSNrgiEWQiXA344lWqPmX3xOLtZj/ywlA=
-github.com/nats-io/nats-server/v2 v2.7.2-0.20220201004847-b23ed778684c/go.mod h1:tckmrt0M6bVaDT3kmh9UrIq/CBOBBse+TpXQi5ldaa8=
+github.com/nats-io/nats-server/v2 v2.7.2 h1:+LEN8m0+jdCkiGc884WnDuxR+qj80/5arj+szKuRpRI=
+github.com/nats-io/nats-server/v2 v2.7.2/go.mod h1:tckmrt0M6bVaDT3kmh9UrIq/CBOBBse+TpXQi5ldaa8=
 github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=
 github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=

--- a/kv.go
+++ b/kv.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The NATS Authors
+// Copyright 2021-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -306,6 +307,11 @@ func (js *js) CreateKeyValue(cfg *KeyValueConfig) (KeyValue, error) {
 		DenyDelete:        true,
 	}
 
+	// If we are at server version 2.7.2 or above use DiscardNew. We can not use DiscardNew for 2.7.1 or below.
+	if js.nc.serverMinVersion(2, 7, 2) {
+		scfg.Discard = DiscardNew
+	}
+
 	if _, err := js.AddStream(scfg); err != nil {
 		return nil, err
 	}
@@ -588,6 +594,7 @@ func (kv *kvs) History(key string, opts ...WatchOpt) ([]KeyValueEntry, error) {
 
 // Implementation for Watch
 type watcher struct {
+	mu      sync.Mutex
 	updates chan KeyValueEntry
 	sub     *Subscription
 }
@@ -597,7 +604,22 @@ func (w *watcher) Updates() <-chan KeyValueEntry {
 	if w == nil {
 		return nil
 	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.updates
+}
+
+// close the update chan.
+func (w *watcher) close() {
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	if w.updates != nil {
+		close(w.updates)
+		w.updates = nil
+	}
+	w.mu.Unlock()
 }
 
 // Stop will unsubscribe from the watcher.
@@ -605,6 +627,7 @@ func (w *watcher) Stop() error {
 	if w == nil {
 		return nil
 	}
+	w.close()
 	return w.sub.Unsubscribe()
 }
 
@@ -626,6 +649,7 @@ func (kv *kvs) Watch(keys string, opts ...WatchOpt) (KeyWatcher, error) {
 	}
 
 	var initDoneMarker bool
+	initPending, received := uint64(0), uint64(0)
 
 	// Could be a pattern so don't check for validity as we normally do.
 	var b strings.Builder
@@ -633,7 +657,8 @@ func (kv *kvs) Watch(keys string, opts ...WatchOpt) (KeyWatcher, error) {
 	b.WriteString(keys)
 	keys = b.String()
 
-	w := &watcher{updates: make(chan KeyValueEntry, 32)}
+	// We will block below on placing items on the chan. That is by design.
+	w := &watcher{updates: make(chan KeyValueEntry, 256)}
 
 	update := func(m *Msg) {
 		tokens, err := getMetadataFields(m.Reply)
@@ -655,30 +680,38 @@ func (kv *kvs) Watch(keys string, opts ...WatchOpt) (KeyWatcher, error) {
 			}
 		}
 		delta := uint64(parseNum(tokens[ackNumPendingTokenPos]))
-		entry := &kve{
-			bucket:   kv.name,
-			key:      subj,
-			value:    m.Data,
-			revision: uint64(parseNum(tokens[ackStreamSeqTokenPos])),
-			created:  time.Unix(0, parseNum(tokens[ackTimestampSeqTokenPos])),
-			delta:    delta,
-			op:       op,
-		}
 		if !o.ignoreDeletes || (op != KeyValueDelete && op != KeyValuePurge) {
-			w.updates <- entry
+			entry := &kve{
+				bucket:   kv.name,
+				key:      subj,
+				value:    m.Data,
+				revision: uint64(parseNum(tokens[ackStreamSeqTokenPos])),
+				created:  time.Unix(0, parseNum(tokens[ackTimestampSeqTokenPos])),
+				delta:    delta,
+				op:       op,
+			}
+			w.mu.Lock()
+			if w.updates != nil {
+				w.updates <- entry
+			}
+			w.mu.Unlock()
 		}
-		// Check if done initial values.
-		if !initDoneMarker && delta == 0 {
-			initDoneMarker = true
-			w.updates <- nil
+		// Check if done and initial values.
+		if !initDoneMarker {
+			received++
+			// We set this on the first trip through..
+			if initPending == 0 {
+				initPending = delta
+			}
+			if received > initPending || delta == 0 {
+				initDoneMarker = true
+				w.mu.Lock()
+				if w.updates != nil {
+					w.updates <- nil
+				}
+				w.mu.Unlock()
+			}
 		}
-	}
-
-	// Check if we have anything pending.
-	_, err := kv.js.GetLastMsg(kv.stream, keys)
-	if err == ErrMsgNotFound {
-		initDoneMarker = true
-		w.updates <- nil
 	}
 
 	// Used ordered consumer to deliver results.
@@ -696,6 +729,15 @@ func (kv *kvs) Watch(keys string, opts ...WatchOpt) (KeyWatcher, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Track watcher.
+	sub.jsi.w = w
+
+	// Check on pending count.
+	if sub.jsi.pending == 0 {
+		initDoneMarker = true
+		w.updates <- nil
+	}
+
 	w.sub = sub
 	return w, nil
 }

--- a/nats.go
+++ b/nats.go
@@ -3929,7 +3929,8 @@ func (nc *Conn) removeSub(s *Subscription) {
 	s.mch = nil
 
 	// If JS subscription then stop HB timer.
-	if jsi := s.jsi; jsi != nil {
+	jsi := s.jsi
+	if jsi != nil {
 		if jsi.hbc != nil {
 			jsi.hbc.Stop()
 			jsi.hbc = nil
@@ -3938,17 +3939,19 @@ func (nc *Conn) removeSub(s *Subscription) {
 			jsi.csfct.Stop()
 			jsi.csfct = nil
 		}
-		// Check on any watcher. If we have one close the update chan.
-		if jsi.w != nil {
-			jsi.w.close()
-			jsi.w = nil
-		}
 	}
 
 	// Mark as invalid
 	s.closed = true
 	if s.pCond != nil {
 		s.pCond.Broadcast()
+	}
+
+	// Check for watchers.
+	if jsi != nil && jsi.w != nil {
+		// Check on any watcher. If we have one close the update chan.
+		jsi.w.close()
+		jsi.w = nil
 	}
 }
 

--- a/nats.go
+++ b/nats.go
@@ -158,6 +158,7 @@ var (
 	ErrConsumerNotActive            = errors.New("nats: consumer not active")
 	ErrMsgNotFound                  = errors.New("nats: message not found")
 	ErrMsgAlreadyAckd               = errors.New("nats: message was already acknowledged")
+	ErrStreamInfoMaxSubjects        = errors.New("nats: subject details would exceed maximum allowed")
 )
 
 func init() {
@@ -3936,6 +3937,11 @@ func (nc *Conn) removeSub(s *Subscription) {
 		if jsi.csfct != nil {
 			jsi.csfct.Stop()
 			jsi.csfct = nil
+		}
+		// Check on any watcher. If we have one close the update chan.
+		if jsi.w != nil {
+			jsi.w.close()
+			jsi.w = nil
 		}
 	}
 


### PR DESCRIPTION
1. If the underlying stream was very busy pending might not go to zero, so snapshot and mark initial state done when received >= init pending or delta == 0
2. When a watcher was cancelled with a context we would not signal to allow and range w.Updates() calls to exit.
3. General flow control checks were timing sensitive after the initial checks, needed to be 2x HB interval always, not just beginning.

Signed-off-by: Derek Collison <derek@nats.io>