### PR TITLE
Revert Fetch() behavior to not verify request ID

### DIFF
--- a/js.go
+++ b/js.go
@@ -2631,7 +2631,7 @@ func (sub *Subscription) Fetch(batch int, opts ...PullOpt) ([]*Msg, error) {
 
 	nc := sub.conn
 	nms := sub.jsi.nms
-	rply, reqID := newFetchInbox(jsi.deliver)
+	rply, _ := newFetchInbox(jsi.deliver)
 	js := sub.jsi.js
 	pmc := len(sub.mch) > 0
 
@@ -2753,17 +2753,10 @@ func (sub *Subscription) Fetch(batch int, opts ...PullOpt) ([]*Msg, error) {
 					// wait this time.
 					noWait = false
 					err = sendReq()
-				} else if err == ErrTimeout {
+				} else if err == ErrTimeout && len(msgs) == 0 {
 					// If we get a 408, we will bail if we already collected some
 					// messages, otherwise ignore and go back calling nextMsg.
-					if len(msgs) == 0 {
-						err = nil
-						continue
-					}
-					// ignore timeout message from server if it comes from a different pull request
-					if reqID != "" && !subjectMatchesReqID(msg.Subject, reqID) {
-						err = nil
-					}
+					err = nil
 				}
 			}
 		}


### PR DESCRIPTION
This reverts the change from #1237 regarding logic in `Fetch()`. This requires careful consideration and while the fix for `FetchBatch()` is straightforward, in `Fetch()` the logic is a bit more convoluted, since we may be sending more than one pull request within a single `Fetch()`, with/without `no_wait` etc.

`Fetch()` will still be using wildcard subscription and distinct subjects per call, but the logic for ignoring timeouts from different invocations is reverted.