### PR TITLE
JetStream API: Fix `Next()` blocking indefinitely after calling `Stop()`

### DIFF
--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -438,6 +438,8 @@ func (s *pullSubscription) Next() (Msg, error) {
 	for {
 		s.checkPending()
 		select {
+		case <-s.done:
+			return nil, ErrMsgIteratorClosed
 		case msg := <-s.msgs:
 			if hbMonitor != nil {
 				hbMonitor.Reset(2 * s.consumeOpts.Heartbeat)

--- a/jetstream/test/pull_test.go
+++ b/jetstream/test/pull_test.go
@@ -1279,7 +1279,7 @@ func TestPullConsumerMessages(t *testing.T) {
 			t.Fatal("Timed out waiting for Next() to return after Stop()")
 		case err := <-errs:
 			if !errors.Is(err, jetstream.ErrMsgIteratorClosed) {
-				t.Fatalf("Unexpected error: %s", err)
+				t.Fatalf("Unexpected error: %v", err)
 			}
 
 			if len(msgs) != len(testMsgs) {


### PR DESCRIPTION
This is a fix for the issue #1343.
I have included a test showing the issue.