### PR TITLE
Add note on disabling reconnect buffer

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -958,7 +958,7 @@ func MaxPingsOutstanding(max int) Option {
 }
 
 // ReconnectBufSize sets the buffer size of messages kept while busy reconnecting.
-// Defaults to 8388608 bytes (8MB).
+// Defaults to 8388608 bytes (8MB).  It can be disabled by setting it to -1.
 func ReconnectBufSize(size int) Option {
 	return func(o *Options) error {
 		o.ReconnectBufSize = size


### PR DESCRIPTION
Always forget whether `nats.ReconnectBufSize(0)` or `nats.ReconnectBufSize(-1)` disables it so adding to the docs.

- `nats.ReconnectBufSize(0)`: Uses default reconnect buf size
-  `nats.ReconnectBufSize(-1)`: Disables and throws outbound buffer limit error when publishing while disconnected
