### PR TITLE
[CHANGED] Listing Key Value stores and object stores to return status instead of interface

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -37,8 +37,8 @@ type KeyValueManager interface {
 	DeleteKeyValue(bucket string) error
 	// KeyValueStoreNames is used to retrieve a list of key value store names
 	KeyValueStoreNames() <-chan string
-	// KeyValueStores is used to retrieve a list of key value stores
-	KeyValueStores() <-chan KeyValue
+	// KeyValueStores is used to retrieve a list of key value store statuses
+	KeyValueStores() <-chan KeyValueStatus
 }
 
 // Notice: Experimental Preview
@@ -992,9 +992,9 @@ func (js *js) KeyValueStoreNames() <-chan string {
 	return ch
 }
 
-// KeyValueStores is used to retrieve a list of key value stores
-func (js *js) KeyValueStores() <-chan KeyValue {
-	ch := make(chan KeyValue)
+// KeyValueStores is used to retrieve a list of key value store statuses
+func (js *js) KeyValueStores() <-chan KeyValueStatus {
+	ch := make(chan KeyValueStatus)
 	l := &streamLister{js: js}
 	l.js.opts.streamListSubject = fmt.Sprintf(kvSubjectsTmpl, "*")
 	go func() {
@@ -1004,7 +1004,7 @@ func (js *js) KeyValueStores() <-chan KeyValue {
 				if !strings.HasPrefix(info.Config.Name, "KV_") {
 					continue
 				}
-				ch <- mapStreamToKVS(js, info)
+				ch <- &KeyValueBucketStatus{nfo: info, bucket: strings.TrimPrefix(info.Config.Name, "KV_")}
 			}
 		}
 	}()

--- a/test/kv_test.go
+++ b/test/kv_test.go
@@ -853,7 +853,7 @@ func TestListKeyValueStores(t *testing.T) {
 			if len(names) != test.bucketsNum {
 				t.Fatalf("Invalid number of stream names; want: %d; got: %d", test.bucketsNum, len(names))
 			}
-			infos := make([]nats.KeyValue, 0)
+			infos := make([]nats.KeyValueStatus, 0)
 			for info := range js.KeyValueStores() {
 				infos = append(infos, info)
 			}

--- a/test/object_test.go
+++ b/test/object_test.go
@@ -893,7 +893,7 @@ func TestListObjectStores(t *testing.T) {
 			if len(names) != test.bucketsNum {
 				t.Fatalf("Invalid number of stream names; want: %d; got: %d", test.bucketsNum, len(names))
 			}
-			infos := make([]nats.ObjectStore, 0)
+			infos := make([]nats.ObjectStoreStatus, 0)
 			for info := range js.ObjectStores() {
 				infos = append(infos, info)
 			}


### PR DESCRIPTION
This PR addresses https://github.com/nats-io/nats-architecture-and-design/issues/154

This PR changes the signatures of `KeyValueStores()` and `ObjectStores()` methods. For KV, this is not a breaking change since this functionality is yet to be released. For object store, **this is a breaking change** since these methods were released as part of v1.17.0.