### PR TITLE
Trial for js.Request

### DIFF
--- a/js.go
+++ b/js.go
@@ -52,6 +52,8 @@ type JetStream interface {
 	// PublishAsyncComplete returns a channel that will be closed when all outstanding messages are ack'd.
 	PublishAsyncComplete() <-chan struct{}
 
+	Request(subj string, data []byte, timeout time.Duration, opts ...PubOpt) (*Msg, error)
+
 	// Subscribe creates an async Subscription for JetStream.
 	// The stream and consumer names can be provided with the nats.Bind() option.
 	// For creating an ephemeral (where the consumer name is picked by the server),
@@ -462,6 +464,7 @@ const (
 	ExpectedLastSubjSeqHdr = "Nats-Expected-Last-Subject-Sequence"
 	ExpectedLastMsgIdHdr   = "Nats-Expected-Last-Msg-Id"
 	MsgRollup              = "Nats-Rollup"
+	MsgReplyHdr            = "Nats-Reply"
 )
 
 // Headers for republished messages and direct gets.
@@ -577,6 +580,85 @@ func (js *js) PublishMsg(m *Msg, opts ...PubOpt) (*PubAck, error) {
 // Publish publishes a message to a stream from JetStream.
 func (js *js) Publish(subj string, data []byte, opts ...PubOpt) (*PubAck, error) {
 	return js.PublishMsg(&Msg{Subject: subj, Data: data}, opts...)
+}
+
+// Helper to setup and send new request style requests. Return the chan to receive the response.
+// TODO: could be refactored out of nc.createNewRequestAndSend to remove duplicate code
+func (js *js) createNewReplySub() (string, chan *Msg, string, error) {
+	js.nc.mu.Lock()
+	// Do setup for the new style if needed.
+	if js.nc.respMap == nil {
+		js.nc.initNewResp()
+	}
+	// Create new literal Inbox and map to a chan msg.
+	mch := make(chan *Msg, RequestChanLen)
+	respInbox := js.nc.newRespInbox()
+	token := respInbox[js.nc.respSubLen:]
+
+	js.nc.respMap[token] = mch
+	if js.nc.respMux == nil {
+		// Create the response subscription we will use for all new style responses.
+		// This will be on an _INBOX with an additional terminal token. The subscription
+		// will be on a wildcard.
+		s, err := js.nc.subscribeLocked(js.nc.respSub, _EMPTY_, js.nc.respHandler, nil, false, nil)
+		if err != nil {
+			js.nc.mu.Unlock()
+			return "", nil, token, err
+		}
+		js.nc.respScanf = strings.Replace(js.nc.respSub, "*", "%s", -1)
+		js.nc.respMux = s
+	}
+	js.nc.mu.Unlock()
+
+	return respInbox, mch, token, nil
+}
+
+// Request publishes a message to a stream and waits for a subscriber to reply.
+func (js *js) Request(subj string, data []byte, timeout time.Duration, opts ...PubOpt) (*Msg, error) {
+	// Allocate a new inbox subject and channel for receiving a message
+	// from the multiplexed inbox subscriber.
+	inbox, mch, token, err := js.createNewReplySub()
+	if err != nil {
+		return nil, err
+	}
+
+	// Build a message, setting the reply header.
+	msg := NewMsg(subj)
+	msg.Data = data
+	msg.Header.Add(MsgReplyHdr, inbox)
+
+	// Publish to the stream. If this fails, delete the reply channel.
+	puback, err := js.PublishMsg(msg)
+	if err != nil {
+		js.nc.mu.Lock()
+		delete(js.nc.respMap, token)
+		js.nc.mu.Unlock()
+		return nil, err
+	}
+
+	// Get a timer and wait for the message. If there is a timeout or other
+	// error, the message will be deleted from the stream.
+	// TODO: make auto-delete configurable?
+	t := globalTimerPool.Get(timeout)
+	defer globalTimerPool.Put(t)
+
+	var ok bool
+
+	select {
+	case msg, ok = <-mch:
+		if !ok {
+			js.DeleteMsg(puback.Stream, puback.Sequence, Domain(puback.Domain))
+			return nil, ErrConnectionClosed
+		}
+	case <-t.C:
+		js.nc.mu.Lock()
+		delete(js.nc.respMap, token)
+		js.nc.mu.Unlock()
+		js.DeleteMsg(puback.Stream, puback.Sequence, Domain(puback.Domain))
+		return nil, ErrTimeout
+	}
+
+	return msg, nil
 }
 
 // PubAckFuture is a future for a PubAck.

--- a/nats.go
+++ b/nats.go
@@ -4626,14 +4626,24 @@ func (m *Msg) Respond(data []byte) error {
 	if m == nil || m.Sub == nil {
 		return ErrMsgNotBound
 	}
-	if m.Reply == "" {
+
+	reply := m.Reply
+
+	// Check if explicit JS-based header is present.
+	// TODO: should this trigger a msg.Ack automatically?
+	pubReply := m.Header.Get(MsgReplyHdr)
+	if pubReply != "" {
+		reply = pubReply
+	}
+
+	if reply == "" {
 		return ErrMsgNoReply
 	}
 	m.Sub.mu.Lock()
 	nc := m.Sub.conn
 	m.Sub.mu.Unlock()
 	// No need to check the connection here since the call to publish will do all the checking.
-	return nc.Publish(m.Reply, data)
+	return nc.Publish(reply, data)
 }
 
 // RespondMsg allows a convenient way to respond to requests in service based subscriptions that might include headers


### PR DESCRIPTION
I have no intention for this to be merged, but I created a branch so that I could add it to my go.mod for these two experiemental examples [request-reply](https://nats-by-example-idy2xdb76-connecteverything.vercel.app/examples/jetstream/request-reply/go) and the actual use case posed in NATS Slack, support for buffering requests in order to [auto-scale](https://nats-by-example-idy2xdb76-connecteverything.vercel.app/examples/use-cases/auto-scaler/go#output) subscribers (up and down to zero). The link is to the output to observe what it is doing. The code is not well written, but wanted to get something working.

This PR just shows a basic, happy path, implementation of what a `js.Request` might look. In general, this form of request-reply feels a bit awkward and error prone with one stream. I think a nicer option would be to store replies in a KV that then the requester could fetch using an ID (by default the random inbox token associated.. or maybe a `MsgId` could be required).

In any case, if nothing else, it is a discussion starter..