### PR TITLE
Add GetRevision to nats.KeyValue

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -373,10 +373,10 @@ func keyValid(key string) bool {
 // Get returns the latest value for the key.
 func (kv *kvs) Get(key string) (KeyValueEntry, error) {
 	e, err := kv.get(key, kvLatestRevision)
-	if err == ErrKeyDeleted {
-		return nil, ErrKeyNotFound
-	}
 	if err != nil {
+		if err == ErrKeyDeleted {
+			return nil, ErrKeyNotFound
+		}
 		return nil, err
 	}
 
@@ -386,10 +386,10 @@ func (kv *kvs) Get(key string) (KeyValueEntry, error) {
 // GetRevision returns a specific revision value for the key.
 func (kv *kvs) GetRevision(key string, revision uint64) (KeyValueEntry, error) {
 	e, err := kv.get(key, revision)
-	if err == ErrKeyDeleted {
-		return nil, ErrKeyNotFound
-	}
 	if err != nil {
+		if err == ErrKeyDeleted {
+			return nil, ErrKeyNotFound
+		}
 		return nil, err
 	}
 

--- a/kv.go
+++ b/kv.go
@@ -411,6 +411,9 @@ func (kv *kvs) get(key string, revision uint64) (KeyValueEntry, error) {
 		m, err = kv.js.GetLastMsg(kv.stream, b.String())
 	} else {
 		m, err = kv.js.GetMsg(kv.stream, revision)
+		if err == nil && m.Subject != b.String() {
+			return nil, ErrKeyNotFound
+		}
 	}
 
 	if err != nil {
@@ -418,10 +421,6 @@ func (kv *kvs) get(key string, revision uint64) (KeyValueEntry, error) {
 			err = ErrKeyNotFound
 		}
 		return nil, err
-	}
-
-	if m.Subject != b.String() {
-		return nil, ErrKeyNotFound
 	}
 
 	entry := &kve{

--- a/kv.go
+++ b/kv.go
@@ -42,6 +42,8 @@ type KeyValueManager interface {
 type KeyValue interface {
 	// Get returns the latest value for the key.
 	Get(key string) (entry KeyValueEntry, err error)
+	// GetRevision returns a specific revision value for the key.
+	GetRevision(key string, revision uint64) (entry KeyValueEntry, err error)
 	// Put will place the new value for the key into the store.
 	Put(key string, value []byte) (revision uint64, err error)
 	// PutString will place the string for the key into the store.
@@ -163,6 +165,7 @@ type KeyValueConfig struct {
 const (
 	KeyValueMaxHistory = 64
 	AllKeys            = ">"
+	kvLatestRevision   = 0
 	kvop               = "KV-Operation"
 	kvdel              = "DEL"
 	kvpurge            = "PURGE"
@@ -369,7 +372,7 @@ func keyValid(key string) bool {
 
 // Get returns the latest value for the key.
 func (kv *kvs) Get(key string) (KeyValueEntry, error) {
-	e, err := kv.get(key)
+	e, err := kv.get(key, kvLatestRevision)
 	if err == ErrKeyDeleted {
 		return nil, ErrKeyNotFound
 	}
@@ -380,7 +383,20 @@ func (kv *kvs) Get(key string) (KeyValueEntry, error) {
 	return e, nil
 }
 
-func (kv *kvs) get(key string) (KeyValueEntry, error) {
+// GetRevision returns a specific revision value for the key.
+func (kv *kvs) GetRevision(key string, revision uint64) (KeyValueEntry, error) {
+	e, err := kv.get(key, revision)
+	if err == ErrKeyDeleted {
+		return nil, ErrKeyNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return e, nil
+}
+
+func (kv *kvs) get(key string, revision uint64) (KeyValueEntry, error) {
 	if !keyValid(key) {
 		return nil, ErrInvalidKey
 	}
@@ -389,12 +405,23 @@ func (kv *kvs) get(key string) (KeyValueEntry, error) {
 	b.WriteString(kv.pre)
 	b.WriteString(key)
 
-	m, err := kv.js.GetLastMsg(kv.stream, b.String())
+	var m *RawStreamMsg
+	var err error
+	if revision == kvLatestRevision {
+		m, err = kv.js.GetLastMsg(kv.stream, b.String())
+	} else {
+		m, err = kv.js.GetMsg(kv.stream, revision)
+	}
+
 	if err != nil {
 		if err == ErrMsgNotFound {
 			err = ErrKeyNotFound
 		}
 		return nil, err
+	}
+
+	if m.Subject != b.String() {
+		return nil, ErrKeyNotFound
 	}
 
 	entry := &kve{
@@ -415,7 +442,6 @@ func (kv *kvs) get(key string) (KeyValueEntry, error) {
 			entry.op = KeyValuePurge
 			return entry, ErrKeyDeleted
 		}
-
 	}
 
 	return entry, nil
@@ -452,7 +478,7 @@ func (kv *kvs) Create(key string, value []byte) (revision uint64, err error) {
 
 	// TODO(dlc) - Since we have tombstones for DEL ops for watchers, this could be from that
 	// so we need to double check.
-	if e, err := kv.get(key); err == ErrKeyDeleted {
+	if e, err := kv.get(key, kvLatestRevision); err == ErrKeyDeleted {
 		return kv.Update(key, value, e.Revision())
 	}
 


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>

Add `GetRevision` to allow retrieval of historical key value versions by revision number