### PR TITLE
Release v1.28.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ When using or transitioning to Go modules support:
 ```bash
 # Go client latest or explicit version
 go get github.com/nats-io/nats.go/@latest
-go get github.com/nats-io/nats.go/@v1.27.1
+go get github.com/nats-io/nats.go/@v1.28.0
 
 # For latest NATS Server, add /v2 at the end
 go get github.com/nats-io/nats-server/v2

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.27.1"
+	Version                   = "1.28.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
### Overview

This release focuses on a set of changes and improvements in new JetStream API. With this release, JetStream API is out of preview.
Additionally, with this release support for go version < 1.18.0 is dropped, due to usage of `any` type in codebase.

### Added
- JetStream:
  - `HeadersOnly` field on `OrderedConsumerConfig` (#1327)
  - `WithStreamListSubject()` option to filter results of `ListStreams()` and `StreamNames()` by stream name (#1312)

### Improved

- Added `dev` and `main` branches of `nats-server` to tests in CI (#1336)
- Core NATS:
  - Fixed incorrect test case in `parse_test.go` (#1334) 
 - JetStream:
   - Fix typos and doc comments in new JetStream API (#1339)
   - Fixed and slightly enhanced the basic example in jetstream package (#1340)
   - Improvements in in `jetstream/README.md` (#1347, #1350)

### Changed

- Replace `interface{}` with `any` across the codebase (#1332)
- JetStream:
  - [BREAKING CHANGE] Move `NakWithDelay` to separate method, instead of it being an option on `Nak()` (#1337)
  - [BREAKING CHANGE] Simplified API for listing streams and stream names (#1312)
  - Add default timeout when `context.Background()` or `context.TODO()` is used (#1348)

### Fixed

- JetStream:
  - Create consumer when calling `OrderedConsumer()` (#1317)
  - Unset start time for ordered consumer on reset (#1341)
  - Fixed `Next()` blocking indefinitely after calling `Stop()` (#1344)
  - Invalid missing heartbeat errors in `Consume()` (#1345)
  - Fixed `PublishAsync()` blocking published due to `PublishAsyncMaxPending` not being reset on reconnect (#1346)
- Legacy JetStream:
  - Fixed `PublishAsync()` blocking published due to `PublishAsyncMaxPending` not being reset on reconnect (#1346)