### PR TITLE
[CHANGED] Simplified API for listing streams and stream names, added option to filter by stream name

### DIFF
--- a/jetstream/README.md
+++ b/jetstream/README.md
@@ -165,28 +165,19 @@ js.DeleteStream(ctx, "ORDERS")
 ```go
 // list streams
 streams := js.ListStreams(ctx)
-var err error
-for err == nil {
-    select {
-    case s := <-streams.Info():
-        fmt.Println(s.Config.Name)
-    case err = <-streams.Err():
-    }
+for s := range streams.Info() {
+    fmt.Println(s.Config.Name)
 }
-if err != nil && !errors.Is(err, jetstream.ErrEndOfData) {
+if streams.Err() != nil {
     fmt.Println("Unexpected error ocurred")
 }
 
 // list stream names
 names := js.StreamNames(ctx)
-for err == nil {
-    select {
-    case name := <-names.Name():
-        fmt.Println(name)
-    case err = <-names.Err():
-    }
+for name := range names.Name() {
+    fmt.Println(name)
 }
-if err != nil && !errors.Is(err, jetstream.ErrEndOfData) {
+if names.Err() != nil {
     fmt.Println("Unexpected error ocurred")
 }
 ```
@@ -202,13 +193,13 @@ Using `Stream` interface, it is also possible to:
 _ = s.Purge(ctx)
 
 // remove all messages from a stream that are stored on a specific subject
-_ = s.Purge(ctx, jetstream.WithSubject("ORDERS.new"))
+_ = s.Purge(ctx, jetstream.WithPurgeSubject("ORDERS.new"))
 
 // remove all messages up to specified sequence number
-_ = s.Purge(ctx, jetstream.WithSequence(100))
+_ = s.Purge(ctx, jetstream.WithPurgeSequence(100))
 
 // remove messages, but keep 10 newest
-_ = s.Purge(ctx, jetstream.WithKeep(10))
+_ = s.Purge(ctx, jetstream.WithPurgeKeep(10))
 ```
 
 - Get and messages from stream

--- a/jetstream/README.md
+++ b/jetstream/README.md
@@ -301,29 +301,20 @@ fmt.Println(cachedInfo.Config.Durable)
 ```go
 // list consumers
 consumers := s.ListConsumers(ctx)
