### PR TITLE
[ADDED] SecureDeleteMsg method to JetStreamManager

### DIFF
--- a/test/js_test.go
+++ b/test/js_test.go
@@ -2207,9 +2207,140 @@ func TestJetStreamManagement_DeleteMsg(t *testing.T) {
 	}
 	originalSeq := meta.Sequence.Stream
 
+	// create a subscription on delete message API subject to verify the content of delete operation
+	apiSub, err := nc.SubscribeSync("$JS.API.STREAM.MSG.DELETE.foo")
+	if err != nil {
+		t.Fatalf("Error on subscribe: %v", err)
+	}
 	err = js.DeleteMsg("foo", originalSeq)
 	if err != nil {
 		t.Fatal(err)
+	}
+	msg, err = apiSub.NextMsg(1 * time.Second)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if str := string(msg.Data); !strings.Contains(str, "no_erase\":true") {
+		t.Fatalf("Request should not have no_erase field set: %s", str)
+	}
+
+	si, err = js.StreamInfo("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	total = 14
+	if si.State.Msgs != total {
+		t.Errorf("Expected %d msgs, got: %d", total, si.State.Msgs)
+	}
+
+	// There should be only 4 messages since one deleted.
+	expected = 4
+	msgs = make([]*nats.Msg, 0)
+	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	sub, err = js.Subscribe("foo.C", func(msg *nats.Msg) {
+		msgs = append(msgs, msg)
+
+		if len(msgs) == expected {
+			cancel()
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-ctx.Done()
+	sub.Unsubscribe()
+
+	msg = msgs[0]
+	meta, err = msg.Metadata()
+	if err != nil {
+		t.Fatal(err)
+	}
+	newSeq := meta.Sequence.Stream
+
+	// First message removed
+	if newSeq <= originalSeq {
+		t.Errorf("Expected %d to be higher sequence than %d", newSeq, originalSeq)
+	}
+}
+
+func TestJetStreamManagement_SecureDeleteMsg(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, s)
+
+	nc, js := jsClient(t, s)
+	defer nc.Close()
+
+	var err error
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "foo",
+		Subjects: []string{"foo.A", "foo.B", "foo.C"},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		js.Publish("foo.A", []byte("A"))
+		js.Publish("foo.B", []byte("B"))
+		js.Publish("foo.C", []byte("C"))
+	}
+
+	si, err := js.StreamInfo("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var total uint64 = 15
+	if si.State.Msgs != total {
+		t.Errorf("Expected %d msgs, got: %d", total, si.State.Msgs)
+	}
+
+	expected := 5
+	msgs := make([]*nats.Msg, 0)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	sub, err := js.Subscribe("foo.C", func(msg *nats.Msg) {
+		msgs = append(msgs, msg)
+		if len(msgs) == expected {
+			cancel()
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-ctx.Done()
+	sub.Unsubscribe()
+
+	got := len(msgs)
+	if got != expected {
+		t.Fatalf("Expected %d, got %d", expected, got)
+	}
+
+	msg := msgs[0]
+	meta, err := msg.Metadata()
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalSeq := meta.Sequence.Stream
+
+	// create a subscription on delete message API subject to verify the content of delete operation
+	apiSub, err := nc.SubscribeSync("$JS.API.STREAM.MSG.DELETE.foo")
+	if err != nil {
+		t.Fatalf("Error on subscribe: %v", err)
+	}
+	err = js.SecureDeleteMsg("foo", originalSeq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg, err = apiSub.NextMsg(1 * time.Second)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if str := string(msg.Data); strings.Contains(str, "no_erase\":true") {
+		t.Fatalf("Request should not have no_erase field set: %s", str)
 	}
 
 	si, err = js.StreamInfo("foo")


### PR DESCRIPTION
This addesses https://github.com/nats-io/nats-architecture-and-design/issues/118

As mentioned in the above issue, the old `DeleteMsg()` now sets `no_erase` to `true` by default (for better performance), and the new `SecureDeleteMsg()` can be used to completely overwrite the deleted message on server.