### PR TITLE
Allow JetStream Publish retries iff ErrNoResponders was returned.

### DIFF
--- a/jsm.go
+++ b/jsm.go
@@ -587,6 +587,9 @@ func (js *js) AddStream(cfg *StreamConfig, opts ...JSOpt) (*StreamInfo, error) {
 		return nil, err
 	}
 	if resp.Error != nil {
+		if resp.Error.ErrorCode == 10058 {
+			return nil, ErrStreamNameAlreadyInUse
+		}
 		return nil, errors.New(resp.Error.Description)
 	}
 

--- a/kv_test.go
+++ b/kv_test.go
@@ -1,0 +1,69 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nats
+
+import (
+	"testing"
+)
+
+func TestKeyValueDiscardOldToDiscardNew(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, s)
+
+	nc, js := jsClient(t, s)
+	defer nc.Close()
+
+	checkDiscard := func(expected DiscardPolicy) KeyValue {
+		t.Helper()
+		kv, err := js.CreateKeyValue(&KeyValueConfig{Bucket: "TEST", History: 1})
+		if err != nil {
+			t.Fatalf("Error creating store: %v", err)
+		}
+		si, err := js.StreamInfo("KV_TEST")
+		if err != nil {
+			t.Fatalf("Error getting stream info: %v", err)
+		}
+		if si.Config.Discard != expected {
+			t.Fatalf("Expected discard policy %v, got %+v", expected, si)
+		}
+		return kv
+	}
+
+	// We are going to go from 2.7.1->2.7.2->2.7.1 and 2.7.2 again.
+	for i := 0; i < 2; i++ {
+		// Change the server version in the connection to
+		// create as-if we were connecting to a v2.7.1 server.
+		nc.mu.Lock()
+		nc.info.Version = "2.7.1"
+		nc.mu.Unlock()
+
+		kv := checkDiscard(DiscardOld)
+		if i == 0 {
+			if _, err := kv.PutString("foo", "value"); err != nil {
+				t.Fatalf("Error adding key: %v", err)
+			}
+		}
+
+		// Now change version to 2.7.2
+		nc.mu.Lock()
+		nc.info.Version = "2.7.2"
+		nc.mu.Unlock()
+
+		kv = checkDiscard(DiscardNew)
+		// Make sure the key still exists
+		if e, err := kv.Get("foo"); err != nil || string(e.Value()) != "value" {
+			t.Fatalf("Error getting key: err=%v e=%+v", err, e)
+		}
+	}
+}

--- a/nats.go
+++ b/nats.go
@@ -160,6 +160,7 @@ var (
 	ErrMsgNotFound                  = errors.New("nats: message not found")
 	ErrMsgAlreadyAckd               = errors.New("nats: message was already acknowledged")
 	ErrStreamInfoMaxSubjects        = errors.New("nats: subject details would exceed maximum allowed")
+	ErrStreamNameAlreadyInUse       = errors.New("nats: stream name already in use")
 )
 
 func init() {

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	mrand "math/rand"
 	"net"
 	"os"
 	"reflect"
@@ -6264,5 +6265,82 @@ func TestJetStreamSubscribeContextCancel(t *testing.T) {
 			}
 			return fmt.Errorf("Consumer still active, got: %v (info=%+v)", err, info)
 		})
+	})
+}
+
+func TestJetStreamClusterStreamLeaderChangeClientErr(t *testing.T) {
+	cfg := &nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	}
+
+	withJSClusterAndStream(t, "R3S", 3, cfg, func(t *testing.T, stream string, servers ...*jsServer) {
+		// We want to make sure the worse thing seen by the lower levels during a leadership change is NoResponders.
+		// We will have three concurrent contexts going on.
+		// 1. Leadership Changes every second.
+		// 2. Publishing messages to the stream every 10ms.
+		// 3. StreamInfo calls every 15ms.
+		expires := time.Now().Add(5 * time.Second)
+		var wg sync.WaitGroup
+		wg.Add(3)
+
+		randServer := func() *server.Server {
+			return servers[mrand.Intn(len(servers))].Server
+		}
+
+		// Leadership changes.
+		go func() {
+			defer wg.Done()
+			nc, js := jsClient(t, randServer())
+			defer nc.Close()
+
+			sds := fmt.Sprintf(server.JSApiStreamLeaderStepDownT, "TEST")
+			for time.Now().Before(expires) {
+				time.Sleep(1 * time.Second)
+				si, err := js.StreamInfo("TEST")
+				expectOk(t, err)
+				_, err = nc.Request(sds, nil, time.Second)
+				expectOk(t, err)
+
+				// Wait on new leader.
+				checkFor(t, time.Second, 10*time.Millisecond, func() error {
+					si, err = js.StreamInfo("TEST")
+					expectOk(t, err)
+					if si.Cluster.Leader == "" {
+						return fmt.Errorf("No leader yet")
+					}
+					return nil
+				})
+			}
+		}()
+
+		// Published every 10ms
+		go func() {
+			defer wg.Done()
+			nc, js := jsClient(t, randServer())
+			defer nc.Close()
+
+			for time.Now().Before(expires) {
+				time.Sleep(10 * time.Millisecond)
+				_, err := js.Publish("foo", []byte("OK"))
+				expectOk(t, err)
+			}
+		}()
+
+		// StreamInfo calls.
+		go func() {
+			defer wg.Done()
+			nc, js := jsClient(t, randServer())
+			defer nc.Close()
+
+			for time.Now().Before(expires) {
+				time.Sleep(15 * time.Millisecond)
+				_, err := js.StreamInfo("TEST")
+				expectOk(t, err)
+			}
+		}()
+
+		wg.Wait()
 	})
 }


### PR DESCRIPTION
This is to avoid small blips from leader changes surfacing to the end application.

Signed-off-by: Derek Collison <derek@nats.io>