### PR TITLE
Create consumer on OrderedConsumer, add missing tests

### DIFF
--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -473,6 +473,10 @@ func (js *jetStream) OrderedConsumer(ctx context.Context, stream string, cfg Ord
 	if cfg.OptStartSeq != 0 {
 		oc.cursor.streamSeq = cfg.OptStartSeq - 1
 	}
+	err := oc.reset()
+	if err != nil {
+		return nil, err
+	}
 
 	return oc, nil
 }

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -638,7 +638,9 @@ func (p *pullConsumer) fetch(req *pullRequest) (MessageBatch, error) {
 		defer close(res.msgs)
 		for {
 			if receivedMsgs == req.Batch || (req.MaxBytes != 0 && receivedBytes == req.MaxBytes) {
+				p.Lock()
 				res.done = true
+				p.Unlock()
 				return
 			}
 			select {

--- a/jetstream/stream.go
+++ b/jetstream/stream.go
@@ -208,6 +208,10 @@ func (s *stream) OrderedConsumer(ctx context.Context, cfg OrderedConsumerConfig)
 	if cfg.OptStartSeq != 0 {
 		oc.cursor.streamSeq = cfg.OptStartSeq - 1
 	}
+	err := oc.reset()
+	if err != nil {
+		return nil, err
+	}
 
 	return oc, nil
 }

--- a/jetstream/test/helper_test.go
+++ b/jetstream/test/helper_test.go
@@ -322,3 +322,19 @@ func restartBasicJSServer(t *testing.T, s *server.Server) *server.Server {
 	s.WaitForShutdown()
 	return RunServerWithOptions(opts)
 }
+
+func checkFor(t *testing.T, totalWait, sleepDur time.Duration, f func() error) {
+	t.Helper()
+	timeout := time.Now().Add(totalWait)
+	var err error
+	for time.Now().Before(timeout) {
+		err = f()
+		if err == nil {
+			return
+		}
+		time.Sleep(sleepDur)
+	}
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}

--- a/jetstream/test/ordered_test.go
+++ b/jetstream/test/ordered_test.go
@@ -402,6 +402,281 @@ func TestOrderedConsumerFetch(t *testing.T) {
 			t.Fatalf("Expected error: %s; got: %s", jetstream.ErrOrderConsumerUsedAsConsume, err)
 		}
 	})
