### PR TITLE
link not allowed in put meta

### DIFF
--- a/object.go
+++ b/object.go
@@ -648,8 +648,7 @@ func publishMeta(info *ObjectInfo, js JetStreamContext) error {
 
 	// Publish the meta message.
 	mm.Data = data
-	_, err = js.PublishMsg(mm)
-	if err != nil {
+	if _, err := js.PublishMsg(mm); err != nil {
 		return err
 	}
 
@@ -695,8 +694,7 @@ func (obs *obs) AddLink(name string, obj *ObjectInfo) (*ObjectInfo, error) {
 	info := &ObjectInfo{Bucket: obs.name, NUID: nuid.Next(), ModTime: time.Now().UTC(), ObjectMeta: *meta}
 
 	// put the link object
-	err = publishMeta(info, obs.js)
-	if err != nil {
+	if err = publishMeta(info, obs.js); err != nil {
 		return nil, err
 	}
 

--- a/object.go
+++ b/object.go
@@ -75,7 +75,7 @@ type ObjectStore interface {
 
 	// GetInfo will retrieve the current information for the object.
 	GetInfo(name string) (*ObjectInfo, error)
-	// UpdateMeta will update the meta data for the object.
+	// UpdateMeta will update the metadata for the object.
 	UpdateMeta(name string, meta *ObjectMeta) error
 
 	// Delete will delete the named object.

--- a/object.go
+++ b/object.go
@@ -316,7 +316,7 @@ func (obs *obs) Put(meta *ObjectMeta, r io.Reader, opts ...ObjectOpt) (*ObjectIn
 		meta.Opts = &ObjectMetaOptions{ChunkSize: objDefaultChunkSize}
 	} else if meta.Opts.Link != nil {
 		return nil, ErrLinkNotAllowed
-	} else if meta.Opts.ChunkSize <= 0 {
+	} else if meta.Opts.ChunkSize == 0 {
 		meta.Opts.ChunkSize = objDefaultChunkSize
 	}
 

--- a/test/object_test.go
+++ b/test/object_test.go
@@ -431,6 +431,11 @@ func TestObjectMetadata(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected an error when trying to update an object that does not exist.")
 	}
+
+	// can't have a link when putting an object
+	meta.Opts = &nats.ObjectMetaOptions{Link: &nats.ObjectLink{Bucket: "DoesntMatter"}}
+	_, err = obs.Put(meta, nil)
+	expectErr(t, err, nats.ErrLinkNotAllowed)
 }
 
 func TestObjectWatch(t *testing.T) {

--- a/test/object_test.go
+++ b/test/object_test.go
@@ -35,13 +35,13 @@ func TestObjectBasics(t *testing.T) {
 	nc, js := jsClient(t, s)
 	defer nc.Close()
 
-	obs, err := js.CreateObjectStore(nil)
+	_, err := js.CreateObjectStore(nil)
 	expectErr(t, err, nats.ErrObjectConfigRequired)
 
-	obs, err = js.CreateObjectStore(&nats.ObjectStoreConfig{Bucket: "notok!", Description: "testing"})
+	_, err = js.CreateObjectStore(&nats.ObjectStoreConfig{Bucket: "notok!", Description: "testing"})
 	expectErr(t, err, nats.ErrInvalidStoreName)
 
-	obs, err = js.CreateObjectStore(&nats.ObjectStoreConfig{Bucket: "OBJS", Description: "testing"})
+	obs, err := js.CreateObjectStore(&nats.ObjectStoreConfig{Bucket: "OBJS", Description: "testing"})
 	expectOk(t, err)
 
 	// Create ~16MB object.
@@ -712,7 +712,7 @@ func TestObjectList(t *testing.T) {
 	root, err := js.CreateObjectStore(&nats.ObjectStoreConfig{Bucket: "ROOT"})
 	expectOk(t, err)
 
-	lch, err := root.List()
+	_, err = root.List()
 	expectErr(t, err, nats.ErrNoObjectsFound)
 
 	put := func(name, value string) {
@@ -735,7 +735,7 @@ func TestObjectList(t *testing.T) {
 	err = root.Delete("D")
 	expectOk(t, err)
 
-	lch, err = root.List()
+	lch, err := root.List()
 	expectOk(t, err)
 
 	omap := make(map[string]struct{})


### PR DESCRIPTION
* Prevented links in meta data for puts
* refactored for common publish meta functionality
* Converted all loose errors to vars.
* Updated unit test to check and cover errors.