### PR TITLE
Provide a way to handle 409 Leadership Changed errors in client

### DIFF
--- a/js.go
+++ b/js.go
@@ -2580,6 +2580,11 @@ func checkMsg(msg *Msg, checkSts, isNoWait bool) (usrMsg bool, err error) {
 			err = ErrConsumerDeleted
 			break
 		}
+
+		if strings.Contains(strings.ToLower(string(msg.Header.Get(descrHdr))), "leadership change") {
+			err = ErrConsumerLeadershipChanged
+			break
+		}
 		fallthrough
 	default:
 		err = fmt.Errorf("nats: %s", msg.Header.Get(descrHdr))

--- a/jserrors.go
+++ b/jserrors.go
@@ -102,7 +102,7 @@ var (
 	ErrConsumerDeleted JetStreamError = &jsError{message: "consumer deleted"}
 
 	// ErrConsumerLeadershipChanged is returned when pending requests are no longer valid after leadership has changed
-	ErrConsumerLeadershipChanged JetStreamError = &jsError{message: "leadership changed"}
+	ErrConsumerLeadershipChanged JetStreamError = &jsError{message: "Leadership Changed"}
 
 	// DEPRECATED: ErrInvalidDurableName is no longer returned and will be removed in future releases.
 	// Use ErrInvalidConsumerName instead.

--- a/jserrors.go
+++ b/jserrors.go
@@ -101,6 +101,9 @@ var (
 	// ErrConsumerDeleted is returned when attempting to send pull request to a consumer which does not exist
 	ErrConsumerDeleted JetStreamError = &jsError{message: "consumer deleted"}
 
+	// ErrConsumerLeadershipChanged is returned when pending requests are no longer valid after leadership has changed
+	ErrConsumerLeadershipChanged JetStreamError = &jsError{message: "leadership changed"}
+
 	// DEPRECATED: ErrInvalidDurableName is no longer returned and will be removed in future releases.
 	// Use ErrInvalidConsumerName instead.
 	ErrInvalidDurableName = errors.New("nats: invalid durable name")


### PR DESCRIPTION
Without this change, it makes it hard for clients to handle consumer errors relating to leadership changes differently from any other error.

Follows same approach as ErrConsumerDeleted.