### PR TITLE
Add a MaxBytes configuration option to the Object Store

### DIFF
--- a/object.go
+++ b/object.go
@@ -136,6 +136,7 @@ type ObjectStoreConfig struct {
 	Bucket      string
 	Description string
 	TTL         time.Duration
+	MaxBytes    int64
 	Storage     StorageType
 	Replicas    int
 	Placement   *Placement
@@ -244,6 +245,7 @@ func (js *js) CreateObjectStore(cfg *ObjectStoreConfig) (ObjectStore, error) {
 		Description: cfg.Description,
 		Subjects:    []string{chunks, meta},
 		MaxAge:      cfg.TTL,
+		MaxBytes:    cfg.MaxBytes,
 		Storage:     cfg.Storage,
 		Replicas:    cfg.Replicas,
 		Placement:   cfg.Placement,

--- a/test/object_test.go
+++ b/test/object_test.go
@@ -588,3 +588,22 @@ func TestObjectList(t *testing.T) {
 		t.Fatalf("Expected %+v but got %+v", expected, omap)
 	}
 }
+
+func TestObjectMaxBytes(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, s)
+
+	nc, js := jsClient(t, s)
+	defer nc.Close()
+
+	obs, err := js.CreateObjectStore(&nats.ObjectStoreConfig{Bucket: "OBJS", MaxBytes: 1024})
+	expectOk(t, err)
+
+	status, err := obs.Status()
+	expectOk(t, err)
+	bs := status.(*nats.ObjectBucketStatus)
+	info := bs.StreamInfo()
+	if info.Config.MaxBytes != 1024 {
+		t.Fatalf("invalid object stream MaxSize %+v", info.Config.MaxBytes)
+	}
+}


### PR DESCRIPTION
Add a MaxBytes configuration option to the object store API.

Signed-off-by: Colin Sullivan <colin@synadia.com>