### PR TITLE
Fix race with async INFO and header APIs

### DIFF
--- a/context.go
+++ b/context.go
@@ -21,20 +21,13 @@ import (
 // RequestMsgWithContext takes a context, a subject and payload
 // in bytes and request expecting a single response.
 func (nc *Conn) RequestMsgWithContext(ctx context.Context, msg *Msg) (*Msg, error) {
-	var hdr []byte
-	var err error
-
-	if len(msg.Header) > 0 {
-		if !nc.info.Headers {
-			return nil, ErrHeadersNotSupported
-		}
-
-		hdr, err = msg.headerBytes()
-		if err != nil {
-			return nil, err
-		}
+	if msg == nil {
+		return nil, ErrInvalidMsg
 	}
-
+	hdr, err := msg.headerBytes()
+	if err != nil {
+		return nil, err
+	}
 	return nc.requestWithContext(ctx, msg.Subject, hdr, msg.Data)
 }
 


### PR DESCRIPTION
`RequestMsg` and `PublishMsg` were not checking for headers support under the lock so there was a race condition with async INFO protocols.

Signed-off-by: Waldemar Quevedo <wally@nats.io>