### PR TITLE
Expose TLS connection state when possible

### DIFF
--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -110,6 +110,19 @@ func TestLeakingGoRoutinesOnFailedConnect(t *testing.T) {
 	checkNoGoroutineLeak(t, base, "failed connect")
 }
 
+func TestTLSConnectionStateNonTLS(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	_, err := nc.TLSConnectionState()
+	if err != nats.ErrConnectionNotTLS {
+		t.Fatalf("Expected a not tls error, got: %v", err)
+	}
+}
+
 func TestConnectedServer(t *testing.T) {
 	s := RunDefaultServer()
 	defer s.Shutdown()

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -161,6 +161,14 @@ func TestServerSecureConnections(t *testing.T) {
 	}
 	nc.Flush()
 
+	state, err := nc.TLSConnectionState()
+	if err != nil {
+		t.Fatalf("Expected connection state: %v", err)
+	}
+	if !state.HandshakeComplete {
+		t.Fatalf("Expected valid connection state")
+	}
+
 	if err := Wait(checkRecv); err != nil {
 		t.Fatal("Failed receiving message")
 	}


### PR DESCRIPTION
I would like to be able to report things like ciphers,
tls or not, verified or not etc in nats account info
where its shows other connection properties but had
no way to get at this information

Signed-off-by: R.I.Pienaar <rip@devco.net>