### PR TITLE
Ordered will force R1 and memory storage

### DIFF
--- a/js.go
+++ b/js.go
@@ -1401,6 +1401,10 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, isSync,
 		o.cfg.AckPolicy = AckNonePolicy
 		o.cfg.MaxDeliver = 1
 		o.cfg.AckWait = 22 * time.Hour // Just set to something known, not utilized.
+		// Force R1 and MemoryStorage for these.
+		o.cfg.Replicas = 1
+		o.cfg.MemoryStorage = true
+
 		if !hasHeartbeats {
 			o.cfg.Heartbeat = orderedHeartbeatsInterval
 		}


### PR DESCRIPTION
For ordered push semantics no need to have file based, so force R1 and memory based.

Signed-off-by: Derek Collison <derek@nats.io>