### PR TITLE
flusher errors now do not fail silently

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -3095,6 +3095,9 @@ func (nc *Conn) flusher() {
 				if nc.err == nil {
 					nc.err = err
 				}
+				if nc.Opts.AsyncErrorCB != nil {
+					nc.ach.push(func() { nc.Opts.AsyncErrorCB(nc, nil, err) })
+				}
 			}
 		}
 		nc.mu.Unlock()


### PR DESCRIPTION
The flusher could fail the write and the user would not be able to handle nor get alerted to this error.

Although this is still poor since the error occurs asynchronously, at least the user will be alerted to the error having happened.