### PR TITLE
js: use custom inbox prefix in async reply

### DIFF
--- a/js.go
+++ b/js.go
@@ -652,7 +652,11 @@ func (js *js) newAsyncReply() string {
 		for i := 0; i < aReplyTokensize; i++ {
 			b[i] = rdigits[int(b[i]%base)]
 		}
-		js.rpre = fmt.Sprintf("%s%s.", InboxPrefix, b[:aReplyTokensize])
+		inboxPrefix := InboxPrefix
+		if js.nc.Opts.InboxPrefix != _EMPTY_ {
+			inboxPrefix = js.nc.Opts.InboxPrefix + "."
+		}
+		js.rpre = fmt.Sprintf("%s%s.", inboxPrefix, b[:aReplyTokensize])
 		sub, err := js.nc.Subscribe(fmt.Sprintf("%s*", js.rpre), js.handleAsyncReply)
 		if err != nil {
 			js.mu.Unlock()


### PR DESCRIPTION
This PR uses Custom Inbox prefix in JS async reply. It should fix #1189 

Signed-off-by: Guillaume Delbergue <guillaume.delbergue@hiventive.com>