### PR TITLE
Fix Race condition in object store with nats context

### DIFF
--- a/object.go
+++ b/object.go
@@ -622,6 +622,7 @@ func (obs *obs) Get(name string, opts ...GetObjectOpt) (ObjectResult, error) {
 	result.digest = sha256.New()
 
 	processChunk := func(m *Msg) {
+		var err error
 		if ctx != nil {
 			select {
 			case <-ctx.Done():

--- a/test/object_test.go
+++ b/test/object_test.go
@@ -97,6 +97,12 @@ func TestObjectBasics(t *testing.T) {
 	expectOk(t, result.Error())
 	defer result.Close()
 
+	// Now get the object back with a context option.
+	result, err = obs.Get("BLOB", nats.Context(context.Background()))
+	expectOk(t, err)
+	expectOk(t, result.Error())
+	defer result.Close()
+
 	// Check info.
 	info, err = result.Info()
 	expectOk(t, err)


### PR DESCRIPTION
The `err` variable can be accessed in separate `goroutines` and that causes a race condition. This is demonstrated in the `object_test` file.

It doesn't look like the `err` in the `processChunk` function needs to be the same error used elsewhere in the `Get` method. By creating an `err` variable in the `processChunk` function, there is no race condition anymore.

Close #1313 