### PR TITLE
Expose ErrNoMessages

### DIFF
--- a/context.go
+++ b/context.go
@@ -150,7 +150,7 @@ func (s *Subscription) nextMsgWithContext(ctx context.Context, pullSubInternal, 
 		// If internal and we don't want to wait, signal that there is no
 		// message in the internal queue.
 		if pullSubInternal && !waitIfNoMsg {
-			return nil, errNoMessages
+			return nil, ErrNoMessages
 		}
 	}
 

--- a/js.go
+++ b/js.go
@@ -2335,8 +2335,6 @@ func PullMaxWaiting(n int) SubOpt {
 	})
 }
 
-var errNoMessages = errors.New("nats: no messages")
-
 // Returns if the given message is a user message or not, and if
 // `checkSts` is true, returns appropriate error based on the
 // content of the status (404, etc..)
@@ -2367,7 +2365,7 @@ func checkMsg(msg *Msg, checkSts bool) (usrMsg bool, err error) {
 		err = ErrNoResponders
 	case noMessagesSts:
 		// 404 indicates that there are no messages.
-		err = errNoMessages
+		err = ErrNoMessages
 	case reqTimeoutSts:
 		// Older servers may send a 408 when a request in the server was expired
 		// and interest is still found, which will be the case for our
@@ -2479,7 +2477,7 @@ func (sub *Subscription) Fetch(batch int, opts ...PullOpt) ([]*Msg, error) {
 		// are no messages.
 		msg, err = sub.nextMsgWithContext(ctx, true, false)
 		if err != nil {
-			if err == errNoMessages {
+			if err == ErrNoMessages {
 				err = nil
 			}
 			break
@@ -2534,7 +2532,7 @@ func (sub *Subscription) Fetch(batch int, opts ...PullOpt) ([]*Msg, error) {
 				usrMsg, err = checkMsg(msg, true)
 				if err == nil && usrMsg {
 					msgs = append(msgs, msg)
-				} else if noWait && (err == errNoMessages) && len(msgs) == 0 {
+				} else if noWait && (err == ErrNoMessages) && len(msgs) == 0 {
 					// If we have a 404 for our "no_wait" request and have
 					// not collected any message, then resend request to
 					// wait this time.

--- a/nats.go
+++ b/nats.go
@@ -160,6 +160,7 @@ var (
 	ErrMsgNotFound                  = errors.New("nats: message not found")
 	ErrMsgAlreadyAckd               = errors.New("nats: message was already acknowledged")
 	ErrStreamInfoMaxSubjects        = errors.New("nats: subject details would exceed maximum allowed")
+	ErrNoMessages                   = errors.New("nats: no messages")
 )
 
 func init() {


### PR DESCRIPTION
Change: make private errNoMessagei (in js.go) into public ErrNoMessages (in nats.go)
Motivation: the JS pull consumer interface Fetch() can throw this error. But there's no way to handle it client-side if the error is not accessible