### PR TITLE
[IMPROVED] Connect error when given an invalid user creds file

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -2138,7 +2138,7 @@ func (nc *Conn) connectProto() (string, error) {
 		}
 		sigraw, err := o.SignatureCB([]byte(nc.info.Nonce))
 		if err != nil {
-			return _EMPTY_, err
+			return _EMPTY_, fmt.Errorf("error signing nonce: %v", err)
 		}
 		sig = base64.RawURLEncoding.EncodeToString(sigraw)
 	}
@@ -5237,7 +5237,7 @@ func nkeyPairFromSeedFile(seedFile string) (nkeys.KeyPair, error) {
 func sigHandler(nonce []byte, seedFile string) ([]byte, error) {
 	kp, err := nkeyPairFromSeedFile(seedFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to extract key pair from file %q: %v", seedFile, err)
 	}
 	// Wipe our key on exit.
 	defer kp.Wipe()

--- a/nats_test.go
+++ b/nats_test.go
@@ -1483,6 +1483,17 @@ func TestUserCredentialsChainedFile(t *testing.T) {
 		t.Fatalf("Expected to connect, got %v", err)
 	}
 	nc.Close()
+
+	chainedFile = createTmpFile(t, []byte("invalid content"))
+	defer os.Remove(chainedFile)
+	nc, err = Connect(url, UserCredentials(chainedFile))
+	if err == nil || !strings.Contains(err.Error(),
+		"error signing nonce: unable to extract key pair from file") {
+		if nc != nil {
+			nc.Close()
+		}
+		t.Fatalf("Expected error about invalid creds file, got %q", err)
+	}
 }
 
 func TestExpiredAuthentication(t *testing.T) {


### PR DESCRIPTION
The failure to connect would be "no nkey seed found". It will now
be more explicit:
```
error signing nonce: unable to extract key pair from file "myfile.creds": no nkey seed found
```

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>