### PR TITLE
Add natsProtoErr that can be used with errors.Is

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -2323,6 +2323,19 @@ func normalizeErr(line string) string {
 	return s
 }
 
+// natsProtoErr represents an -ERR protocol message sent by the server.
+type natsProtoErr struct {
+	description string
+}
+
+func (nerr *natsProtoErr) Error() string {
+	return fmt.Sprintf("nats: %s", nerr.description)
+}
+
+func (nerr *natsProtoErr) Is(err error) bool {
+	return strings.ToLower(nerr.Error()) == err.Error()
+}
+
 // Send a connect protocol message to the server, issue user/password if
 // applicable. Will wait for a flush to return from the server for error
 // processing.
@@ -2377,8 +2390,7 @@ func (nc *Conn) sendConnect() error {
 				// in doReconnect()).
 				nc.processAuthError(authErr)
 			}
-
-			return errors.New("nats: " + proto)
+			return &natsProtoErr{proto}
 		}
 
 		// Notify that we got an unexpected protocol.

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -14,6 +14,7 @@
 package test
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -41,6 +42,10 @@ func TestAuth(t *testing.T) {
 	// This test may be a bit too strict for the future, but for now makes
 	// sure that we correctly process the -ERR content on connect.
 	if strings.ToLower(err.Error()) != nats.ErrAuthorization.Error() {
+		t.Fatalf("Expected error '%v', got '%v'", nats.ErrAuthorization, err)
+	}
+
+	if !errors.Is(err, nats.ErrAuthorization) {
 		t.Fatalf("Expected error '%v', got '%v'", nats.ErrAuthorization, err)
 	}
 

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -14,6 +14,7 @@
 package test
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -191,6 +192,10 @@ func TestAuthServers(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "Authorization") {
 		t.Fatalf("Wrong error, wanted Auth failure, got '%s'\n", err)
+	}
+
+	if !errors.Is(err, nats.ErrAuthorization) {
+		t.Fatalf("Expected error '%v', got '%v'", nats.ErrAuthorization, err)
 	}
 
 	// Test that we can connect to a subsequent correct server.


### PR DESCRIPTION
The server can send both `-ERR 'Authorization Violation'` or `-ERR 'authorization violation'` depending on some conditions so in the client side we usually try to normalize the behavior by changing to lowercase when checking for an error.
One exception was during the initial connect where the client instead returned the raw error protocol message.

Since this behavior has been in the wild for many years, instead of returning the raw error or the proper error type like `ErrAuthorization` to keep things backwards compatible just in case, this adds a new `natsProtoErr` that can be used with `errors.Is` to check whether the raw protocol message is equivalent to other errors.

Fixes #1081

Signed-off-by: Waldemar Quevedo <wally@nats.io>