### PR TITLE
Add `nats: ` prefix to stream info errors to match consumer info

### DIFF
--- a/jsm.go
+++ b/jsm.go
@@ -624,7 +624,7 @@ func (js *js) StreamInfo(stream string, opts ...JSOpt) (*StreamInfo, error) {
 		if resp.Error.Code == 404 {
 			return nil, ErrStreamNotFound
 		}
-		return nil, errors.New(resp.Error.Description)
+		return nil, fmt.Errorf("nats: %s", resp.Error.Description)
 	}
 
 	return resp.StreamInfo, nil


### PR DESCRIPTION
Make same as consumer by adding prefix.

Signed-off-by: Derek Collison <derek@nats.io>