### PR TITLE
Add SkipTLSHandshake optional function to CustomDialer

### DIFF
--- a/services/service.go
+++ b/services/service.go
@@ -31,7 +31,7 @@ import (
 
 type (
 
-	// Service is an interface for sevice management.
+	// Service is an interface for service management.
 	// It exposes methods to stop/reset a service, as well as get information on a service.
 	Service interface {
 		ID() string


### PR DESCRIPTION
Follow up from https://github.com/nats-io/nats.go/pull/1146

This adds a small interface `SkipTLSHandshake() bool` that when implemented a `CustomDialer` may opt into skipping the handshake if not needed by the dialer implementation.

/cc @oderwat