### PR TITLE
[FIXED] JetStream: Fail Ack() (and the likes) for AckNone consumer

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -164,6 +164,7 @@ var (
 	ErrConsumerNotActive            = errors.New("nats: consumer not active")
 	ErrMsgNotFound                  = errors.New("nats: message not found")
 	ErrMsgAlreadyAckd               = errors.New("nats: message was already acknowledged")
+	ErrCantAckIfConsumerAckNone     = errors.New("nats: cannot acknowledge a message for a consumer with AckNone policy")
 	ErrStreamInfoMaxSubjects        = errors.New("nats: subject details would exceed maximum allowed")
 	ErrStreamNameAlreadyInUse       = errors.New("nats: stream name already in use")
 	ErrMaxConnectionsExceeded       = errors.New("nats: server maximum connections exceeded")

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -1592,6 +1592,9 @@ func TestCustomFlusherTimeout(t *testing.T) {
 		// Notify when connection lost
 		nats.ClosedHandler(func(_ *nats.Conn) {
 			doneCh <- struct{}{}
+		}),
+		// Use error handler to silence the stderr output
+		nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, _ error) {
 		}))
 	if err != nil {
 		t.Fatalf("Expected to be able to connect, got: %s", err)


### PR DESCRIPTION
Resolves #1027

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>