### PR TITLE
[FIXED] Trailing comma at end of URL lists should be ignored

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1268,10 +1268,15 @@ func (nc *Conn) SetErrorHandler(cb ErrHandler) {
 // Return an array of urls, even if only one.
 func processUrlString(url string) []string {
 	urls := strings.Split(url, ",")
-	for i, s := range urls {
-		urls[i] = strings.TrimSpace(s)
+	var j int
+	for _, s := range urls {
+		u := strings.TrimSpace(s)
+		if len(u) > 0 {
+			urls[j] = u
+			j++
+		}
 	}
-	return urls
+	return urls[:j]
 }
 
 // Connect will attempt to connect to a NATS server with multiple options.

--- a/nats_test.go
+++ b/nats_test.go
@@ -2920,3 +2920,23 @@ func TestInProcessConn(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestServerListWithTrailingComma(t *testing.T) {
+	s := RunServerOnPort(-1)
+	defer s.Shutdown()
+
+	// Notice the comma at the end of the "list"
+	nc, err := Connect(fmt.Sprintf("%s,", s.ClientURL()))
+	if err != nil {
+		t.Fatalf("Unable to connect: %v", err)
+	}
+	defer nc.Close()
+
+	// Now check server pool
+	nc.mu.Lock()
+	l := len(nc.srvPool)
+	nc.mu.Unlock()
+	if l != 1 {
+		t.Fatalf("There should be only 1 URL in the list, got %v", l)
+	}
+}


### PR DESCRIPTION
Resolves #1056

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>