### PR TITLE
[ADDED] Exposes Bytes from stream info in KeyValueStatus

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -94,6 +94,9 @@ type KeyValueStatus interface {
 
 	// BackingStore indicates what technology is used for storage of the bucket
 	BackingStore() string
+
+	// Bytes returns the size in bytes of the bucket
+	Bytes() uint64
 }
 
 // KeyWatcher is what is returned when doing a watch.
@@ -955,6 +958,9 @@ func (s *KeyValueBucketStatus) BackingStore() string { return "JetStream" }
 
 // StreamInfo is the stream info retrieved to create the status
 func (s *KeyValueBucketStatus) StreamInfo() *StreamInfo { return s.nfo }
+
+// Bytes is the size of the stream
+func (s *KeyValueBucketStatus) Bytes() uint64 { return s.nfo.State.Bytes }
 
 // Status retrieves the status and configuration of a bucket
 func (kv *kvs) Status() (KeyValueStatus, error) {


### PR DESCRIPTION
Currently, in order to get the size in bytes of a bucket people are resorting to getting the stream info directly adding themselves a hard coded "KV_" prefix to the bucket name which is not great and not future proof. This exposes `Bytes()` which is already present in `s.nfo` in KeyValueBucketStatus.