### PR TITLE
ADDED: Example usages of JetStream and KeyValue APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ _testmain.go
 
 # Goland
 .idea
+
+# VS Code
+.vscode

--- a/examples/jetstream/consumers/main.go
+++ b/examples/jetstream/consumers/main.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+/*
+This example shows implementation of consumers management.
+`js-consumer-management` command can be used to create, update or get information about a consumer.
+`-push-target` option can be used to configure a delivery subject for a push-based consumer. If not provided, the consumer will be created in push mode.
+`-filter` option can be used to filter subjects from the stream.
+`-queue` option can be used to create a queue consumer.
+
+Example usage:
+./js-consumer-management -creds '/path/to/nats/credentials' -s 'nats://127.0.0.1:4222' -push-target=ORDERS_RECV add ORDERS ORDERS_CONSUMER
+*/
+
+func usage() {
+	log.Printf("Usage: js-consumer-management [-s server] [-creds file] [-nkey file] [-tlscert file] [-tlskey file] [-tlscacert file] [-push-target subject] [-filter subject] [-queue queue] <operation> [ add | delete | info ] <stream> <name>\n")
+	flag.PrintDefaults()
+}
+
+func showUsageAndExit(exitcode int) {
+	usage()
+	os.Exit(exitcode)
+}
+
+func main() {
+
+	// CLI flags
+	var (
+		urls          = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+		userCreds     = flag.String("creds", "", "User Credentials File")
+		nkeyFile      = flag.String("nkey", "", "NKey Seed File")
+		tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+		tlsClientKey  = flag.String("tlskey", "", "Private key file for client certificate")
+		tlsCACert     = flag.String("tlscacert", "", "CA certificate to verify peer against")
+		pushTarget    = flag.String("push-target", "", "Deliverty subject for push-based consumer")
+		filter        = flag.String("filter", "", "FilterSubject for a consumer")
+		queue         = flag.String("queue", "", "Delivery target group for a consumer")
+		showHelp      = flag.Bool("h", false, "Show help message")
+	)
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	if *showHelp {
+		showUsageAndExit(0)
+	}
+
+	args := flag.Args()
+	if len(args) != 3 {
+		showUsageAndExit(1)
+	}
+
+	// Connect Options.
+	opts := []nats.Option{nats.Name("JetStream Sample Stream Management")}
+
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
+	// Use UserCredentials
+	if *userCreds != "" {
+		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
+	}
+
+	// Connect to NATS
+	nc, err := nats.Connect(*urls, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	// Retrieve JetStream connections
+	js, err := nc.JetStream()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	operation, streamName, consumerName := args[0], args[1], args[2]
+
+	switch operation {
+	case "add":
+		// create new stream if it does not exist
+		if err := setupStream(js, streamName); err != nil {
+			log.Fatal(err)
+		}
+
+		// Create a new durable consumer
+		// If DeliverSubject is not empty, consumer will be created in 'push' mode
+		// Otherwise, a 'pull' consumer will be created
+		_, err = js.AddConsumer(streamName, &nats.ConsumerConfig{
+			Durable:        consumerName,
+			DeliverSubject: *pushTarget,
+			AckPolicy:      nats.AckExplicitPolicy,
+			FilterSubject:  *filter,
+			DeliverGroup:   *queue,
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		if *pushTarget != "" {
+			log.Printf("Created push consumer '%s' on stream '%s'\nDelivery subject: %s", consumerName, streamName, *pushTarget)
+			break
+		}
+		log.Printf("Created pull consumer '%s' on stream '%s'\n", consumerName, streamName)
+	case "delete":
+		// Remove an existing consumer. If consumer does not exist, a 'consumer not found' error will be returned
+		err = js.DeleteConsumer(streamName, consumerName)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("Removed consumer '%s'\n", consumerName)
+	case "info":
+		// Get an existing consumer
+		cons, err := js.ConsumerInfo(streamName, consumerName)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("Fetched consumer '%s' from stream '%s'", consumerName, streamName)
+		log.Printf("Created on '%s'", cons.Created.Format(time.RFC3339))
+		log.Printf("Deliver Subject: %s", cons.Config.DeliverSubject)
+		log.Printf("Ack Policy: %s", cons.Config.AckPolicy)
+		log.Printf("Filter subject: %s", cons.Config.FilterSubject)
+		log.Printf("Queue group: %s", cons.Config.DeliverGroup)
+	default:
+		log.Fatalf("Operation not supported: %s\nAvailable options: %s", operation, "add, delete, info")
+	}
+}
+
+func setupStream(js nats.JetStreamContext, stream string) error {
+	_, err := js.StreamInfo(stream)
+	if err != nil && !errors.Is(err, nats.ErrStreamNotFound) {
+		return err
+	}
+	if err == nil {
+		log.Printf("Using existing stream: %s\n", stream)
+		return nil
+	}
+	log.Printf("Stream '%s' not found. New stream will be created.\n", stream)
+	subs := []string{fmt.Sprintf("%s.*", stream)}
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     stream,
+		Subjects: subs,
+		MaxBytes: 256 << 20,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Created stream '%s'\nConsumed subjects: %s\n", stream, strings.Join(subs, ", "))
+	return nil
+}

--- a/examples/jetstream/consumers/main.go
+++ b/examples/jetstream/consumers/main.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/jetstream/consumers/main.go
+++ b/examples/jetstream/consumers/main.go
@@ -28,9 +28,9 @@ import (
 /*
 This example shows implementation of consumers management.
 `js-consumer-management` command can be used to create, update or get information about a consumer.
-`-push-target` option can be used to configure a delivery subject for a push-based consumer. If not provided, the consumer will be created in push mode.
+`-push-target` option can be used to configure a delivery subject for a push-based consumer. If not provided, the consumer will be created in pull mode.
 `-filter` option can be used to filter subjects from the stream.
-`-queue` option can be used to create a queue consumer.
+`-queue` option can be used to create a queue consumer. If used, `-push-target` should be provided as well (DeliverGroup is only relevant for push consumers).
 
 Example usage:
 ./js-consumer-management -creds '/path/to/nats/credentials' -s 'nats://127.0.0.1:4222' -push-target=ORDERS_RECV add ORDERS ORDERS_CONSUMER
@@ -56,9 +56,9 @@ func main() {
 		tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
 		tlsClientKey  = flag.String("tlskey", "", "Private key file for client certificate")
 		tlsCACert     = flag.String("tlscacert", "", "CA certificate to verify peer against")
-		pushTarget    = flag.String("push-target", "", "Deliverty subject for push-based consumer")
+		pushTarget    = flag.String("push-target", "", "Delivery subject for push-based consumer")
 		filter        = flag.String("filter", "", "FilterSubject for a consumer")
-		queue         = flag.String("queue", "", "Delivery target group for a consumer")
+		queue         = flag.String("queue", "", "Delivery target group for a consumer. Only applicable on push consumers (-push-target has to be provided)")
 		showHelp      = flag.Bool("h", false, "Show help message")
 	)
 
@@ -76,7 +76,7 @@ func main() {
 	}
 
 	// Connect Options.
-	opts := []nats.Option{nats.Name("JetStream Sample Stream Management")}
+	opts := []nats.Option{nats.Name("JetStream Consumer Management")}
 
 	if *userCreds != "" && *nkeyFile != "" {
 		log.Fatal("specify -seed or -creds")

--- a/examples/jetstream/pub-async/main.go
+++ b/examples/jetstream/pub-async/main.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"log"
+	"os"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+/*
+This example showcases implementation of asynchronous publish on a stream.
+`js-pub-async` command can be used to publish a message on a given subject.
+If a given stream does not exist, a new stream will be created.
+
+Example usage:
+./js-pub-async -creds '/path/to/nats/credentials' -s 'nats://127.0.0.1:4222' ORDERS ORDERS.created 'new order'
+*/
+
+func usage() {
+	log.Printf("Usage: js-pub-async [-s server] [-creds file] [-nkey file] [-tlscert file] [-tlskey file] [-tlscacert file] <stream> <subject> <message>\n")
+	flag.PrintDefaults()
+}
+
+func showUsageAndExit(exitcode int) {
+	usage()
+	os.Exit(exitcode)
+}
+
+func main() {
+
+	// CLI flags
+	var (
+		urls          = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+		userCreds     = flag.String("creds", "", "User Credentials File")
+		nkeyFile      = flag.String("nkey", "", "NKey Seed File")
+		tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+		tlsClientKey  = flag.String("tlskey", "", "Private key file for client certificate")
+		tlsCACert     = flag.String("tlscacert", "", "CA certificate to verify peer against")
+		showHelp      = flag.Bool("h", false, "Show help message")
+	)
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	if *showHelp {
+		showUsageAndExit(0)
+	}
+
+	args := flag.Args()
+	if len(args) != 3 {
+		showUsageAndExit(1)
+	}
+
+	// Connect Options.
+	opts := []nats.Option{nats.Name("JetStream Sample Async Publisher")}
+
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
+	// Use UserCredentials
+	if *userCreds != "" {
+		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
+	}
+
+	// Connect to NATS
+	nc, err := nats.Connect(*urls, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	// Retrieve JetStream connections
+	js, err := nc.JetStream()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	streamName, subject, message := args[0], args[1], []byte(args[2])
+
+	// Create default stream if it does not exist
+	if err := setupStream(js, streamName, subject); err != nil {
+		log.Fatal(err)
+	}
+
+	// Publishes a message on subject. Subject has to be assigned to an existing stream
+	ackFuture, err := js.PublishAsync(subject, []byte(message))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	// Wait for message to be delivered, or error is returned
+	select {
+	case ack := <-ackFuture.Ok():
+		log.Printf("Published message: '%s'\n", message)
+		log.Printf("Subject: %s\n", subject)
+		log.Printf("Stream: %s\n", ack.Stream)
+		log.Printf("Message sequence number: %d\n", ack.Sequence)
+	case err = <-ackFuture.Err():
+		log.Fatalf("error publishing message: %s", err.Error())
+	case <-ctx.Done():
+		log.Fatal("unable to finish in time")
+	}
+}
+
+func setupStream(js nats.JetStreamContext, stream, subject string) error {
+	_, err := js.StreamInfo(stream)
+	if err != nil && !errors.Is(err, nats.ErrStreamNotFound) {
+		return err
+	}
+	if err == nil {
+		log.Printf("Using existing stream: %s\n", stream)
+		return nil
+	}
+	log.Printf("Stream '%s' not found. New stream will be created.\n", stream)
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     stream,
+		Subjects: []string{subject},
+		MaxBytes: 256 << 20,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Created stream '%s'\nConsumed subjects: %s\n", stream, subject)
+	return nil
+}

--- a/examples/jetstream/pub-async/main.go
+++ b/examples/jetstream/pub-async/main.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/jetstream/pub-sync/main.go
+++ b/examples/jetstream/pub-sync/main.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"log"
+	"os"
+
+	"github.com/nats-io/nats.go"
+)
+
+/*
+This example showcases implementation of synchronous publish on a stream.
+`js-pub-sync` command can be used to publish a message on a given subject.
+If a given stream does not exist, a new stream will be created.
+
+Example usage:
+./js-pub-sync -creds '/path/to/nats/credentials' -s 'nats://127.0.0.1:4222' ORDERS ORDERS.created 'new order'
+*/
+
+func usage() {
+	log.Printf("Usage: js-pub-sync [-s server] [-creds file] [-nkey file] [-tlscert file] [-tlskey file] [-tlscacert file] <stream> <subject> <message>\n")
+	flag.PrintDefaults()
+}
+
+func showUsageAndExit(exitcode int) {
+	usage()
+	os.Exit(exitcode)
+}
+
+func main() {
+
+	// CLI flags
+	var (
+		urls          = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+		userCreds     = flag.String("creds", "", "User Credentials File")
+		nkeyFile      = flag.String("nkey", "", "NKey Seed File")
+		tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+		tlsClientKey  = flag.String("tlskey", "", "Private key file for client certificate")
+		tlsCACert     = flag.String("tlscacert", "", "CA certificate to verify peer against")
+		showHelp      = flag.Bool("h", false, "Show help message")
+	)
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	if *showHelp {
+		showUsageAndExit(0)
+	}
+
+	args := flag.Args()
+	if len(args) != 3 {
+		showUsageAndExit(1)
+	}
+
+	// Connect Options.
+	opts := []nats.Option{nats.Name("JetStream Sample Sync Publisher")}
+
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
+	// Use UserCredentials
+	if *userCreds != "" {
+		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
+	}
+
+	// Connect to NATS
+	nc, err := nats.Connect(*urls, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	// Retrieve JetStream connections
+	js, err := nc.JetStream()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	streamName, subject, message := args[0], args[1], []byte(args[2])
+
+	// Create default stream if it does not exist
+	if err := setupStream(js, streamName, subject); err != nil {
+		log.Fatal(err)
+	}
+
+	// Publishes a message on subject. Subject has to be assigned to an existing stream
+	ack, err := js.Publish(subject, []byte(message))
+	if err != nil {
+		if lerr := nc.LastError(); lerr != nil {
+			log.Fatal(lerr)
+		}
+		log.Fatal(err)
+	}
+
+	log.Printf("Published message: '%s'\n", message)
+	log.Printf("Subject: %s\n", subject)
+	log.Printf("Stream: %s\n", ack.Stream)
+	log.Printf("Message sequence number: %d\n", ack.Sequence)
+}
+
+func setupStream(js nats.JetStreamContext, stream, subject string) error {
+	_, err := js.StreamInfo(stream)
+	if err != nil && !errors.Is(err, nats.ErrStreamNotFound) {
+		return err
+	}
+	if err == nil {
+		log.Printf("Using existing stream: %s\n", stream)
+		return nil
+	}
+	log.Printf("Stream '%s' not found. New stream will be created.\n", stream)
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     stream,
+		Subjects: []string{subject},
+		MaxBytes: 256 << 20,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Created stream '%s'\nConsumed subjects: %s\n", stream, subject)
+	return nil
+}

--- a/examples/jetstream/pub-sync/main.go
+++ b/examples/jetstream/pub-sync/main.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/jetstream/streams/main.go
+++ b/examples/jetstream/streams/main.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/jetstream/streams/main.go
+++ b/examples/jetstream/streams/main.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/nats-io/nats.go"
+)
+
+/*
+This example shows implementation of stream management.
+`js-stream` command can be used to create, update and delete a stream.
+The `subjects` option can be used to supply the stream with a list of comma-separated subjects to be consumed by the stream
+
+Example usage:
+./js-stream -creds '/path/to/nats/credentials' -s 'nats://127.0.0.1:4222' -subjects 'ORDERS.*' add 'ORDERS'
+*/
+
+func usage() {
+	log.Printf("Usage: js-stream [-s server] [-creds file] [-nkey file] [-tlscert file] [-tlskey file] [-tlscacert file] [-subjects subjects] <operation> [ add | update | delete ] <name>\n")
+	flag.PrintDefaults()
+}
+
+func showUsageAndExit(exitcode int) {
+	usage()
+	os.Exit(exitcode)
+}
+
+func main() {
+
+	// CLI flags
+	var (
+		urls          = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+		userCreds     = flag.String("creds", "", "User Credentials File")
+		nkeyFile      = flag.String("nkey", "", "NKey Seed File")
+		tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+		tlsClientKey  = flag.String("tlskey", "", "Private key file for client certificate")
+		tlsCACert     = flag.String("tlscacert", "", "CA certificate to verify peer against")
+		subjects      = flag.String("subjects", "foo", "A list of comma-separated subjects consumed by the stream")
+		showHelp      = flag.Bool("h", false, "Show help message")
+	)
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	if *showHelp {
+		showUsageAndExit(0)
+	}
+
+	args := flag.Args()
+	if len(args) != 2 {
+		showUsageAndExit(1)
+	}
+
+	// Connect Options.
+	opts := []nats.Option{nats.Name("JetStream Sample Stream Management")}
+
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
+	// Use UserCredentials
+	if *userCreds != "" {
+		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
+	}
+
+	// Connect to NATS
+	nc, err := nats.Connect(*urls, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	// Retrieve JetStream connections
+	js, err := nc.JetStream()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	*subjects = strings.ReplaceAll(*subjects, " ", "")
+	subs := strings.Split(*subjects, ",")
+	operation, streamName := args[0], args[1]
+
+	switch operation {
+	case "add":
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:     streamName,
+			Subjects: subs,
+			MaxBytes: 256 << 20,
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("Created stream '%s'\nConsumed subjects: %s", streamName, strings.Join(subs, ", "))
+	case "update":
+		_, err = js.UpdateStream(&nats.StreamConfig{
+			Name:     streamName,
+			Subjects: subs,
+			MaxBytes: 256 << 20,
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("Updated stream '%s'\nConsumed subjects: %s", streamName, strings.Join(subs, ", "))
+	case "delete":
+		err = js.DeleteStream(streamName)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("Removed stream '%s'", streamName)
+	default:
+		log.Fatalf("Operation not supported: %s\nAvailable options: %s", operation, "add, update, delete")
+	}
+}

--- a/examples/jetstream/sub-chan/main.go
+++ b/examples/jetstream/sub-chan/main.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+/*
+This example showcases the implementation of a push-based subscription using a channel.
+After running the `js-sub-chan` command, a new subscription to a given subject will be created
+If `-consumer` option was not provided, an ephemeral consumer will be created. Otherwise, an existing durable consumer will be used.
+To test it out, run `js-sub` using `-pub-sample` option - the message will be published to a given subject and will be consumed in the subscription.
+
+Example usage:
+./js-sub-chan -creds '/path/to/nats/credentials' -s 'nats://127.0.0.1:4222' -pub-sample 'some message' 'ORDERS' 'ORDERS.*'
+*/
+
+func usage() {
+	log.Printf("Usage: js-sub-chan [-s server] [-creds file] [-nkey file] [-tlscert file] [-tlskey file] [-tlscacert file] [-consumer name] [-pub-sample message] <stream> <subject>\n")
+	flag.PrintDefaults()
+}
+
+func showUsageAndExit(exitcode int) {
+	usage()
+	os.Exit(exitcode)
+}
+
+func main() {
+
+	// CLI flags
+	var (
+		urls          = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+		userCreds     = flag.String("creds", "", "User Credentials File")
+		nkeyFile      = flag.String("nkey", "", "NKey Seed File")
+		tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+		tlsClientKey  = flag.String("tlskey", "", "Private key file for client certificate")
+		tlsCACert     = flag.String("tlscacert", "", "CA certificate to verify peer against")
+		consumerName  = flag.String("consumer", "", "Name of the durable consumer. If empty, ephemenral consumer will be used")
+		showHelp      = flag.Bool("h", false, "Show help message")
+		sampleMessage = flag.String("pub-sample", "", "Sample message to be published on given subject")
+	)
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	if *showHelp {
+		showUsageAndExit(0)
+	}
+
+	args := flag.Args()
+	if len(args) != 2 {
+		showUsageAndExit(1)
+	}
+
+	// Connect Options.
+	opts := []nats.Option{nats.Name("JetStream Sample Channel Subscriber")}
+	opts = setupConnOptions(opts)
+
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
+	// Use UserCredentials
+	if *userCreds != "" {
+		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
+	}
+
+	// Connect to NATS
+	nc, err := nats.Connect(*urls, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Retrieve JetStream connection
+	js, err := nc.JetStream()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	streamName, subject := args[0], args[1]
+	// Create default stream if it does not exist
+	if err := setupStream(js, streamName, subject); err != nil {
+		log.Fatal(err)
+	}
+	if *sampleMessage != "" {
+		publishMessage(js, subject, *sampleMessage)
+	}
+	msgs := make(chan *nats.Msg, 64)
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	// If consumer name was not provided, create subscription with ephemeral consumer
+	if *consumerName == "" {
+		log.Print("No consumer name provided. Creating Ephemeral consumer.")
+		sub, err := js.ChanSubscribe(subject, msgs, nats.BindStream(streamName))
+		go func() {
+			for m := range msgs {
+				log.Printf("Received message on [%s]: %s\n", m.Subject, m.Data)
+				// When using ephememeral consumer, and  the default AckPolicy is set to 'AckPolicyExplicit',
+				// so the message has to be acknowledged manually
+				if err := m.Ack(); err != nil {
+					log.Fatal(err)
+				}
+			}
+		}()
+		if err != nil {
+			log.Fatal(err)
+		}
+		<-c
+		if err := sub.Unsubscribe(); err != nil {
+			log.Fatal(err)
+		}
+		log.Fatal("Exiting")
+	}
+
+	// Else, create subscription by connecting to an existing durable consumer
+	// In case durable consumer is used, 'subject' argument must match the consumer's Delivery Subject
+	log.Printf("Using existing durable consumer: %s", *consumerName)
+	sub, err := js.ChanSubscribe(subject, msgs, nats.Bind(streamName, *consumerName))
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Retrieve consumer info to verify whether acknowledgement is needed
+	consumerInfo, err := sub.ConsumerInfo()
+	if err != nil {
+		log.Fatal(err)
+	}
+	go func() {
+		for m := range msgs {
+			log.Printf("Received message on [%s]: %s\n", m.Subject, m.Data)
+			if consumerInfo.Config.AckPolicy == nats.AckExplicitPolicy {
+				if err := m.Ack(); err != nil {
+					log.Fatal(err)
+				}
+			}
+		}
+	}()
+	if err != nil {
+		log.Fatal(err)
+	}
+	<-c
+	if err := sub.Unsubscribe(); err != nil {
+		log.Fatal(err)
+	}
+	log.Fatal("Exiting")
+}
+
+func setupStream(js nats.JetStreamContext, stream, subject string) error {
+	_, err := js.StreamInfo(stream)
+	if err != nil && !errors.Is(err, nats.ErrStreamNotFound) {
+		return err
+	}
+	if err == nil {
+		log.Printf("Using existing stream: %s\n", stream)
+		return nil
+	}
+	log.Printf("Stream '%s' not found. New stream will be created.\n", stream)
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     stream,
+		Subjects: []string{subject},
+		MaxBytes: 256 << 20,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Created stream '%s'\nConsumed subjects: %s\n", stream, subject)
+	return nil
+}
+
+func setupConnOptions(opts []nats.Option) []nats.Option {
+	totalWait := 10 * time.Minute
+	reconnectDelay := time.Second
+
+	opts = append(opts, nats.ReconnectWait(reconnectDelay))
+	opts = append(opts, nats.MaxReconnects(int(totalWait/reconnectDelay)))
+	opts = append(opts, nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {
+		log.Printf("Disconnected due to:%s, will attempt reconnects for %.0fm", err, totalWait.Minutes())
+	}))
+	opts = append(opts, nats.ReconnectHandler(func(nc *nats.Conn) {
+		log.Printf("Reconnected [%s]", nc.ConnectedUrl())
+	}))
+	opts = append(opts, nats.ClosedHandler(func(nc *nats.Conn) {
+		log.Fatalf("Exiting: %v", nc.LastError())
+	}))
+	return opts
+}
+
+// Publish sample message
+func publishMessage(js nats.JetStreamContext, subject, message string) error {
+	ack, err := js.Publish(subject, []byte(message))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Published sample message: '%s'", message)
+	log.Printf("Subject: %s\n", subject)
+	log.Printf("Stream: %s\n", ack.Stream)
+	log.Printf("Message sequence number: %d\n\n", ack.Sequence)
+	return nil
+}

--- a/examples/jetstream/sub-chan/main.go
+++ b/examples/jetstream/sub-chan/main.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/jetstream/sub-pull/main.go
+++ b/examples/jetstream/sub-pull/main.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"log"
+	"os"
+
+	"github.com/nats-io/nats.go"
+)
+
+/*
+This example showcases the implementation of a pull-based subscription.
+After running the `js-pull` command, a pull subscription to a given subject will be created and the oldest unacknowledged message will be consumed.
+Multiple messages can be consumed using `-count` option. If no messages are available in a given stream, command will time out.
+If a given consumer does not exist, a default consumer will be created.
+To test it out, run `js-pull` using `-pub-sample` option - the message will be published to a given subject and will be consumed in the subscription.
+
+Example usage:
+./js-pull -creds '/path/to/nats/credentials' -s 'nats://127.0.0.1:4222' -pub-sample 'some message' 'ORDERS' 'ORDERS_CONSUMER' 'ORDERS.*'
+*/
+
+func usage() {
+	log.Printf("Usage: js-pull [-s server] [-creds file] [-nkey file] [-tlscert file] [-tlskey file] [-tlscacert file] [-count number] [-pub-sample message] <stream> <consumer> <subject>\n")
+	flag.PrintDefaults()
+}
+
+func showUsageAndExit(exitcode int) {
+	usage()
+	os.Exit(exitcode)
+}
+
+func main() {
+
+	// CLI flags
+	var (
+		urls          = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+		userCreds     = flag.String("creds", "", "User Credentials File")
+		nkeyFile      = flag.String("nkey", "", "NKey Seed File")
+		tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+		tlsClientKey  = flag.String("tlskey", "", "Private key file for client certificate")
+		tlsCACert     = flag.String("tlscacert", "", "CA certificate to verify peer against")
+		count         = flag.Int("count", 1, "Number of messages to pull")
+		showHelp      = flag.Bool("h", false, "Show help message")
+		sampleMessage = flag.String("pub-sample", "", "Sample message to be published on given subject")
+	)
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	if *showHelp {
+		showUsageAndExit(0)
+	}
+
+	args := flag.Args()
+	if len(args) != 3 {
+		showUsageAndExit(1)
+	}
+
+	// Connect Options.
+	opts := []nats.Option{nats.Name("JetStream Sample Pull Subscriber")}
+
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
+	// Use UserCredentials
+	if *userCreds != "" {
+		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
+	}
+
+	// Connect to NATS
+	nc, err := nats.Connect(*urls, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	// Retrieve JetStream connection
+	js, err := nc.JetStream()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	streamName, consumer, subject := args[0], args[1], args[2]
+	// Create default stream and publish message if stream does not exist
+	if err := setupStream(js, streamName, subject); err != nil {
+		log.Fatal(err)
+	}
+	// Create default consumer it does not exist
+	if err := setupConsumer(js, streamName, consumer); err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a subscription to pull messages
+	sub, err := js.PullSubscribe(subject, consumer, nats.MaxAckPending(1000), nats.Bind(streamName, consumer))
+	if err != nil {
+		log.Fatal(err)
+	}
+	if *sampleMessage != "" {
+		if err := publishMessage(js, subject, *sampleMessage); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	// Pull selected number of messages from the consumer. If no messages are available for a consumer, server will time out
+	msgs, err := sub.Fetch(*count)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, msg := range msgs {
+		log.Printf("Received message: %s\n", msg.Data)
+		if err := msg.AckSync(); err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("Message acknowledged\n")
+	}
+
+	if err := sub.Unsubscribe(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func setupStream(js nats.JetStreamContext, stream, subject string) error {
+	_, err := js.StreamInfo(stream)
+	if err != nil && !errors.Is(err, nats.ErrStreamNotFound) {
+		return err
+	}
+	if err == nil {
+		log.Printf("Using existing stream: %s\n", stream)
+		return nil
+	}
+	log.Printf("Stream '%s' not found. New stream will be created.\n", stream)
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     stream,
+		Subjects: []string{subject},
+		MaxBytes: 256 << 20,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Created stream '%s'\nConsumed subjects: %s\n\n", stream, subject)
+	return nil
+}
+
+func setupConsumer(js nats.JetStreamContext, stream, consumer string) error {
+	_, err := js.ConsumerInfo(stream, consumer)
+	if err != nil && !errors.Is(err, nats.ErrConsumerNotFound) {
+		return err
+	}
+	if err == nil {
+		log.Printf("Using existing consumer: %s\n", consumer)
+		return nil
+	}
+	_, err = js.AddConsumer(stream, &nats.ConsumerConfig{
+		Durable:   consumer,
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Created pull consumer '%s' on stream '%s'\n\n", consumer, stream)
+	return nil
+}
+
+// Publish sample message
+func publishMessage(js nats.JetStreamContext, subject, message string) error {
+	ack, err := js.Publish(subject, []byte(message))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Published sample message: '%s'", message)
+	log.Printf("Subject: %s\n", subject)
+	log.Printf("Stream: %s\n", ack.Stream)
+	log.Printf("Message sequence number: %d\n\n", ack.Sequence)
+	return nil
+}

--- a/examples/jetstream/sub-pull/main.go
+++ b/examples/jetstream/sub-pull/main.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/jetstream/sub-push/main.go
+++ b/examples/jetstream/sub-push/main.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/jetstream/sub-push/main.go
+++ b/examples/jetstream/sub-push/main.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+/*
+This example showcases the implementation of a push-based subscription.
+After running the `js-sub` command, a new subscription to a given subject will be created
+If `-consumer` option was not provided, an ephemeral consumer will be created. Otherwise, an existing durable consumer will be used.
+To test it out, run `js-sub` using `-pub-sample` option - the message will be published to a given subject and will be consumed in the subscription.
+
+Example usage:
+./js-sub -creds '/path/to/nats/credentials' -s 'nats://127.0.0.1:4222' -pub-sample 'some message' 'ORDERS' 'ORDERS.*'
+*/
+
+func usage() {
+	log.Printf("Usage: js-sub [-s server] [-creds file] [-nkey file] [-tlscert file] [-tlskey file] [-tlscacert file] [-consumer name] [-pub-sample message] <stream> <subject>\n")
+	flag.PrintDefaults()
+}
+
+func showUsageAndExit(exitcode int) {
+	usage()
+	os.Exit(exitcode)
+}
+
+func main() {
+
+	// CLI flags
+	var (
+		urls          = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+		userCreds     = flag.String("creds", "", "User Credentials File")
+		nkeyFile      = flag.String("nkey", "", "NKey Seed File")
+		tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+		tlsClientKey  = flag.String("tlskey", "", "Private key file for client certificate")
+		tlsCACert     = flag.String("tlscacert", "", "CA certificate to verify peer against")
+		consumerName  = flag.String("consumer", "", "Name of the durable consumer. If empty, ephemenral consumer will be used")
+		showHelp      = flag.Bool("h", false, "Show help message")
+		sampleMessage = flag.String("pub-sample", "", "Sample message to be published on given subject")
+	)
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	if *showHelp {
+		showUsageAndExit(0)
+	}
+
+	args := flag.Args()
+	if len(args) != 2 {
+		showUsageAndExit(1)
+	}
+
+	// Connect Options.
+	opts := []nats.Option{nats.Name("JetStream Sample Push Subscriber")}
+	opts = setupConnOptions(opts)
+
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
+	// Use UserCredentials
+	if *userCreds != "" {
+		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
+	}
+
+	// Connect to NATS
+	nc, err := nats.Connect(*urls, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Retrieve JetStream connection
+	js, err := nc.JetStream()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	streamName, subject := args[0], args[1]
+	// Create default stream if it does not exist
+	if err := setupStream(js, streamName, subject); err != nil {
+		log.Fatal(err)
+	}
+	if *sampleMessage != "" {
+		publishMessage(js, subject, *sampleMessage)
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	// If consumer name was not provided, create subscription with ephemeral consumer
+	if *consumerName == "" {
+		log.Print("No consumer name provided. Creating Ephemeral consumer.")
+		sub, err := js.Subscribe(subject, func(msg *nats.Msg) {
+			log.Printf("Received message on [%s]: %s\n", msg.Subject, msg.Data)
+			if err := msg.AckSync(); err != nil {
+				log.Fatal(err)
+			}
+		}, nats.BindStream(streamName))
+		if err != nil {
+			log.Fatal(err)
+		}
+		<-c
+		if err := sub.Unsubscribe(); err != nil {
+			log.Fatal(err)
+		}
+		log.Fatal("Exiting")
+	}
+
+	// Else, create subscription by connecting to an existing durable consumer
+	sub, err := js.Subscribe(subject, func(msg *nats.Msg) {
+		log.Printf("Received message on [%s]: %s\n", msg.Subject, msg.Data)
+		if err := msg.Ack(); err != nil {
+			log.Fatal(err)
+		}
+	}, nats.Bind(streamName, *consumerName))
+	if err != nil {
+		log.Fatal(err)
+	}
+	<-c
+	if err := sub.Unsubscribe(); err != nil {
+		log.Fatal(err)
+	}
+	log.Fatal("Exiting")
+}
+
+func setupConnOptions(opts []nats.Option) []nats.Option {
+	totalWait := 10 * time.Minute
+	reconnectDelay := time.Second
+
+	opts = append(opts, nats.ReconnectWait(reconnectDelay))
+	opts = append(opts, nats.MaxReconnects(int(totalWait/reconnectDelay)))
+	opts = append(opts, nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {
+		log.Printf("Disconnected due to:%s, will attempt reconnects for %.0fm", err, totalWait.Minutes())
+	}))
+	opts = append(opts, nats.ReconnectHandler(func(nc *nats.Conn) {
+		log.Printf("Reconnected [%s]", nc.ConnectedUrl())
+	}))
+	opts = append(opts, nats.ClosedHandler(func(nc *nats.Conn) {
+		log.Fatalf("Exiting: %v", nc.LastError())
+	}))
+	return opts
+}
+
+func setupStream(js nats.JetStreamContext, stream, subject string) error {
+	_, err := js.StreamInfo(stream)
+	if err != nil && !errors.Is(err, nats.ErrStreamNotFound) {
+		return err
+	}
+	if err == nil {
+		log.Printf("Using existing stream: %s\n", stream)
+		return nil
+	}
+	log.Printf("Stream '%s' not found. New stream will be created.\n", stream)
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     stream,
+		Subjects: []string{subject},
+		MaxBytes: 256 << 20,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Created stream '%s'\nConsumed subjects: %s\n", stream, subject)
+	return nil
+}
+
+// Publish sample message
+func publishMessage(js nats.JetStreamContext, subject, message string) error {
+	ack, err := js.Publish(subject, []byte(message))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Published sample message: '%s'", message)
+	log.Printf("Subject: %s\n", subject)
+	log.Printf("Stream: %s\n", ack.Stream)
+	log.Printf("Message sequence number: %d\n\n", ack.Sequence)
+	return nil
+}

--- a/examples/jetstream/sub-queue/main.go
+++ b/examples/jetstream/sub-queue/main.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/jetstream/sub-queue/main.go
+++ b/examples/jetstream/sub-queue/main.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+/*
+This example showcases the implementation of a queue subscription.
+After running the `js-queue` command, a new subscription to a given queue will be created
+If `-consumer` option was not provided, a default consumer will be created. Otherwise, an existing durable consumer will be used.
+To test it out, run `js-queue` commands in separate terminal windows and publish some messages on the given subject
+
+Example usage:
+./js-queue -creds '/path/to/nats/credentials' -s 'nats://127.0.0.1:4222' 'ORDERS' 'ORDERS.*' 'PROCESS_ORDERS'
+*/
+
+func usage() {
+	log.Printf("Usage: js-queue [-s server] [-creds file] [-nkey file] [-tlscert file] [-tlskey file] [-tlscacert file] [-consumer name] <stream> <subject> <queue>\n")
+	flag.PrintDefaults()
+}
+
+func showUsageAndExit(exitcode int) {
+	usage()
+	os.Exit(exitcode)
+}
+
+func main() {
+
+	// CLI flags
+	var (
+		urls          = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+		userCreds     = flag.String("creds", "", "User Credentials File")
+		nkeyFile      = flag.String("nkey", "", "NKey Seed File")
+		tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+		tlsClientKey  = flag.String("tlskey", "", "Private key file for client certificate")
+		tlsCACert     = flag.String("tlscacert", "", "CA certificate to verify peer against")
+		consumerName  = flag.String("consumer", "", "Name of the durable consumer. If empty, ephemenral consumer will be used")
+		showHelp      = flag.Bool("h", false, "Show help message")
+	)
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	if *showHelp {
+		showUsageAndExit(0)
+	}
+
+	args := flag.Args()
+	if len(args) != 3 {
+		showUsageAndExit(1)
+	}
+
+	// Connect Options.
+	opts := []nats.Option{nats.Name("JetStream Sample Queue Subscriber")}
+	opts = setupConnOptions(opts)
+
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
+	// Use UserCredentials
+	if *userCreds != "" {
+		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
+	}
+
+	// Connect to NATS
+	nc, err := nats.Connect(*urls, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Retrieve JetStream connection
+	js, err := nc.JetStream()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	streamName, subject, queue := args[0], args[1], args[2]
+
+	// Create default stream if it does not exist
+	if err := setupStream(js, streamName, subject); err != nil {
+		log.Fatal(err)
+	}
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+
+	// If consumer name was not provided, create subscription with default consumer
+	// NOTE: this consumer will not be removed automatically, and will have the same name as the provided queue name
+	if *consumerName == "" {
+		log.Print("No consumer name provided. Creating Ephemeral consumer.")
+		sub, err := js.QueueSubscribe(subject, queue, func(msg *nats.Msg) {
+			log.Printf("Received message on [%s]: %s\n", msg.Subject, msg.Data)
+		}, nats.BindStream(streamName))
+		if err != nil {
+			log.Fatal(err)
+		}
+		<-c
+		if err := sub.Unsubscribe(); err != nil {
+			log.Fatal(err)
+		}
+		log.Fatal("Exiting")
+	}
+
+	// Else, create queue subscription by connecting to an existing durable consumer
+	log.Printf("Using existing durable consumer: %s", *consumerName)
+	sub, err := js.QueueSubscribe(subject, queue, func(msg *nats.Msg) {
+		log.Printf("Received message on [%s]: %s\n", msg.Subject, msg.Data)
+	}, nats.Bind(streamName, *consumerName))
+	if err != nil {
+		log.Fatal(err)
+	}
+	<-c
+	if err := sub.Unsubscribe(); err != nil {
+		log.Fatal(err)
+	}
+	log.Fatal("Exiting")
+}
+
+func setupConnOptions(opts []nats.Option) []nats.Option {
+	totalWait := 10 * time.Minute
+	reconnectDelay := time.Second
+
+	opts = append(opts, nats.ReconnectWait(reconnectDelay))
+	opts = append(opts, nats.MaxReconnects(int(totalWait/reconnectDelay)))
+	opts = append(opts, nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {
+		log.Printf("Disconnected due to:%s, will attempt reconnects for %.0fm", err, totalWait.Minutes())
+	}))
+	opts = append(opts, nats.ReconnectHandler(func(nc *nats.Conn) {
+		log.Printf("Reconnected [%s]", nc.ConnectedUrl())
+	}))
+	opts = append(opts, nats.ClosedHandler(func(nc *nats.Conn) {
+		log.Fatalf("Exiting: %v", nc.LastError())
+	}))
+	return opts
+}
+
+func setupStream(js nats.JetStreamContext, stream, subject string) error {
+	_, err := js.StreamInfo(stream)
+	if err != nil && !errors.Is(err, nats.ErrStreamNotFound) {
+		return err
+	}
+	if err == nil {
+		log.Printf("Using existing stream: %s\n", stream)
+		return nil
+	}
+	log.Printf("Stream '%s' not found. New stream will be created.\n", stream)
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     stream,
+		Subjects: []string{subject},
+		MaxBytes: 256 << 20,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Created stream '%s'\nConsumed subjects: %s\n", stream, subject)
+	return nil
+}

--- a/examples/kv/delete/main.go
+++ b/examples/kv/delete/main.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/kv/delete/main.go
+++ b/examples/kv/delete/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/nats-io/nats.go"
+)
+
+/*
+This example shows implementation of JetStream KeyValue delete operation.
+`kv-get` command can be used to delete a value by key from an existing bucket.
+
+Example usage:
+./kv-delete -creds '/path/to/nats/credentials' -s 'nats://127.0.0.1:4222' SOME_BUCKET my_key
+*/
+
+func usage() {
+	log.Printf("Usage: kv-delete [-s server] [-creds file] [-nkey file] [-tlscert file] [-tlskey file] [-tlscacert file] <bucket> <key>\n")
+	flag.PrintDefaults()
+}
+
+func showUsageAndExit(exitcode int) {
+	usage()
+	os.Exit(exitcode)
+}
+
+func main() {
+
+	// CLI flags
+	var (
+		urls          = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+		userCreds     = flag.String("creds", "", "User Credentials File")
+		nkeyFile      = flag.String("nkey", "", "NKey Seed File")
+		tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+		tlsClientKey  = flag.String("tlskey", "", "Private key file for client certificate")
+		tlsCACert     = flag.String("tlscacert", "", "CA certificate to verify peer against")
+		showHelp      = flag.Bool("h", false, "Show help message")
+	)
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	if *showHelp {
+		showUsageAndExit(0)
+	}
+
+	args := flag.Args()
+	if len(args) != 2 {
+		showUsageAndExit(1)
+	}
+
+	// Connect Options.
+	opts := []nats.Option{nats.Name("JetStream Sample KeyValue Delete")}
+
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
+	// Use UserCredentials
+	if *userCreds != "" {
+		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
+	}
+
+	// Connect to NATS
+	nc, err := nats.Connect(*urls, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	// Retrieve JetStream connections
+	js, err := nc.JetStream()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	bucket, key := args[0], args[1]
+
+	kv, err := js.KeyValue(bucket)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = kv.Delete(key)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Key '%s' marked for deletion", key)
+}

--- a/examples/kv/get/main.go
+++ b/examples/kv/get/main.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/kv/get/main.go
+++ b/examples/kv/get/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/nats-io/nats.go"
+)
+
+/*
+This example shows implementation of JetStream KeyValue get operation.
+`kv-get` command can be used to fetch a value from an existing bucket.
+
+Example usage:
+./kv-get -creds '/path/to/nats/credentials' -s 'nats://127.0.0.1:4222' SOME_BUCKET my_key
+*/
+
+func usage() {
+	log.Printf("Usage: kv-get [-s server] [-creds file] [-nkey file] [-tlscert file] [-tlskey file] [-tlscacert file] <bucket> <key>\n")
+	flag.PrintDefaults()
+}
+
+func showUsageAndExit(exitcode int) {
+	usage()
+	os.Exit(exitcode)
+}
+
+func main() {
+
+	// CLI flags
+	var (
+		urls          = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+		userCreds     = flag.String("creds", "", "User Credentials File")
+		nkeyFile      = flag.String("nkey", "", "NKey Seed File")
+		tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+		tlsClientKey  = flag.String("tlskey", "", "Private key file for client certificate")
+		tlsCACert     = flag.String("tlscacert", "", "CA certificate to verify peer against")
+		showHelp      = flag.Bool("h", false, "Show help message")
+	)
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	if *showHelp {
+		showUsageAndExit(0)
+	}
+
+	args := flag.Args()
+	if len(args) != 2 {
+		showUsageAndExit(1)
+	}
+
+	// Connect Options.
+	opts := []nats.Option{nats.Name("JetStream Sample KeyValue Get")}
+
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
+	// Use UserCredentials
+	if *userCreds != "" {
+		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
+	}
+
+	// Connect to NATS
+	nc, err := nats.Connect(*urls, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	// Retrieve JetStream connections
+	js, err := nc.JetStream()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	bucket, key := args[0], args[1]
+
+	kv, err := js.KeyValue(bucket)
+	if err != nil {
+		log.Fatal(err)
+	}
+	entry, err := kv.Get(key)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Value for '%s': %s\nRev: %d", key, entry.Value(), entry.Revision())
+}

--- a/examples/kv/manage/main.go
+++ b/examples/kv/manage/main.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/nats-io/nats.go"
+)
+
+/*
+This example shows implementation of JetStream KeyValue store management.
+`kv-manage` command can be used to create and delete a KV store.
+
+Example usage:
+./kv-manage -creds '/path/to/nats/credentials' -s 'nats://127.0.0.1:4222' create STORAGE_KV
+*/
+
+func usage() {
+	log.Printf("Usage: kv-manage [-s server] [-creds file] [-nkey file] [-tlscert file] [-tlskey file] [-tlscacert file] <operation> [ create | delete ] <name>\n")
+	flag.PrintDefaults()
+}
+
+func showUsageAndExit(exitcode int) {
+	usage()
+	os.Exit(exitcode)
+}
+
+func main() {
+
+	// CLI flags
+	var (
+		urls          = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+		userCreds     = flag.String("creds", "", "User Credentials File")
+		nkeyFile      = flag.String("nkey", "", "NKey Seed File")
+		tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+		tlsClientKey  = flag.String("tlskey", "", "Private key file for client certificate")
+		tlsCACert     = flag.String("tlscacert", "", "CA certificate to verify peer against")
+		showHelp      = flag.Bool("h", false, "Show help message")
+	)
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	if *showHelp {
+		showUsageAndExit(0)
+	}
+
+	args := flag.Args()
+	if len(args) != 2 {
+		showUsageAndExit(1)
+	}
+
+	// Connect Options.
+	opts := []nats.Option{nats.Name("JetStream Sample KeyValue Management")}
+
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
+	// Use UserCredentials
+	if *userCreds != "" {
+		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
+	}
+
+	// Connect to NATS
+	nc, err := nats.Connect(*urls, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	// Retrieve JetStream connections
+	js, err := nc.JetStream()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	operation, bucket := args[0], args[1]
+
+	switch operation {
+	case "create":
+		_, err = js.CreateKeyValue(&nats.KeyValueConfig{
+			Bucket:   bucket,
+			MaxBytes: 256 << 20,
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("Created KeyValue store '%s'", bucket)
+	case "delete":
+		err = js.DeleteKeyValue(bucket)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("Removed KeyValue store: '%s'", bucket)
+	default:
+		log.Fatalf("Operation not supported: %s\nAvailable options: %s", operation, "create, delete")
+	}
+}

--- a/examples/kv/manage/main.go
+++ b/examples/kv/manage/main.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/kv/put/main.go
+++ b/examples/kv/put/main.go
@@ -66,7 +66,7 @@ func main() {
 	}
 
 	// Connect Options.
-	opts := []nats.Option{nats.Name("JetStream Sample KeyValue Management")}
+	opts := []nats.Option{nats.Name("JetStream Sample KeyValue Put")}
 
 	if *userCreds != "" && *nkeyFile != "" {
 		log.Fatal("specify -seed or -creds")

--- a/examples/kv/put/main.go
+++ b/examples/kv/put/main.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/kv/put/main.go
+++ b/examples/kv/put/main.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/nats-io/nats.go"
+)
+
+/*
+This example shows implementation of JetStream KeyValue put operation.
+`kv-put` command can be used to insert a new value to an existing bucket.
+
+Example usage:
+./kv-put -creds '/path/to/nats/credentials' -s 'nats://127.0.0.1:4222' SOME_BUCKET my_key val
+*/
+
+func usage() {
+	log.Printf("Usage: kv-put [-s server] [-creds file] [-nkey file] [-tlscert file] [-tlskey file] [-tlscacert file] <bucket> <key> <value>\n")
+	flag.PrintDefaults()
+}
+
+func showUsageAndExit(exitcode int) {
+	usage()
+	os.Exit(exitcode)
+}
+
+func main() {
+
+	// CLI flags
+	var (
+		urls          = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+		userCreds     = flag.String("creds", "", "User Credentials File")
+		nkeyFile      = flag.String("nkey", "", "NKey Seed File")
+		tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+		tlsClientKey  = flag.String("tlskey", "", "Private key file for client certificate")
+		tlsCACert     = flag.String("tlscacert", "", "CA certificate to verify peer against")
+		showHelp      = flag.Bool("h", false, "Show help message")
+	)
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	if *showHelp {
+		showUsageAndExit(0)
+	}
+
+	args := flag.Args()
+	if len(args) != 3 {
+		showUsageAndExit(1)
+	}
+
+	// Connect Options.
+	opts := []nats.Option{nats.Name("JetStream Sample KeyValue Management")}
+
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
+	// Use UserCredentials
+	if *userCreds != "" {
+		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
+	}
+
+	// Connect to NATS
+	nc, err := nats.Connect(*urls, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	// Retrieve JetStream connections
+	js, err := nc.JetStream()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	bucket, key, value := args[0], args[1], args[2]
+
+	// Retrieve KeyValue store
+	kv, err := js.KeyValue(bucket)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rev, err := kv.PutString(key, value)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Value stored for key '%s': %s\nRev: %d", key, value, rev)
+}

--- a/examples/kv/watch/main.go
+++ b/examples/kv/watch/main.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+/*
+This example shows implementation of JetStream KeyValue watcher.
+`kv-watch` command can be used to monitor updates on a given key.
+
+Example usage:
+./kv-watch -creds '/path/to/nats/credentials' -s 'nats://127.0.0.1:4222' SOME_BUCKET my_key
+*/
+
+func usage() {
+	log.Printf("Usage: kv-watch [-s server] [-creds file] [-nkey file] [-tlscert file] [-tlskey file] [-tlscacert file] <bucket> <key>\n")
+	flag.PrintDefaults()
+}
+
+func showUsageAndExit(exitcode int) {
+	usage()
+	os.Exit(exitcode)
+}
+
+func main() {
+
+	// CLI flags
+	var (
+		urls          = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+		userCreds     = flag.String("creds", "", "User Credentials File")
+		nkeyFile      = flag.String("nkey", "", "NKey Seed File")
+		tlsClientCert = flag.String("tlscert", "", "TLS client certificate file")
+		tlsClientKey  = flag.String("tlskey", "", "Private key file for client certificate")
+		tlsCACert     = flag.String("tlscacert", "", "CA certificate to verify peer against")
+		showHelp      = flag.Bool("h", false, "Show help message")
+	)
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	if *showHelp {
+		showUsageAndExit(0)
+	}
+
+	args := flag.Args()
+	if len(args) != 2 {
+		showUsageAndExit(1)
+	}
+
+	// Connect Options.
+	opts := []nats.Option{nats.Name("JetStream Sample Key Watcher")}
+	opts = setupConnOptions(opts)
+
+	if *userCreds != "" && *nkeyFile != "" {
+		log.Fatal("specify -seed or -creds")
+	}
+
+	// Use UserCredentials
+	if *userCreds != "" {
+		opts = append(opts, nats.UserCredentials(*userCreds))
+	}
+
+	// Use TLS client authentication
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		opts = append(opts, nats.ClientCert(*tlsClientCert, *tlsClientKey))
+	}
+
+	// Use specific CA certificate
+	if *tlsCACert != "" {
+		opts = append(opts, nats.RootCAs(*tlsCACert))
+	}
+
+	// Use Nkey authentication.
+	if *nkeyFile != "" {
+		opt, err := nats.NkeyOptionFromSeed(*nkeyFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts = append(opts, opt)
+	}
+
+	// Connect to NATS
+	nc, err := nats.Connect(*urls, opts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	// Retrieve JetStream connections
+	js, err := nc.JetStream()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	bucket, key := args[0], args[1]
+
+	kv, err := js.KeyValue(bucket)
+	if err != nil {
+		log.Fatal(err)
+	}
+	watcher, err := kv.Watch(key)
+	if err != nil {
+		log.Fatal(err)
+	}
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	for {
+		select {
+		case entry := <-watcher.Updates():
+			if entry == nil {
+				log.Print("Waiting for updates")
+				continue
+			}
+			log.Printf("Value for '%s': %s; Revision: %d", key, entry.Value(), entry.Revision())
+		case <-c:
+			log.Fatal("Exiting")
+			return
+		}
+	}
+}
+
+func setupConnOptions(opts []nats.Option) []nats.Option {
+	totalWait := 10 * time.Minute
+	reconnectDelay := time.Second
+
+	opts = append(opts, nats.ReconnectWait(reconnectDelay))
+	opts = append(opts, nats.MaxReconnects(int(totalWait/reconnectDelay)))
+	opts = append(opts, nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {
+		log.Printf("Disconnected due to:%s, will attempt reconnects for %.0fm", err, totalWait.Minutes())
+	}))
+	opts = append(opts, nats.ReconnectHandler(func(nc *nats.Conn) {
+		log.Printf("Reconnected [%s]", nc.ConnectedUrl())
+	}))
+	opts = append(opts, nats.ClosedHandler(func(nc *nats.Conn) {
+		log.Fatalf("Exiting: %v", nc.LastError())
+	}))
+	return opts
+}

--- a/examples/kv/watch/main.go
+++ b/examples/kv/watch/main.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (


### PR DESCRIPTION
As per #867, added examples for:
- stream/consumer management
- synchronous and asynchronous message publish
- various subscribers (push, pull, queue)
- KeyValue bucket management
- basic operations on values in KV bucket (put, get, delete, watch)