### PR TITLE
Added support for KV mirrors and sources.

### DIFF
--- a/js.go
+++ b/js.go
@@ -120,6 +120,9 @@ const (
 	// jsDomainT is used to create JetStream API prefix by specifying only Domain
 	jsDomainT = "$JS.%s.API."
 
+	// jsExtDomainT is used to create a StreamSource External APIPrefix
+	jsExtDomainT = "$JS.%s.API"
+
 	// apiAccountInfo is for obtaining general information about JetStream.
 	apiAccountInfo = "INFO"
 


### PR DESCRIPTION
 Also updated state for proper Put() and Get() semantics with mirrors and across domains, e.g. leafnodes.

In practice when a mirror is across a domain, should be named the same as origin. That allows an app to run anywhere without anything special in terms of domains when binding to the KV itself.

Signed-off-by: Derek Collison <derek@nats.io>