### PR TITLE
[FIXED] Correct input for "parse 0" test case

### DIFF
--- a/internal/parser/parse_test.go
+++ b/internal/parser/parse_test.go
@@ -35,7 +35,7 @@ func TestParseNum(t *testing.T) {
 		},
 		{
 			name:     "parse 0",
-			given:    "",
+			given:    "0",
 			expected: 0,
 		},
 		{


### PR DESCRIPTION
# Resolve issue #1333

This change aligns the input with the name of the test case and ensures that the function is accurately tested with this input.