### PR TITLE
Increase maximum history for kv entries

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -237,7 +237,7 @@ type KeyValueConfig struct {
 
 // Used to watch all keys.
 const (
-	KeyValueMaxHistory = 64
+	KeyValueMaxHistory = 255
 	AllKeys            = ">"
 	kvLatestRevision   = 0
 	kvop               = "KV-Operation"


### PR DESCRIPTION
This change increases the maximum amount of history messages a Key Value entry contains.
Related issue https://github.com/nats-io/nats.go/issues/1365