### PR TITLE
fixed + slightly enhanced the basic example in jetstream package

### DIFF
--- a/jetstream/README.md
+++ b/jetstream/README.md
@@ -62,71 +62,80 @@ experimenting with the new APIs as soon as possible.
 ## Basic usage
 
 ```go
-import (
-    "context"
-    "fmt"
-    "time"
+package main
 
-    "github.com/nats-io/nats.go"
-    "github.com/nats-io/nats.go/jetstream"
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 )
 
 func main() {
-    // In the `jetstream` package, almost all API calls rely on `context.Context` for timeout/cancellation handling
-    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-    defer cancel()
-    nc, _ := nats.Connect(nats.DefaultURL)
+	// In the `jetstream` package, almost all API calls rely on `context.Context` for timeout/cancellation handling
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	nc, _ := nats.Connect(nats.DefaultURL)
 
-    // Create a JetStream management interface
-    js, _ := jetstream.New(nc)
+	// Create a JetStream management interface
+	js, _ := jetstream.New(nc)
 
-    // Create a stream
-    s, _ := js.CreateStream(ctx, jetstream.StreamConfig{
-        Name:     "ORDERS",
-        Subjects: []string{"ORDERS.*"},
-    })
+	// Create a stream
+	s, _ := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "ORDERS",
+		Subjects: []string{"ORDERS.*"},
+	})
 
-    // Publish some messages
-    for i := 0; i < 100; i++ {
-        js.Publish(ctx, "ORDERS.new", []byte("hello"))
-    }
+	// Publish some messages
+	for i := 0; i < 100; i++ {
+		js.Publish(ctx, "ORDERS.new", []byte("hello message "+strconv.Itoa(i)))
+		fmt.Printf("Published hello message %d\n", i)
+	}
 
-    // Create durable consumer
-    c, _ := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
-        Durable:   "CONS",
-        AckPolicy: jetstream.AckExplicitPolicy,
-    })
+	// Create durable consumer
+	c, _ := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+		Durable:   "CONS",
+		AckPolicy: jetstream.AckExplicitPolicy,
+	})
 
-    // Get 10 messages from the consumer
-    msgs, _ := c.Fetch(10)
-    var msg jetstream.Msg
-    for msg := range msgs.Messages() {
-        msg.Ack()
-        fmt.Printf("Received a JetStream message: %s\n", string(msg.Data()))
-    }
-    if msgs.Error() {
-        fmt.Println("Error during Fetch(): ", msgs.Error())
-    }
+	// Get 10 messages from the consumer
+	messageCounter := 0
+	msgs, _ := c.Fetch(10)
+	for msg := range msgs.Messages() {
+		msg.Ack()
+		fmt.Printf("Received a JetStream message via fetch: %s\n", string(msg.Data()))
+		messageCounter++
+	}
+	fmt.Printf("received %d messages\n", messageCounter)
+	if msgs.Error() != nil {
+		fmt.Println("Error during Fetch(): ", msgs.Error())
+	}
 
-    // Receive messages continuously in a callback
-    cons, _ := c.Consume(ctx, func(msg jetstream.Msg) {
-        msg.Ack()
-        fmt.Printf("Received a JetStream message: %s\n", string(msg.Data()))
-    })
-    defer cons.Stop()
+	// Receive messages continuously in a callback
+	cons, _ := c.Consume(func(msg jetstream.Msg) {
+		msg.Ack()
+		fmt.Printf("Received a JetStream message via callback: %s\n", string(msg.Data()))
+		messageCounter++
+	})
+	defer cons.Stop()
 
+	// Iterate over messages continuously
+	it, _ := c.Messages()
+	for i := 0; i < 10; i++ {
+		msg, _ := it.Next()
+		msg.Ack()
+		fmt.Printf("Received a JetStream message via iterator: %s\n", string(msg.Data()))
+		messageCounter++
+	}
+	it.Stop()
 
-    // Iterate over messages continuously
-    it, _ := cons.Messages()
-    for i := 0; i < 10; i++ {
-        msg, err := it.Next()
-        if err != nil {
-            log.Fatal(err)
-        }
-        msg.Ack()
-        fmt.Println("Received a JetStream message: %s\n", string(msg.Data()))
-    }
-    it.Stop()
+	// block until all 100 published messages have been processed
+	for messageCounter < 100 {
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 ```
 


### PR DESCRIPTION
When trying to get started with jetstream, I couldn't compile the basic example that was given in the `README.md`. One of the variables was never read (`var msg jetstream.Msg`), one check for a bool was not against a bool (`if msgs.Error() {`), `cons` is actually not the consumer but `c` is (`it, _ := cons.Messages()`), and a few more things (see new code).

I also made it clear in the console output which receiving type was used to get the particular message (fetch vs. callback vs. iterator).

This now compiles fine, and the crude loop at the end also waits for all test messages to be received as well. Dirty (like omitting all checks for `err`), but it should be enough to grasp the basic concepts.

