### PR TITLE
New JetStream client docs: Fixed unit from kB to B in documentation o…

### DIFF
--- a/jetstream/README.md
+++ b/jetstream/README.md
@@ -381,7 +381,7 @@ if msgs.Error() != nil {
     // handle error
 }
 
-// receive up to 1024kB of data
+// receive up to 1024 B of data
 msgs, _ := c.FetchBytes(1024)
 for msg := range msgs.Messages() {
     fmt.Printf("Received a JetStream message: %s\n", string(msg.Data()))


### PR DESCRIPTION
The number argument of the consumer's FetchBytes method means bytes, not kilobytes.
Fixed the comment.