### PR TITLE
[FIXED] Websocket: discovered urls would not have "wss://" scheme

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1435,7 +1435,7 @@ func (nc *Conn) setupServerPool() error {
 
 	// Check for Scheme hint to move to TLS mode.
 	for _, srv := range nc.srvPool {
-		if srv.url.Scheme == tlsScheme {
+		if srv.url.Scheme == tlsScheme || srv.url.Scheme == wsSchemeTLS {
 			// FIXME(dlc), this is for all in the pool, should be case by case.
 			nc.Opts.Secure = true
 			if nc.Opts.TLSConfig == nil {


### PR DESCRIPTION
If the user originally connects with "wss://" but has not configured
any secure related option (Options.Secure/TLSConfig), then when
adding implicit URLs (from the server INFO) the library would add
the "ws://" prefix to the received URL.
When trying to connect to those URLs, the library would not try
to make a TLS handshake and would get an error back that would
result in a "websocket invalid connection".

Resolves #914

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>