+
+	t.Run("concurrent fetch requests", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		publishTestMsgs(t, nc)
+		res, err := c.Fetch(1, jetstream.FetchMaxWait(100*time.Millisecond))
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		_, err = c.Fetch(1)
+		if !errors.Is(err, jetstream.ErrOrderedConsumerConcurrentRequests) {
+			t.Fatalf("Expected error: %s; got: %s", jetstream.ErrOrderedConsumerConcurrentRequests, err)
+		}
+		for msg := range res.Messages() {
+			msg.Ack()
+		}
+	})
+}
+
+func TestOrderedConsumerFetchBytes(t *testing.T) {
+	testSubject := "FOO.123"
+	testMsgs := []string{"m1", "m2", "m3", "m4", "m5"}
+	publishTestMsgs := func(t *testing.T, nc *nats.Conn) {
+		for _, msg := range testMsgs {
+			if err := nc.Publish(testSubject, []byte(msg)); err != nil {
+				t.Fatalf("Unexpected error during publish: %s", err)
+			}
+		}
+	}
+	t.Run("base usage, delete consumer", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		msgs := make([]jetstream.Msg, 0)
+
+		publishTestMsgs(t, nc)
+		res, err := c.FetchBytes(500, jetstream.FetchMaxWait(100*time.Millisecond))
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		for msg := range res.Messages() {
+			msgs = append(msgs, msg)
+		}
+		if res.Error() != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		name := c.CachedInfo().Name
+		if err := s.DeleteConsumer(ctx, name); err != nil {
+			t.Fatal(err)
+		}
+		publishTestMsgs(t, nc)
+		res, err = c.Fetch(500, jetstream.FetchMaxWait(100*time.Millisecond))
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		for msg := range res.Messages() {
+			msgs = append(msgs, msg)
+		}
+		if res.Error() != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if len(msgs) != 2*len(testMsgs) {
+			t.Fatalf("Expected %d messages; got: %d", 2*len(testMsgs), len(msgs))
+		}
+	})
+
+	t.Run("consumer used as consume", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		cc, err := c.Consume(func(msg jetstream.Msg) {})
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		cc.Stop()
+
+		_, err = c.FetchBytes(500)
+		if !errors.Is(err, jetstream.ErrOrderConsumerUsedAsConsume) {
+			t.Fatalf("Expected error: %s; got: %s", jetstream.ErrOrderConsumerUsedAsConsume, err)
+		}
+	})
+
+	t.Run("concurrent fetch requests", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		publishTestMsgs(t, nc)
+		res, err := c.FetchBytes(500, jetstream.FetchMaxWait(100*time.Millisecond))
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		_, err = c.FetchBytes(500)
+		if !errors.Is(err, jetstream.ErrOrderedConsumerConcurrentRequests) {
+			t.Fatalf("Expected error: %s; got: %s", jetstream.ErrOrderedConsumerConcurrentRequests, err)
+		}
+		for msg := range res.Messages() {
+			msg.Ack()
+		}
+	})
+}
+
+func TestOrderedConsumerNext(t *testing.T) {
+	testSubject := "FOO.123"
+	testMsgs := []string{"m1", "m2", "m3", "m4", "m5"}
+	publishTestMsgs := func(t *testing.T, nc *nats.Conn) {
+		for _, msg := range testMsgs {
+			if err := nc.Publish(testSubject, []byte(msg)); err != nil {
+				t.Fatalf("Unexpected error during publish: %s", err)
+			}
+		}
+	}
+	t.Run("base usage, delete consumer", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		publishTestMsgs(t, nc)
+		msg, err := c.Next()
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		msg.Ack()
+
+		name := c.CachedInfo().Name
+		if err := s.DeleteConsumer(ctx, name); err != nil {
+			t.Fatal(err)
+		}
+		msg, err = c.Next()
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		msg.Ack()
+	})
+
+	t.Run("consumer used as consume", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		cc, err := c.Consume(func(msg jetstream.Msg) {})
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		cc.Stop()
+
+		_, err = c.Next()
+		if !errors.Is(err, jetstream.ErrOrderConsumerUsedAsConsume) {
+			t.Fatalf("Expected error: %s; got: %s", jetstream.ErrOrderConsumerUsedAsConsume, err)
+		}
+	})
 }
 
 func TestOrderedConsumerFetchNoWait(t *testing.T) {
@@ -531,7 +806,7 @@ func TestOrderedConsumerInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	c, err := s.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{})
+	c, err := js.OrderedConsumer(ctx, "foo", jetstream.OrderedConsumerConfig{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/jetstream/test/ordered_test.go
+++ b/jetstream/test/ordered_test.go
@@ -810,14 +810,6 @@ func TestOrderedConsumerInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	_, err = c.Info(ctx)
-	if !errors.Is(err, jetstream.ErrOrderedConsumerNotCreated) {
-		t.Fatalf("Expected error: %v; got: %v", jetstream.ErrOrderedConsumerNotCreated, err)
-	}
-	info := c.CachedInfo()
-	if info != nil {
-		t.Fatalf("Cached info should be nil if consumer is not yet created")
-	}
 
 	cc, err := c.Consume(func(msg jetstream.Msg) {})
 	if err != nil {
@@ -825,7 +817,7 @@ func TestOrderedConsumerInfo(t *testing.T) {
 	}
 	defer cc.Stop()
 
-	info, err = c.Info(ctx)
+	info, err := c.Info(ctx)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}


### PR DESCRIPTION
- Previously client was lazily initializing consumer when `OrderedConsumer` was used, but that made `Info()` return an error if invoked before consuming messages
- Added some missing unit tests