### PR TITLE
Expose nats.Context option for nats.KeyWatcher

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -93,8 +93,8 @@ type KeyValueStatus interface {
 
 // KeyWatcher is what is returned when doing a watch.
 type KeyWatcher interface {
-	// GetContext returns watcher context optionally provided by nats.Context option.
-	GetContext() context.Context
+	// Context returns watcher context optionally provided by nats.Context option.
+	Context() context.Context
 	// Updates returns a channel to read any updates to entries.
 	Updates() <-chan KeyValueEntry
 	// Stop will stop this watcher.
@@ -630,8 +630,8 @@ type watcher struct {
 	ctx         context.Context
 }
 
-// GetContext returns the context for the watcher if set.
-func (w *watcher) GetContext() context.Context {
+// Context returns the context for the watcher if set.
+func (w *watcher) Context() context.Context {
 	if w == nil {
 		return nil
 	}

--- a/kv.go
+++ b/kv.go
@@ -627,7 +627,7 @@ type watcher struct {
 	initDone    bool
 	initPending uint64
 	received    uint64
-	options     watchOpts
+	ctx         context.Context
 }
 
 // GetContext returns the context for the watcher if set.
@@ -635,7 +635,7 @@ func (w *watcher) GetContext() context.Context {
 	if w == nil {
 		return nil
 	}
-	return w.options.ctx
+	return w.ctx
 }
 
 // Updates returns the interior channel.
@@ -678,7 +678,7 @@ func (kv *kvs) Watch(keys string, opts ...WatchOpt) (KeyWatcher, error) {
 	keys = b.String()
 
 	// We will block below on placing items on the chan. That is by design.
-	w := &watcher{updates: make(chan KeyValueEntry, 256), options: o}
+	w := &watcher{updates: make(chan KeyValueEntry, 256), ctx: o.ctx}
 
 	update := func(m *Msg) {
 		tokens, err := getMetadataFields(m.Reply)


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>

Currently if you wish to extend the `nats.KeyValue` interface, when implementing `Watch` you have no means to get at the `nats.Context` option if it has been set on the `nats.KeyWatcher`. This PR proposes a method to the nats.KeyWatcher to access that context.

