### PR TITLE
Go 1.20 updates, add build tag for rand.Seed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: go
 go:
-- 1.19.x
-- 1.18.x
+- "1.20.x"
+- "1.19.x"
 go_import_path: github.com/nats-io/nats.go
 install:
 - go get -t ./...
-- if [[ "$TRAVIS_GO_VERSION" =~ 1.19 ]]; then
+- if [[ "$TRAVIS_GO_VERSION" =~ 1.20 ]]; then
     go install github.com/mattn/goveralls@latest;
     go install github.com/wadey/gocovmerge@latest;
     go install honnef.co/go/tools/cmd/staticcheck@latest;
@@ -14,12 +14,12 @@ install:
 before_script:
 - $(exit $(go fmt ./... | wc -l))
 - go vet -modfile=go_test.mod ./...
-- if [[ "$TRAVIS_GO_VERSION" =~ 1.19 ]]; then
+- if [[ "$TRAVIS_GO_VERSION" =~ 1.20 ]]; then
     find . -type f -name "*.go" | xargs misspell -error -locale US;
     GOFLAGS="-mod=mod -modfile=go_test.mod" staticcheck ./...;
   fi
 script:
 - go test -modfile=go_test.mod -v -run=TestNoRace -p=1 ./... --failfast -vet=off
-- if [[ "$TRAVIS_GO_VERSION" =~ 1.19 ]]; then ./scripts/cov.sh TRAVIS; else go test -modfile=go_test.mod -race -v -p=1 ./... --failfast -vet=off; fi
+- if [[ "$TRAVIS_GO_VERSION" =~ 1.20 ]]; then ./scripts/cov.sh TRAVIS; else go test -modfile=go_test.mod -race -v -p=1 ./... --failfast -vet=off; fi
 after_success:
-- if [[ "$TRAVIS_GO_VERSION" =~ 1.19 ]]; then $HOME/gopath/bin/goveralls -coverprofile=acc.out -service travis-ci; fi
+- if [[ "$TRAVIS_GO_VERSION" =~ 1.20 ]]; then $HOME/gopath/bin/goveralls -coverprofile=acc.out -service travis-ci; fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nats-io/nats.go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/nats-io/nkeys v0.3.0

--- a/go_test.mod
+++ b/go_test.mod
@@ -1,6 +1,6 @@
 module github.com/nats-io/nats.go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/golang/protobuf v1.4.2

--- a/js_test.go
+++ b/js_test.go
@@ -116,6 +116,7 @@ func TestJetStreamOrderedConsumer(t *testing.T) {
 
 	// Create a sample asset.
 	msg := make([]byte, 1024*1024)
+	//lint:ignore SA1019 crypto/rand.Read is recommended after Go 1.20 but fine for this test.
 	rand.Read(msg)
 	msg = []byte(base64.StdEncoding.EncodeToString(msg))
 	mlen, sum := len(msg), sha256.Sum256(msg)

--- a/nats.go
+++ b/nats.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2022 The NATS Authors
+// Copyright 2012-2023 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -139,10 +139,6 @@ var (
 	ErrMaxConnectionsExceeded = errors.New("nats: server maximum connections exceeded")
 	ErrConnectionNotTLS       = errors.New("nats: connection is not tls")
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 // GetDefaultOptions returns default configuration options for the client.
 func GetDefaultOptions() Options {

--- a/rand.go
+++ b/rand.go
@@ -1,0 +1,29 @@
+// Copyright 2023 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !go1.20
+// +build !go1.20
+
+// A Go client for the NATS messaging system (https://nats.io).
+package nats
+
+import (
+	"math/rand"
+	"time"
+)
+
+func init() {
+	// This is not needed since Go 1.20 because now rand.Seed always happens
+	// by default (uses runtime.fastrand64 instead as source).
+	rand.Seed(time.Now().UnixNano())
+}


### PR DESCRIPTION
Adds Go 1.20 and also deprecates use of rand.Seed in the client for Go +1.20 series since this is now always done by default (https://github.com/golang/go/issues/54880)

Signed-off-by: Waldemar Quevedo <wally@nats.io>