### PR TITLE
jetstream: fix datarace when using consumer #1279

### DIFF
--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -652,8 +652,7 @@ func (p *pullConsumer) fetch(req *pullRequest) (MessageBatch, error) {
 				}
 				userMsg, err := checkMsg(msg)
 				if err != nil {
-					if !errors.Is(err, nats.ErrTimeout) && !errors.Is(err, ErrNoMessages) && !errors.Is(err,
-						ErrMaxBytesExceeded) {
+					if !errors.Is(err, nats.ErrTimeout) && !errors.Is(err, ErrNoMessages) && !errors.Is(err,ErrMaxBytesExceeded) {
 						res.err = err
 					}
 					res.done = true

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -505,7 +505,6 @@ func (s *pullSubscription) Next() (Msg, error) {
 }
 
 func (s *pullSubscription) handleStatusMsg(msg *nats.Msg, msgErr error) error {
-	s.TryLock()
 	if !errors.Is(msgErr, nats.ErrTimeout) && !errors.Is(msgErr, ErrMaxBytesExceeded) {
 		if s.consumeOpts.ErrHandler != nil {
 			s.consumeOpts.ErrHandler(s, msgErr)

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -652,7 +652,8 @@ func (p *pullConsumer) fetch(req *pullRequest) (MessageBatch, error) {
 				}
 				userMsg, err := checkMsg(msg)
 				if err != nil {
-					if !errors.Is(err, nats.ErrTimeout) && !errors.Is(err, ErrNoMessages) && !errors.Is(err,ErrMaxBytesExceeded) {
+					errNotTimeoutOrNoMsgs := !errors.Is(err, nats.ErrTimeout) && !errors.Is(err, ErrNoMessages)
+					if errNotTimeoutOrNoMsgs && !errors.Is(err, ErrMaxBytesExceeded) {
 						res.err = err
 					}
 					res.done = true


### PR DESCRIPTION
Hi, I opened the issue #1279 and give a try to fix it. It seems that some code using the pending field on the pull struct was not protected at certain point. 

With the help of the stacktrace of the datarace I fixed it.