### PR TITLE
Add ErrKeyExists that is compatible with errors.Is on kv.Create

### DIFF
--- a/jserrors.go
+++ b/jserrors.go
@@ -123,6 +123,8 @@ const (
 	JSErrCodeMessageNotFound ErrorCode = 10037
 
 	JSErrCodeBadRequest ErrorCode = 10003
+
+	JSErrStreamWrongLastSequence ErrorCode = 10071
 )
 
 // APIError is included in all API responses if there was an error.

--- a/jserrors.go
+++ b/jserrors.go
@@ -124,7 +124,7 @@ const (
 
 	JSErrCodeBadRequest ErrorCode = 10003
 
-	JSErrStreamWrongLastSequence ErrorCode = 10071
+	JSErrCodeStreamWrongLastSequence ErrorCode = 10071
 )
 
 // APIError is included in all API responses if there was an error.

--- a/kv.go
+++ b/kv.go
@@ -635,9 +635,9 @@ func (kv *kvs) Create(key string, value []byte) (revision uint64, err error) {
 
 	// Check if the expected last subject sequence is not zero which implies
 	// the key already exists.
-	var aerr *APIError
-	if errors.Is(err, ErrKeyExists) && errors.As(err, &aerr) {
-		return 0, fmt.Errorf("%w: %s", ErrKeyExists, aerr.Description)
+	if errors.Is(err, ErrKeyExists) {
+		jserr := ErrKeyExists.(*jsError)
+		return 0, fmt.Errorf("%w: %s", err, jserr.message)
 	}
 
 	return 0, err

--- a/kv_test.go
+++ b/kv_test.go
@@ -223,7 +223,7 @@ func TestKeyValueCreate(t *testing.T) {
 	}
 
 	_, err = kv.Create("key", []byte("1"))
-	expected := "nats: key exists: wrong last sequence: 1"
+	expected := "nats: wrong last sequence: 1: key exists"
 	if err.Error() != expected {
 		t.Fatalf("Expected %q, got: %v", expected, err)
 	}
@@ -233,6 +233,9 @@ func TestKeyValueCreate(t *testing.T) {
 	aerr := &APIError{}
 	if !errors.As(err, &aerr) {
 		t.Fatalf("Expected APIError, got: %v", err)
+	}
+	if aerr.Description != "wrong last sequence: 1" {
+		t.Fatalf("Unexpected APIError message, got: %v", aerr.Description)
 	}
 	if aerr.ErrorCode != 10071 {
 		t.Fatalf("Unexpected error code, got: %v", aerr.ErrorCode)

--- a/kv_test.go
+++ b/kv_test.go
@@ -14,6 +14,7 @@
 package nats
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -222,7 +223,28 @@ func TestKeyValueCreate(t *testing.T) {
 	}
 
 	_, err = kv.Create("key", []byte("1"))
-	if err != ErrKeyExists {
+	expected := "nats: wrong last sequence: 1"
+	if err.Error() != expected {
+		t.Fatalf("Expected %q, got: %v", expected, err)
+	}
+	if !errors.Is(err, ErrKeyExists) {
 		t.Fatalf("Expected ErrKeyExists, got: %v", err)
+	}
+	aerr := &APIError{}
+	if !errors.As(err, &aerr) {
+		t.Fatalf("Expected APIError, got: %v", err)
+	}
+	if aerr.ErrorCode != 10071 {
+		t.Fatalf("Unexpected error code, got: %v", aerr.ErrorCode)
+	}
+	if aerr.Code != ErrKeyExists.APIError().Code {
+		t.Fatalf("Unexpected error code, got: %v", aerr.Code)
+	}
+	var kerr KeyValueError
+	if !errors.As(err, &kerr) {
+		t.Fatalf("Expected KeyValueError, got: %v", err)
+	}
+	if kerr.APIError().ErrorCode != 10071 {
+		t.Fatalf("Unexpected error code, got: %v", kerr.APIError().ErrorCode)
 	}
 }

--- a/kv_test.go
+++ b/kv_test.go
@@ -223,7 +223,7 @@ func TestKeyValueCreate(t *testing.T) {
 	}
 
 	_, err = kv.Create("key", []byte("1"))
-	expected := "nats: wrong last sequence: 1"
+	expected := "nats: key exists: wrong last sequence: 1"
 	if err.Error() != expected {
 		t.Fatalf("Expected %q, got: %v", expected, err)
 	}
@@ -240,7 +240,7 @@ func TestKeyValueCreate(t *testing.T) {
 	if aerr.Code != ErrKeyExists.APIError().Code {
 		t.Fatalf("Unexpected error code, got: %v", aerr.Code)
 	}
-	var kerr KeyValueError
+	var kerr JetStreamError
 	if !errors.As(err, &kerr) {
 		t.Fatalf("Expected KeyValueError, got: %v", err)
 	}


### PR DESCRIPTION
Follow up from (https://github.com/nats-io/nats.go/pull/1135)
This changes the returned error on `kv.Create` now to be wrapping the APIError and show error information relevant to the `kv.Create` API as well:

```
nats: wrong last sequence: 1: key exists
```

instead of:

```
nats: wrong last sequence: 1
```

The wrapped error makes it possible to make checks like this as well:

```go
_, err = kv.Create("key", []byte("1"))
if !errors.Is(err, ErrKeyExists) { ... }
```

And also still possible to get the original `APIError` if needed:

```go
_, err = kv.Create("key", []byte("1"))
var aerr *APIError
if errors.As(err, &aerr) { ... }
```

Signed-off-by: Waldemar Quevedo <wally@nats.io>