### PR TITLE
Fix deadlock caused by locked mutex

### DIFF
--- a/jetstream/message.go
+++ b/jetstream/message.go
@@ -218,6 +218,7 @@ func (m *jetStreamMsg) ackReply(ctx context.Context, ackType ackType, sync bool,
 
 	m.Lock()
 	if m.ackd {
+		m.Unlock()
 		return ErrMsgAlreadyAckd
 	}
 	m.Unlock()


### PR DESCRIPTION
Mutex must be unlocked on return from function.