### PR TITLE
Release v1.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ When using or transitioning to Go modules support:
 ```bash
 # Go client latest or explicit version
 go get github.com/nats-io/nats.go/@latest
-go get github.com/nats-io/nats.go/@v1.26.0
+go get github.com/nats-io/nats.go/@v1.27.0
 
 # For latest NATS Server, add /v2 at the end
 go get github.com/nats-io/nats-server/v2

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.26.0"
+	Version                   = "1.27.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
## Changelog

### Overview

This release focuses on improvements to new JetStream API and Service API (`micro`) preview functionalities.

### Added

- JetStream Simplified API:
  - `StreamNameBySubject()` method for stream discovery based on provided subject (#1292)

### Improved

- JetStream Simplified API:
  - Simplified lock handling for `Consume()` and `Messages()` (#1303)

### Changed

- JetStream Simplified API:
  - [BREAKING CHANGE] Renamed `AddConsumer` to `CreateOrUpdateConsumer`. This change is introduced in anticipation for separation of create and update operations in `nats-server` (#1300)
  - [BREAKING CHANGE] Change default `AckPolicy` to `AckPolicyExplicit` (#1278)
  - [BREAKING CHANGE] Fixed typo in `PullThresholdBytes` type name (#1300)
  - [BREAKING CHANGE] Removed push consumer only fields from `ConsumerConfig` (#1300)
  - [BREAKING CHANGE] Removed `context.Context` from `PublishAsync` and `PublishMsgAsync` (#1300)
- Service API (`micro`):
  - [BREAKING CHANGE] More verbose endpoint `INFO` schema (#1277)
    -  Endpoint metadata was moved from `STATS` response to `INFO` response
    - `INFO` now returns `endpoints` object, containing subject, name and metatada. This replaces `subject` field.

### Fixed

- JetStream Simplified API:
  - Fixed data race on `ErrNoHeartbeat` (#1291)
  - Fixed incorrect example in `jetstream/README.md`) (#1295)
- Object Store:
  - Fixed leaking goroutines after calling `Put()` and `PutBytes()` (#1282)
- Flaky tests picking the used port for cluster connections (#1284, #1298)
- Division by zero fixes in bechmark tests (#1293)

### Complete Changes

https://github.com/nats-io/nats.go/compare/v1.26.0...v1.27.0