### PR TITLE
Check whether credentials are missing before using them

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1136,6 +1136,12 @@ func UserJWT(userCB UserJWTHandler, sigCB SignatureHandler) Option {
 		if sigCB == nil {
 			return ErrUserButNoSigCB
 		}
+		// Smoke test the user callback to ensure it is setup properly
+		// when processing options.
+		if _, err := userCB(); err != nil {
+			return err
+		}
+
 		o.UserJWT = userCB
 		o.SignatureCB = sigCB
 		return nil
@@ -5432,12 +5438,12 @@ func wipeSlice(buf []byte) {
 func userFromFile(userFile string) (string, error) {
 	path, err := expandPath(userFile)
 	if err != nil {
-		return _EMPTY_, fmt.Errorf("nats: %v", err)
+		return _EMPTY_, fmt.Errorf("nats: %w", err)
 	}
 
 	contents, err := os.ReadFile(path)
 	if err != nil {
-		return _EMPTY_, fmt.Errorf("nats: %v", err)
+		return _EMPTY_, fmt.Errorf("nats: %w", err)
 	}
 	defer wipeSlice(contents)
 	return nkeys.ParseDecoratedJWT(contents)
@@ -5486,7 +5492,7 @@ func expandPath(p string) (string, error) {
 func nkeyPairFromSeedFile(seedFile string) (nkeys.KeyPair, error) {
 	contents, err := os.ReadFile(seedFile)
 	if err != nil {
-		return nil, fmt.Errorf("nats: %v", err)
+		return nil, fmt.Errorf("nats: %w", err)
 	}
 	defer wipeSlice(contents)
 	return nkeys.ParseDecoratedNKey(contents)

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -16,6 +16,7 @@ package test
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -362,5 +363,17 @@ func TestPermViolation(t *testing.T) {
 	// Make sure connection has not been closed
 	if nc.IsClosed() {
 		t.Fatal("Connection should be not be closed")
+	}
+}
+
+func TestConnectMissingCreds(t *testing.T) {
+	s := RunServerOnPort(-1)
+	defer s.Shutdown()
+
+	// Using TEST-NET sample address from RFC 5737.
+	testnetaddr := "nats://192.0.2.2:4222"
+	_, err := nats.Connect(fmt.Sprintf("%s,%s", s.ClientURL(), testnetaddr), nats.UserCredentials("missing"), nats.DontRandomize())
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("Expected not exists error, got: %v", err)
 	}
 }


### PR DESCRIPTION
On `nats.Connect` only the last error when attempting to connect will be reported, so a failure to connect with a bad configuration will result in `no servers available` in case there are multiple servers discovered or configured. In case of using credentials, this will hide issues like not configuring correctly the path to the credentials and just getting an Authorization Error for example as well.
To improve usability we can check whether the creds have been configured correctly when processing the option rather than waiting to connect (have stumbled upon this issue a couple of times so this should improve usability).

Also started to adopt wrapping errors syntax to check for the underlying io error.

Signed-off-by: Waldemar Quevedo <wally@nats.io>