### PR TITLE
Change DefaultSubPendingMsgsLimit comment to reflect actual value

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -4446,8 +4446,8 @@ func (s *Subscription) ClearMaxPending() error {
 
 // Pending Limits
 const (
-	// DefaultSubPendingMsgsLimit will be 524,288 msgs.
-	DefaultSubPendingMsgsLimit = 512 * 1024
+	// DefaultSubPendingMsgsLimit will be 500k msgs.
+	DefaultSubPendingMsgsLimit = 500_000
 	// DefaultSubPendingBytesLimit is 64MB
 	DefaultSubPendingBytesLimit = 64 * 1024 * 1024
 )


### PR DESCRIPTION
This is just for consistency.. I don't seeing it help with _understanding_ per se, but it could help in the edge case situation where the pending number is being reported and its greater than 512k which could be confusing. 