### PR TITLE
spelling fix & dictionary updates

### DIFF
--- a/.words
+++ b/.words
@@ -1,26 +1,9 @@
 1
-## ^^^ size estimate, just needs to be non-zero
-##
-## The .words file is used by gospel (v1.2+), which wraps the Hunspell libraries but populates the dictionary with identifiers from the Go source.
-## <https://github.com/kortschak/gospel>
-##
-## Comment lines are not actually parsed as comments, try to be careful ... but in practice they seem to work?
-##
-## We assume en_US hunspell dictionaries are installed and used.  The /AFFIXRULES are defined in en_US.aff (eg: /usr/share/hunspell/en_US.aff)
-##
-## words which are in the base dictionary can't have extra affix rules added to them, so we have to start with the affixed variant we want to add.
-##   thus creds rather than cred/S and so on
-## So we can't use receive/DRSZGBU, adding 'U', to allow unreceive and variants, we have to use unreceive as the stem.
-## We can't define our own affix or compound rules, to capture rfc\d{3,} or 0x[0-9A-Fa-f]{2}
 
-## People involved who are referenced in todo/fixmes
 derek
 dlc
 ivan
 
-## Legitimate spellings in non-US English dialects;
-## regular-if-rarer words just missing from the dictionary;
-## variants of words not covered by hunspell en_US rules.
 acknowledgement/SM
 arity
 deduplication/S
@@ -31,30 +14,11 @@ observable/S
 redelivery/S
 retransmitting
 retry/SB
-unmarshal/SDG
 
-# I think that retry, being added as a symbol, is precluding the re-addition here with affix rules,
-# so "retry/SB" above is ignored
-retries
-retryable
-
-## Things gospel doesn't pick up, but doesn't yet; I've filed <https://github.com/kortschak/gospel/issues/9>
-## Eg, plurals of non-collection types, or wire-format encodings in a struct field's tag
-AsyncSubscriptions
-ChanSubscriptions
-PubAckFutures
-SubOpts
-SyncSubscriptions
-no_wait
-
-## Conceptual nouns not actually in the source, describing state
 SlowConsumer
 
-## Symbols from elsewhere referred to in comments but not referenced in the code, so not currently surfaced by gospel as acceptable
 AppendInt
 ReadMIMEHeader
-
-## The rest
 
 clientProtoZero
 jetstream
@@ -83,8 +47,6 @@ tm
 todo
 unsub/S
 
-## The spelling tokenizer doesn't take "permessage-deflate" as allowing for ... "permessage-deflate",
-## which is an RFC7692 registered extension.  We have to explicitly list "permessage".
 permessage
 permessage-deflate
 urlA

--- a/.words.readme
+++ b/.words.readme
@@ -1,0 +1,25 @@
+The .words file is used by gospel (v1.2+), which wraps the Hunspell libraries
+but populates the dictionary with identifiers from the Go source.
+
+<https://github.com/kortschak/gospel>
+
+Alas, no comments are allowed in the .words file and newer versions of gospel
+error out on seeing them.  This is really a hunspell restriction.
+
+We assume en_US hunspell dictionaries are installed and used.
+The /AFFIXRULES are defined in en_US.aff (eg: /usr/share/hunspell/en_US.aff)
+Invoke `hunspell -D` to see the actual locations.
+
+Words which are in the base dictionary can't have extra affix rules added to
+them, so we have to start with the affixed variant we want to add.
+Thus `creds` rather than `cred/S` and so on.
+
+So we can't use receive/DRSZGBU, adding 'U', to allow unreceive and variants,
+we have to use unreceive as the stem.
+
+We can't define our own affix or compound rules,
+to capture rfc\d{3,} or 0x[0-9A-Fa-f]{2}
+
+The spelling tokenizer doesn't take "permessage-deflate" as allowing for ...
+"permessage-deflate", which is an RFC7692 registered extension for websockets.
+We have to explicitly list "permessage".

--- a/js.go
+++ b/js.go
@@ -851,7 +851,7 @@ func RetryWait(dur time.Duration) PubOpt {
 	})
 }
 
-// RetryAttempts sets the retry number of attemopts when ErrNoResponders is encountered.
+// RetryAttempts sets the retry number of attempts when ErrNoResponders is encountered.
 func RetryAttempts(num int) PubOpt {
 	return pubOptFn(func(opts *pubOpts) error {
 		opts.rnum = num


### PR DESCRIPTION
Fix a spelling mistake which made it through to go docs.

gospel 1.13.0 is now out, and it added features which let us remove some old words (eg, pluralizations of types we define), but it also errored out on seeing a comment in .words which used to be acceptable.  So remove comments from .words and introduce .words.readme instead.

We lose the section-introducer comments.  Which is a shame.
