### PR TITLE
Updates to KV

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -3935,8 +3935,7 @@ func (nc *Conn) removeSub(s *Subscription) {
 	s.mch = nil
 
 	// If JS subscription then stop HB timer.
-	jsi := s.jsi
-	if jsi != nil {
+	if jsi := s.jsi; jsi != nil {
 		if jsi.hbc != nil {
 			jsi.hbc.Stop()
 			jsi.hbc = nil


### PR DESCRIPTION
Relying on ConsumerInfo.NumPending on create does not always work
if the NATS subscription exists before (which is normal case)
due to a design in the server that process the add consumer
request and then computes the consumer info (after the consumer
is setup which means it could start to deliver messages).

Changed a bit so that we add a JS consumer without attached
subscription and use internal option to allow a js.Subscribe()
with a bind to existing consumer.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>