### PR TITLE
Add additional note to JetStream.PullSubscribe on durable semantics

### DIFF
--- a/js.go
+++ b/js.go
@@ -97,7 +97,8 @@ type JetStream interface {
 	QueueSubscribeSync(subj, queue string, opts ...SubOpt) (*Subscription, error)
 
 	// PullSubscribe creates a Subscription that can fetch messages.
-	// See important note in Subscribe()
+	// See important note in Subscribe(). Additionally, for an ephemeral pull consumer, the "durable" value must be
+	// set to an empty string.
 	PullSubscribe(subj, durable string, opts ...SubOpt) (*Subscription, error)
 }
 


### PR DESCRIPTION
Based on user confusion on what the `durable` argument should be for an ephemeral consumer. The `Subscribe` method notes calls out `nats.Durable`, but not the argument itself.