### PR TITLE
Sample doc format update

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -24,23 +24,41 @@ import (
 
 // Shows different ways to create a Conn.
 func ExampleConnect() {
+	// Simple connect, no options
 	nc, _ := nats.Connect("demo.nats.io")
 	nc.Close()
 
+	// Connect with username/password
 	nc, _ = nats.Connect("nats://derek:secretpassword@demo.nats.io:4222")
 	nc.Close()
 
+	// Establish TLS connection
 	nc, _ = nats.Connect("tls://derek:secretpassword@demo.nats.io:4443")
 	nc.Close()
 
+	// Connect to multiple servers
+	nc, _ = nats.Connect("demo.nats.io,nats://127.0.0.1:1223,nats://127.0.0.1:1224")
+	nc.Close()
+
+	// Connect with Options
+	nc, _ = nats.Connect("demo.nats.io",
+		nats.MaxReconnects(10),
+		nats.ReconnectWait(5*time.Second),
+		nats.Timeout(1*time.Second))
+
+	nc.Close()
+}
+
+func ExampleOptions_Connect() {
 	opts := nats.Options{
+		Url:            "demo.nats.io",
 		AllowReconnect: true,
 		MaxReconnect:   10,
 		ReconnectWait:  5 * time.Second,
 		Timeout:        1 * time.Second,
 	}
 
-	nc, _ = opts.Connect()
+	nc, _ := opts.Connect()
 	nc.Close()
 }
 


### PR DESCRIPTION
This is a first attempt to establish a cleaner and more verbose documentation.

These are not full changes! If this approach will be deemed appropriate, I will continue with improving documentation across the whole repository.

Some rules I am trying to follow:
1. Each exported function, method and type has to be documented.
2. Constants and variables should be divided into logical blocks, that way it is displayed nicely in godoc, e.g.:
```go
// Client version and language name.
// Used by nats-server to help identify a client connection.
const (
	Version    = "1.20.0"
	LangString = "go"
)

// Default values used by [Connect] and [GetDefaultOptions].
const (
	DefaultURL                = "nats://127.0.0.1:4222"
	DefaultPort               = 4222
	DefaultMaxReconnect       = 60
	DefaultReconnectWait      = 2 * time.Second
	DefaultReconnectJitter    = 100 * time.Millisecond
	DefaultReconnectJitterTLS = time.Second
	DefaultTimeout            = 2 * time.Second
	DefaultPingInterval       = 2 * time.Minute
	DefaultMaxPingOut         = 2
	DefaultMaxChanLen         = 64 * 1024       // 64k
	DefaultReconnectBufSize   = 8 * 1024 * 1024 // 8MB
	RequestChanLen            = 8
	DefaultDrainTimeout       = 30 * time.Second
)
```

is formatted to:
<img width="893" alt="image" src="https://user-images.githubusercontent.com/15184508/203781179-ce198401-3abd-4379-8d33-f486130a7224.png">

3. Each error variable is documented separately.
4. Each function and method should have at least one example in `example_test.go`.
5. Comments should use links to internal and external documentation whenever it's necessary. (e.g. `[*net.Dialer]` instead of `*net.Dialer` or `[GetDefaultOptions]` instead of `GetDefaultOptions()`.
6. In general, comments in code should not need long blocks of code - examples can be used for that (of course code blocks are still useful at times).
7. Headings can be used whenever we feel like a part of documentation is necessary and can potentially be linked to. Errors block is a good example of that: 
<img width="887" alt="image" src="https://user-images.githubusercontent.com/15184508/203782434-0ae215ab-d0a5-42f5-a912-82c76ac84942.png">