### PR TITLE
Fix possible race on EncodedConnection LastError

### DIFF
--- a/enc.go
+++ b/enc.go
@@ -265,5 +265,5 @@ func (c *EncodedConn) Drain() error {
 
 // LastError reports the last error encountered via the Connection.
 func (c *EncodedConn) LastError() error {
-	return c.Conn.err
+	return c.Conn.LastError()
 }


### PR DESCRIPTION
accessing the err property of Conn is not thread safe. This uses the getter method with proper locks.