### PR TITLE
Fix TestJetStreamStreamInfoWithSubjectDetails test

### DIFF
--- a/js_test.go
+++ b/js_test.go
@@ -1206,7 +1206,10 @@ func TestJetStreamStreamInfoWithSubjectDetails(t *testing.T) {
 	// Publish on enough subjects to exercise the pagination
 	payload := make([]byte, 10)
 	for i := 0; i < 100001; i++ {
-		nc.Publish(fmt.Sprintf("test.%d", i), payload)
+		_, err := js.Publish(fmt.Sprintf("test.%d", i), payload)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
 	}
 
 	// Check that passing a filter returns the subject details


### PR DESCRIPTION
Since 2.9.15, the server handles inbound messages in a separate execution context, which is an optimisation, but it also means clients can't rely on flushing published messages to ensure that JetStream has it stored and accounted. That behaviour was never guaranteed, and it worked only because of the lack of this optimisation.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>