### PR TITLE
[FIXED] Flaky tests picking same ports more than once

### DIFF
--- a/jetstream/test/helper_test.go
+++ b/jetstream/test/helper_test.go
@@ -156,7 +156,8 @@ func setupJSClusterWithSize(t *testing.T, clusterName string, size int) []*jsSer
 	nodes := make([]*jsServer, size)
 	opts := make([]*server.Options, 0)
 
-	getAddr := func() (string, string, int) {
+	var activeListeners []net.Listener
+	getAddr := func(t *testing.T) (string, string, int) {
 		l, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
@@ -166,8 +167,11 @@ func setupJSClusterWithSize(t *testing.T, clusterName string, size int) []*jsSer
 		addr := l.Addr()
 		host := addr.(*net.TCPAddr).IP.String()
 		port := addr.(*net.TCPAddr).Port
-		l.Close()
 		time.Sleep(100 * time.Millisecond)
+
+		// we cannot close the listener immediately to avoid duplicate port binding
+		// the returned net.Listener has to be closed after all ports are drawn
+		activeListeners = append(activeListeners, l)
 		return addr.String(), host, port
 	}
 
@@ -184,17 +188,21 @@ func setupJSClusterWithSize(t *testing.T, clusterName string, size int) []*jsSer
 
 		if size > 1 {
 			o.Cluster.Name = clusterName
-			_, host1, port1 := getAddr()
+			_, host1, port1 := getAddr(t)
 			o.Host = host1
 			o.Port = port1
 
-			addr2, host2, port2 := getAddr()
+			addr2, host2, port2 := getAddr(t)
 			o.Cluster.Host = host2
 			o.Cluster.Port = port2
 			o.Tags = []string{o.ServerName}
 			routes = append(routes, fmt.Sprintf("nats://%s", addr2))
 		}
 		opts = append(opts, &o)
+	}
+	// close all connections used to randomize ports
+	for _, l := range activeListeners {
+		l.Close()
 	}
 
 	if size > 1 {

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -8717,9 +8717,6 @@ func TestJetStreamDirectGetMsg(t *testing.T) {
 }
 
 func TestJetStreamConsumerReplicasOption(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	defer shutdownJSServerAndRemoveStorage(t, s)
-
 	withJSCluster(t, "CR", 3, func(t *testing.T, nodes ...*jsServer) {
 		nc, js := jsClient(t, nodes[0].Server)
 		defer nc.Close()


### PR DESCRIPTION
Some clustered tests were failing with "Unable to start NATS Server in Go Routine" panic from server.

This was most probably caused by client choosing random server/cluster ports, where it sometimes chose same port more than once, as observed by adding this log after each test using `withJSCluster()`

```
=== RUN   TestJetStreamConsumerReplicasOption/TestJetStreamConsumerReplicasOption-3

Server 0 , server name:  NODE_0 , server port:  38473 , cluster port:  44391 , routes:  [127.0.0.1:44391 127.0.0.1:44625 127.0.0.1:38473]

Server 1 , server name:  NODE_1 , server port:  39243 , cluster port:  44625 , routes:  [127.0.0.1:44391 127.0.0.1:44625 127.0.0.1:38473]

Server 2 , server name:  NODE_2 , server port:  45755 , cluster port:  38473 , routes:  [127.0.0.1:44391 127.0.0.1:44625 127.0.0.1:38473]

```

In the example above, the test panicked because server port on Server 0 was the same as cluster port on Server 2.