### PR TITLE
[FIXED] KV use of JS prefix

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -530,6 +530,9 @@ func (kv *kvs) Update(key string, value []byte, revision uint64) (uint64, error)
 	}
 
 	var b strings.Builder
+	if kv.useJSPfx {
+		b.WriteString(kv.js.opts.pre)
+	}
 	b.WriteString(kv.pre)
 	b.WriteString(key)
 


### PR DESCRIPTION
If the user creates a JS context with a custom prefix, this needs
to be used for the subject of the Put() and Delete() operations.
This is addressing the architecture design ADR-19.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>