### PR TITLE
Release v1.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ When using or transitioning to Go modules support:
 ```bash
 # Go client latest or explicit version
 go get github.com/nats-io/nats.go/@latest
-go get github.com/nats-io/nats.go/@v1.19.1
+go get github.com/nats-io/nats.go/@v1.20.0
 
 # For latest NATS Server, add /v2 at the end
 go get github.com/nats-io/nats-server/v2

--- a/nats.go
+++ b/nats.go
@@ -48,7 +48,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.19.1"
+	Version                   = "1.20.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
## Changelog

### Changed
- JetStream:
  - [BREAKING CHANGE] Extract `nats: Consumer Deleted` server error to `ErrConsumerDeleted` variable. This error is returned when consumer is deleted while waiting on pull request and was introduced in nats-server v2.9.6 (#1125)

### Improved
- JetStream:
  - Fix broken comments on `ErrConsumerNameAlreadyInUse` and `StreamNameBySubject()` (#1128)
- Core NATS:
  - Improve comment on `RetryOnFailedConnect` connect option (#1127) 
