### PR TITLE
Use BindStream for watcher so it works with mirrors.

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -926,7 +926,7 @@ func (kv *kvs) Watch(keys string, opts ...WatchOpt) (KeyWatcher, error) {
 	}
 
 	// Used ordered consumer to deliver results.
-	subOpts := []SubOpt{OrderedConsumer()}
+	subOpts := []SubOpt{BindStream(kv.stream), OrderedConsumer()}
 	if !o.includeHistory {
 		subOpts = append(subOpts, DeliverLastPerSubject())
 	}

--- a/test/kv_test.go
+++ b/test/kv_test.go
@@ -968,6 +968,11 @@ func TestKeyValueMirrorCrossDomains(t *testing.T) {
 		t.Fatalf("Got wrong value: %q vs %q", e.Value(), "rip")
 	}
 
+	// Also make sure we can create a watcher on the mirror KV.
+	watcher, err := mkv.WatchAll()
+	expectOk(t, err)
+	defer watcher.Stop()
+
 	// Bind through leafnode connection but to origin KV.
 	rjs, err := lnc.JetStream(nats.Domain("HUB"))
 	expectOk(t, err)


### PR DESCRIPTION
Updated so connecting to mirror would allow watchers to work.

Signed-off-by: Derek Collison <derek@nats.io>