-var err error
-for err != nil {
-    select {
-    case s := <-consumers.Info():
-        fmt.Println(s.Name)
-    case err = <-consumers.Err():
-    }
+for cons := range consumers.Info() {
+    fmt.Println(cons.Name)
 }
-if err != nil && !errors.Is(err, jetstream.ErrEndOfData) {
-    fmt.Println("Unexpected error occured")
+if consumers.Err() != nil {
+    fmt.Println("Unexpected error ocurred")
 }
 
 // list consumer names
 names := s.ConsumerNames(ctx)
-for err != nil {
-    select {
-    case name := <-names.Name():
-        fmt.Println(name)
-    case err = <-names.Err():
-    }
+for name := range names.Name() {
+    fmt.Println(name)
 }
-if err != nil && !errors.Is(err, jetstream.ErrEndOfData) {
-    fmt.Println("Unexpected error occured")
+if names.Err() != nil {
+    fmt.Println("Unexpected error ocurred")
 }
 ```
 

--- a/jetstream/options.go
+++ b/jetstream/options.go
@@ -241,6 +241,15 @@ func WithSubjectFilter(subject string) StreamInfoOpt {
 	}
 }
 
+// WithStreamListSubject can be used to filter results of ListStreams and StreamNames requests
+// to only streams that have given subject in their configuration
+func WithStreamListSubject(subject string) StreamListOpt {
+	return func(req *streamsRequest) error {
+		req.Subject = subject
+		return nil
+	}
+}
+
 // WithMsgID sets the message ID used for deduplication.
 func WithMsgID(id string) PublishOpt {
 	return func(opts *pubOpts) error {

--- a/jetstream/test/jetstream_test.go
+++ b/jetstream/test/jetstream_test.go
@@ -955,8 +955,8 @@ func TestStreamNames(t *testing.T) {
 				streams = append(streams, s)
 			}
 			if test.withError != nil {
-			    if !errors.Is(err, test.withError) {
-					t.Fatalf("Expected error: %v; got: %v", test.withError, err)
+				if !errors.Is(streamsList.Err(), test.withError) {
+					t.Fatalf("Expected error: %v; got: %v", test.withError, streamsList.Err())
 				}
 				return
 			}

--- a/jetstream/test/jetstream_test.go
+++ b/jetstream/test/jetstream_test.go
@@ -244,7 +244,7 @@ func TestCreateStream(t *testing.T) {
 			name:      "context timeout",
 			stream:    "foo",
 			subject:   "BAR.123",
-			timeout:   10 * time.Microsecond,
+			timeout:   1 * time.Microsecond,
 			withError: context.DeadlineExceeded,
 		},
 	}
@@ -475,7 +475,7 @@ func TestUpdateStream(t *testing.T) {
 			name:      "context timeout",
 			stream:    "foo",
 			subject:   "FOO.123",
-			timeout:   10 * time.Microsecond,
+			timeout:   1 * time.Microsecond,
 			withError: context.DeadlineExceeded,
 		},
 	}
@@ -563,7 +563,7 @@ func TestStream(t *testing.T) {
 		{
 			name:      "context timeout",
 			stream:    "foo",
-			timeout:   10 * time.Microsecond,
+			timeout:   1 * time.Microsecond,
 			withError: context.DeadlineExceeded,
 		},
 	}
@@ -816,7 +816,7 @@ func TestListStreams(t *testing.T) {
 		{
 			name:       "context timeout",
 			streamsNum: 260,
-			timeout:    10 * time.Microsecond,
+			timeout:    1 * time.Microsecond,
 			withError:  context.DeadlineExceeded,
 		},
 	}
@@ -914,7 +914,7 @@ func TestStreamNames(t *testing.T) {
 		{
 			name:       "context timeout",
 			streamsNum: 500,
-			timeout:    10 * time.Microsecond,
+			timeout:    1 * time.Microsecond,
 			withError:  context.DeadlineExceeded,
 		},
 	}
@@ -1030,7 +1030,7 @@ func TestJetStream_CreateOrUpdateConsumer(t *testing.T) {
 			name:           "context timeout",
 			consumerConfig: jetstream.ConsumerConfig{AckPolicy: jetstream.AckExplicitPolicy},
 			stream:         "foo",
-			timeout:        10 * time.Microsecond,
+			timeout:        1 * time.Microsecond,
 			withError:      context.DeadlineExceeded,
 		},
 	}
@@ -1138,7 +1138,7 @@ func TestJetStream_Consumer(t *testing.T) {
 			name:      "context timeout",
 			stream:    "foo",
 			durable:   "dur",
-			timeout:   10 * time.Microsecond,
+			timeout:   1 * time.Microsecond,
 			withError: context.DeadlineExceeded,
 		},
 	}
@@ -1238,7 +1238,7 @@ func TestJetStream_DeleteConsumer(t *testing.T) {
 			name:      "context timeout",
 			stream:    "foo",
 			durable:   "dur",
-			timeout:   10 * time.Microsecond,
+			timeout:   1 * time.Microsecond,
 			withError: context.DeadlineExceeded,
 		},
 	}
@@ -1337,7 +1337,7 @@ func TestStreamNameBySubject(t *testing.T) {
 		{
 			name:      "context timeout",
 			subject:   "FOO.123",
-			timeout:   10 * time.Microsecond,
+			timeout:   1 * time.Microsecond,
 			withError: context.DeadlineExceeded,
 		},
 	}

--- a/jetstream/test/stream_test.go
+++ b/jetstream/test/stream_test.go
@@ -966,26 +966,17 @@ func TestListConsumers(t *testing.T) {
 			}
 			consumersList := s.ListConsumers(ctx)
 			consumers := make([]*jetstream.ConsumerInfo, 0)
-		Loop:
-			for {
-				select {
-				case s := <-consumersList.Info():
-					consumers = append(consumers, s)
-					if test.withError != nil {
-						t.Fatalf("Expected error: %v; got none", test.withError)
-					}
-				case err := <-consumersList.Err():
-					if test.withError != nil {
-						if !errors.Is(err, test.withError) {
-							t.Fatalf("Expected error: %v; got: %v", test.withError, err)
-						}
-						return
-					}
-					if !errors.Is(err, jetstream.ErrEndOfData) {
-						t.Fatalf("Unexpected error: %v", err)
-					}
-					break Loop
+			for s := range consumersList.Info() {
+				consumers = append(consumers, s)
+			}
+			if test.withError != nil {
+				if !errors.Is(consumersList.Err(), test.withError) {
+					t.Fatalf("Expected error: %v; got: %v", test.withError, consumersList.Err())
 				}
+				return
+			}
+			if consumersList.Err() != nil {
+				t.Fatalf("Unexpected error: %v", consumersList.Err())
 			}
 			if len(consumers) != test.consumersNum {
 				t.Fatalf("Wrong number of streams; want: %d; got: %d", test.consumersNum, len(consumers))
@@ -1055,26 +1046,17 @@ func TestConsumerNames(t *testing.T) {
 			}
 			consumersList := s.ConsumerNames(ctx)
 			consumers := make([]string, 0)
-		Loop:
-			for {
-				select {
-				case s := <-consumersList.Name():
-					consumers = append(consumers, s)
-					if test.withError != nil {
-						t.Fatalf("Expected error: %v; got none", test.withError)
-					}
-				case err := <-consumersList.Err():
-					if test.withError != nil {
-						if !errors.Is(err, test.withError) {
-							t.Fatalf("Expected error: %v; got: %v", test.withError, err)
-						}
-						return
-					}
-					if !errors.Is(err, jetstream.ErrEndOfData) {
-						t.Fatalf("Unexpected error: %v", err)
-					}
-					break Loop
+			for name := range consumersList.Name() {
+				consumers = append(consumers, name)
+			}
+			if test.withError != nil {
+				if !errors.Is(consumersList.Err(), test.withError) {
+					t.Fatalf("Expected error: %v; got: %v", test.withError, consumersList.Err())
 				}
+				return
+			}
+			if consumersList.Err() != nil {
+				t.Fatalf("Unexpected error: %v", consumersList.Err())
 			}
 			if len(consumers) != test.consumersNum {
 				t.Fatalf("Wrong number of streams; want: %d; got: %d", test.consumersNum, len(consumers))

--- a/jetstream/test/stream_test.go
+++ b/jetstream/test/stream_test.go
@@ -295,7 +295,7 @@ func TestStreamInfo(t *testing.T) {
 		},
 		{
 			name:      "context timeout",
-			timeout:   10 * time.Microsecond,
+			timeout:   1 * time.Microsecond,
 			withError: context.DeadlineExceeded,
 		},
 	}
@@ -486,7 +486,7 @@ func TestGetMsg(t *testing.T) {
 		{
 			name:      "context timeout",
 			seq:       1,
-			timeout:   10 * time.Microsecond,
+			timeout:   1 * time.Microsecond,
 			withError: context.DeadlineExceeded,
 		},
 	}
@@ -650,7 +650,7 @@ func TestGetLastMsgForSubject(t *testing.T) {
 		{
 			name:      "context timeout",
 			subject:   "*.A",
-			timeout:   10 * time.Microsecond,
+			timeout:   1 * time.Microsecond,
 			withError: context.DeadlineExceeded,
 		},
 	}
@@ -764,7 +764,7 @@ func TestDeleteMsg(t *testing.T) {
 		{
 			name:      "context timeout",
 			seq:       1,
-			timeout:   10 * time.Microsecond,
+			timeout:   1 * time.Microsecond,
 			withError: context.DeadlineExceeded,
 		},
 	}
@@ -929,7 +929,7 @@ func TestListConsumers(t *testing.T) {
 		{
 			name:         "context timeout",
 			consumersNum: 500,
-			timeout:      10 * time.Microsecond,
+			timeout:      1 * time.Microsecond,
 			withError:    context.DeadlineExceeded,
 		},
 	}
@@ -1009,7 +1009,7 @@ func TestConsumerNames(t *testing.T) {
 		{
 			name:         "context timeout",
 			consumersNum: 500,
-			timeout:      10 * time.Microsecond,
+			timeout:      1 * time.Microsecond,
 			withError:    context.DeadlineExceeded,
 		},
 	}
@@ -1119,7 +1119,7 @@ func TestPurgeStream(t *testing.T) {
 		},
 		{
 			name:      "context timeout",
-			timeout:   10 * time.Microsecond,
+			timeout:   1 * time.Microsecond,
 			withError: context.DeadlineExceeded,
 		},
 	}


### PR DESCRIPTION
- `ListStreams` and `StreamNames` now allow for iterating over returned channel (channel is always closed)
- `ListStreams` and `StreamNames` now both accept `WithStreamListSubject` for filtering out returned streams