### PR TITLE
[FIXED] Ephemeral PullConsumer's Fetch() would fail with "no responders"

### DIFF
--- a/js.go
+++ b/js.go
@@ -1662,7 +1662,9 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, isSync,
 			// after the AddConsumer returns.
 			if consumer == _EMPTY_ {
 				sub.jsi.consumer = info.Name
-				sub.jsi.nms = fmt.Sprintf(js.apiSubj(apiRequestNextT), stream, info.Name)
+				if isPullMode {
+					sub.jsi.nms = fmt.Sprintf(js.apiSubj(apiRequestNextT), stream, info.Name)
+				}
 			}
 			sub.mu.Unlock()
 		}

--- a/js.go
+++ b/js.go
@@ -1662,6 +1662,7 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, isSync,
 			// after the AddConsumer returns.
 			if consumer == _EMPTY_ {
 				sub.jsi.consumer = info.Name
+				sub.jsi.nms = fmt.Sprintf(js.apiSubj(apiRequestNextT), stream, info.Name)
 			}
 			sub.mu.Unlock()
 		}


### PR DESCRIPTION
This was a bug @piotrpio found where passed consumer name (assuming a durable) was being used to define the "next message" subject. This resets it if an ephemeral was created using the server-generated name.