### PR TITLE
Allow `AckAll` for pull-based consumers

### DIFF
--- a/js.go
+++ b/js.go
@@ -1390,7 +1390,7 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, isSync,
 	// Some checks for pull subscribers
 	if isPullMode {
 		// Check for bad ack policy
-		if o.cfg.AckPolicy == AckNonePolicy || o.cfg.AckPolicy == AckAllPolicy {
+		if o.cfg.AckPolicy == AckNonePolicy {
 			return nil, fmt.Errorf("nats: invalid ack mode for pull consumers: %s", o.cfg.AckPolicy)
 		}
 		// No deliver subject should be provided


### PR DESCRIPTION
If you are the only client pulling on a given consumer, the efficiency gains of fetching in batches is largely lost if you have to acknowledge every message you received individually afterwards.

It would seem intuitive to be able to acknowledge only the most recent message in the batch instead and to have that do the right thing.