### PR TITLE
Release v1.27.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ When using or transitioning to Go modules support:
 ```bash
 # Go client latest or explicit version
 go get github.com/nats-io/nats.go/@latest
-go get github.com/nats-io/nats.go/@v1.27.0
+go get github.com/nats-io/nats.go/@v1.27.1
 
 # For latest NATS Server, add /v2 at the end
 go get github.com/nats-io/nats-server/v2

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.27.0"
+	Version                   = "1.27.1"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
### Improved

- JetStream Simplified API:
  - Fixed unit from kB to B for `FetchBytes()` in `jetstream/README.md` (#1329)
  - Add param names in API interfaces to better document the code (#1316)

### Fixed

- JetStream Simplified API:
  - Use custom inbox prefix set on `nats.Conn` for pull requests (#1322)
- Object Store:
  - Fixed race condition in object store when `nats.Context` is used (#1314)
- JetStream:
  - Fixed creating a consumer with `Durable` not set on server versions prior to 2.9.0 (#1325)

### Complete Changes

https://github.com/nats-io/nats.go/compare/v1.27.0...v1.27.1