### PR TITLE
Fix incorrect example in jetstream README

### DIFF
--- a/jetstream/README.md
+++ b/jetstream/README.md
@@ -476,7 +476,7 @@ in the buffer.
 
 ```go
 // a maximum of 10 messages or 1024 bytes will be stored in memory (whichever is encountered first)
-iter, _ := cons.Messages(WithMessagesMaxMessages(10), WithMessagesMaxBytes(1024))
+iter, _ := cons.Messages(jetstream.PullMaxMessages(10), jetstream.PullMaxBytes(1024))
 ```
 
 `Messages()` exposes the following options:


### PR DESCRIPTION
The options right below the example are correct, but the example itself uses what I assume are outdated method names.