### PR TITLE
js: Fix typo in AccountInfo JSON to handle Tiers

### DIFF
--- a/jsm.go
+++ b/jsm.go
@@ -186,7 +186,7 @@ type AccountInfo struct {
 	Tier
 	Domain string          `json:"domain"`
 	API    APIStats        `json:"api"`
-	Tiers  map[string]Tier `json:"tier"`
+	Tiers  map[string]Tier `json:"tiers"`
 }
 
 type Tier struct {


### PR DESCRIPTION
Looking at the schema seems it should have been `tiers`: https://github.com/nats-io/nats-architecture-and-design/issues/120