### PR TITLE
[ADDED] AutoStopAfter options to Consumer Consume() and Messages()

### DIFF
--- a/jetstream/options.go
+++ b/jetstream/options.go
@@ -212,7 +212,7 @@ type AutoStopAfter int
 
 func (nMsgs AutoStopAfter) configureConsume(opts *consumeOpts) error {
 	if nMsgs <= 0 {
-		return fmt.Errorf("%w: invalid auto stop after value", ErrInvalidOption)
+		return fmt.Errorf("%w: auto stop after value cannot be less than 1", ErrInvalidOption)
 	}
 	opts.AutoStopAfter = int(nMsgs)
 	return nil
@@ -220,7 +220,7 @@ func (nMsgs AutoStopAfter) configureConsume(opts *consumeOpts) error {
 
 func (nMsgs AutoStopAfter) configureMessages(opts *consumeOpts) error {
 	if nMsgs <= 0 {
-		return fmt.Errorf("%w: invalid auto stop after value", ErrInvalidOption)
+		return fmt.Errorf("%w: auto stop after value cannot be less than 1", ErrInvalidOption)
 	}
 	opts.AutoStopAfter = int(nMsgs)
 	return nil

--- a/jetstream/options.go
+++ b/jetstream/options.go
@@ -207,22 +207,22 @@ func (hb PullHeartbeat) configureMessages(opts *consumeOpts) error {
 	return nil
 }
 
-// AutoStopAfter sets the number of messages after which the consumer is automatically stopped
-type AutoStopAfter int
+// StopAfter sets the number of messages after which the consumer is automatically stopped
+type StopAfter int
 
-func (nMsgs AutoStopAfter) configureConsume(opts *consumeOpts) error {
+func (nMsgs StopAfter) configureConsume(opts *consumeOpts) error {
 	if nMsgs <= 0 {
 		return fmt.Errorf("%w: auto stop after value cannot be less than 1", ErrInvalidOption)
 	}
-	opts.AutoStopAfter = int(nMsgs)
+	opts.StopAfter = int(nMsgs)
 	return nil
 }
 
-func (nMsgs AutoStopAfter) configureMessages(opts *consumeOpts) error {
+func (nMsgs StopAfter) configureMessages(opts *consumeOpts) error {
 	if nMsgs <= 0 {
 		return fmt.Errorf("%w: auto stop after value cannot be less than 1", ErrInvalidOption)
 	}
-	opts.AutoStopAfter = int(nMsgs)
+	opts.StopAfter = int(nMsgs)
 	return nil
 }
 

--- a/jetstream/options.go
+++ b/jetstream/options.go
@@ -197,6 +197,17 @@ func (hb PullHeartbeat) configureMessages(opts *consumeOpts) error {
 	return nil
 }
 
+// AutoUnsubscribeAfter
+type PullAutoUnsubscribeAfter int
+
+func (t PullAutoUnsubscribeAfter) configureConsume(opts *consumeOpts) error {
+	if t <= 0 {
+		return fmt.Errorf("%w: invalide auto unsubscribe after value", ErrInvalidOption)
+	}
+	opts.PullAutoUnsubscribeAfter = int(t)
+	return nil
+}
+
 // ConsumeErrHandler sets custom error handler invoked when an error was encountered while consuming messages
 // It will be invoked for both terminal (Consumer Deleted, invalid request body) and non-terminal (e.g. missing heartbeats) errors
 func ConsumeErrHandler(cb ConsumeErrHandlerFunc) PullConsumeOpt {

--- a/jetstream/options.go
+++ b/jetstream/options.go
@@ -164,11 +164,21 @@ func (t PullThresholdMessages) configureConsume(opts *consumeOpts) error {
 	return nil
 }
 
+func (t PullThresholdMessages) configureMessages(opts *consumeOpts) error {
+	opts.ThresholdMessages = int(t)
+	return nil
+}
+
 // PullThresholdBytes sets the byte count on which Consume will trigger
 // new pull request to the server. Defaults to 50% of MaxBytes (if set).
 type PullThresholdBytes int
 
 func (t PullThresholdBytes) configureConsume(opts *consumeOpts) error {
+	opts.ThresholdBytes = int(t)
+	return nil
+}
+
+func (t PullThresholdBytes) configureMessages(opts *consumeOpts) error {
 	opts.ThresholdBytes = int(t)
 	return nil
 }
@@ -202,7 +212,7 @@ type AutoStopAfter int
 
 func (nMsgs AutoStopAfter) configureConsume(opts *consumeOpts) error {
 	if nMsgs <= 0 {
-		return fmt.Errorf("%w: invalide auto unsubscribe after value", ErrInvalidOption)
+		return fmt.Errorf("%w: invalid auto stop after value", ErrInvalidOption)
 	}
 	opts.AutoStopAfter = int(nMsgs)
 	return nil
@@ -210,7 +220,7 @@ func (nMsgs AutoStopAfter) configureConsume(opts *consumeOpts) error {
 
 func (nMsgs AutoStopAfter) configureMessages(opts *consumeOpts) error {
 	if nMsgs <= 0 {
-		return fmt.Errorf("%w: invalid auto unsubscribe after value", ErrInvalidOption)
+		return fmt.Errorf("%w: invalid auto stop after value", ErrInvalidOption)
 	}
 	opts.AutoStopAfter = int(nMsgs)
 	return nil

--- a/jetstream/options.go
+++ b/jetstream/options.go
@@ -197,14 +197,22 @@ func (hb PullHeartbeat) configureMessages(opts *consumeOpts) error {
 	return nil
 }
 
-// AutoUnsubscribeAfter
-type PullAutoUnsubscribeAfter int
+// AutoStopAfter sets the number of messages after which the consumer is automatically stopped
+type AutoStopAfter int
 
-func (t PullAutoUnsubscribeAfter) configureConsume(opts *consumeOpts) error {
-	if t <= 0 {
+func (nMsgs AutoStopAfter) configureConsume(opts *consumeOpts) error {
+	if nMsgs <= 0 {
 		return fmt.Errorf("%w: invalide auto unsubscribe after value", ErrInvalidOption)
 	}
-	opts.PullAutoUnsubscribeAfter = int(t)
+	opts.AutoStopAfter = int(nMsgs)
+	return nil
+}
+
+func (nMsgs AutoStopAfter) configureMessages(opts *consumeOpts) error {
+	if nMsgs <= 0 {
+		return fmt.Errorf("%w: invalid auto unsubscribe after value", ErrInvalidOption)
+	}
+	opts.AutoStopAfter = int(nMsgs)
 	return nil
 }
 

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -72,14 +72,15 @@ type (
 	}
 
 	consumeOpts struct {
-		Expires                 time.Duration
-		MaxMessages             int
-		MaxBytes                int
-		Heartbeat               time.Duration
-		ErrHandler              ConsumeErrHandlerFunc
-		ReportMissingHeartbeats bool
-		ThresholdMessages       int
-		ThresholdBytes          int
+		Expires                  time.Duration
+		MaxMessages              int
+		MaxBytes                 int
+		Heartbeat                time.Duration
+		ErrHandler               ConsumeErrHandlerFunc
+		ReportMissingHeartbeats  bool
+		ThresholdMessages        int
+		ThresholdBytes           int
+		PullAutoUnsubscribeAfter int
 	}
 
 	ConsumeErrHandlerFunc func(consumeCtx ConsumeContext, err error)
@@ -99,6 +100,7 @@ type (
 		connStatusChanged chan nats.Status
 		fetchNext         chan *pullRequest
 		consumeOpts       *consumeOpts
+		delivered         int
 	}
 
 	pendingMsgs struct {
@@ -132,6 +134,13 @@ const (
 	DefaultHeartbeat   = 5 * time.Second
 	unset              = -1
 )
+
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
 
 // Consume returns a ConsumeContext, allowing for processing incoming messages from a stream in a given callback function.
 //
@@ -214,7 +223,12 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 		handler(p.jetStream.toJSMsg(msg))
 		sub.Lock()
 		sub.decrementPendingMsgs(msg)
+		sub.incrementDeliveredMsgs()
 		sub.Unlock()
+
+		if sub.consumeOpts.PullAutoUnsubscribeAfter != 0 && sub.consumeOpts.PullAutoUnsubscribeAfter == sub.delivered {
+			sub.Stop()
+		}
 	}
 	inbox := p.jetStream.conn.NewInbox()
 	sub.subscription, err = p.jetStream.conn.Subscribe(inbox, internalHandler)
@@ -225,9 +239,13 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 	sub.Lock()
 	// initial pull
 	sub.resetPendingMsgs()
+	batchSize := sub.consumeOpts.MaxMessages
+	if sub.consumeOpts.PullAutoUnsubscribeAfter != 0 {
+		batchSize = min(batchSize, sub.consumeOpts.PullAutoUnsubscribeAfter-sub.delivered)
+	}
 	if err := sub.pull(&pullRequest{
 		Expires:   consumeOpts.Expires,
-		Batch:     consumeOpts.MaxMessages,
+		Batch:     batchSize,
 		MaxBytes:  consumeOpts.MaxBytes,
 		Heartbeat: consumeOpts.Heartbeat,
 	}, subject); err != nil {
@@ -276,10 +294,13 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 							}
 							time.Sleep(5 * time.Second)
 						}
-
+						batchSize := sub.consumeOpts.MaxMessages
+						if sub.consumeOpts.PullAutoUnsubscribeAfter != 0 {
+							min(batchSize, sub.consumeOpts.PullAutoUnsubscribeAfter-sub.delivered)
+						}
 						sub.fetchNext <- &pullRequest{
 							Expires:   sub.consumeOpts.Expires,
-							Batch:     sub.consumeOpts.MaxMessages,
+							Batch:     batchSize,
 							MaxBytes:  sub.consumeOpts.MaxBytes,
 							Heartbeat: sub.consumeOpts.Heartbeat,
 						}
@@ -293,9 +314,13 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 					sub.consumeOpts.ErrHandler(sub, err)
 				}
 				if errors.Is(err, ErrNoHeartbeat) {
+					batchSize := sub.consumeOpts.MaxMessages
+					if sub.consumeOpts.PullAutoUnsubscribeAfter != 0 {
+						min(batchSize, sub.consumeOpts.PullAutoUnsubscribeAfter-sub.delivered)
+					}
 					sub.fetchNext <- &pullRequest{
 						Expires:   sub.consumeOpts.Expires,
-						Batch:     sub.consumeOpts.MaxMessages,
+						Batch:     batchSize,
 						MaxBytes:  sub.consumeOpts.MaxBytes,
 						Heartbeat: sub.consumeOpts.Heartbeat,
 					}
@@ -328,6 +353,12 @@ func (s *pullSubscription) decrementPendingMsgs(msg *nats.Msg) {
 	}
 }
 
+// incrementDeliveredMsgs decrements pending message count and byte count
+// lock should be held before calling this method
+func (s *pullSubscription) incrementDeliveredMsgs() {
+	s.delivered++
+}
+
 // checkPending verifies whether there are enough messages in
 // the buffer to trigger a new pull request.
 // lock should be held before calling this method
@@ -335,16 +366,21 @@ func (s *pullSubscription) checkPending() {
 	if s.pending.msgCount < s.consumeOpts.ThresholdMessages ||
 		(s.pending.byteCount < s.consumeOpts.ThresholdBytes && s.consumeOpts.MaxBytes != 0) &&
 			atomic.LoadUint32(&s.fetchInProgress) == 1 {
-
-		s.fetchNext <- &pullRequest{
-			Expires:   s.consumeOpts.Expires,
-			Batch:     s.consumeOpts.MaxMessages - s.pending.msgCount,
-			MaxBytes:  s.consumeOpts.MaxBytes - s.pending.byteCount,
-			Heartbeat: s.consumeOpts.Heartbeat,
+		batchSize := s.consumeOpts.MaxMessages - s.pending.msgCount
+		if s.consumeOpts.PullAutoUnsubscribeAfter != 0 {
+			batchSize = min(batchSize, s.consumeOpts.PullAutoUnsubscribeAfter-s.delivered-s.pending.msgCount)
 		}
+		if batchSize > 0 {
+			s.fetchNext <- &pullRequest{
+				Expires:   s.consumeOpts.Expires,
+				Batch:     batchSize,
+				MaxBytes:  s.consumeOpts.MaxBytes - s.pending.byteCount,
+				Heartbeat: s.consumeOpts.Heartbeat,
+			}
 
-		s.pending.msgCount = s.consumeOpts.MaxMessages
-		s.pending.byteCount = s.consumeOpts.MaxBytes
+			s.pending.msgCount = s.consumeOpts.MaxMessages
+			s.pending.byteCount = s.consumeOpts.MaxBytes
+		}
 	}
 }
 
@@ -436,6 +472,11 @@ func (s *pullSubscription) Next() (Msg, error) {
 	}()
 
 	isConnected := true
+	if s.consumeOpts.PullAutoUnsubscribeAfter != 0 && s.delivered > s.consumeOpts.PullAutoUnsubscribeAfter {
+		s.Stop()
+		return nil, ErrMsgIteratorClosed
+	}
+
 	for {
 		s.checkPending()
 		select {
@@ -458,6 +499,7 @@ func (s *pullSubscription) Next() (Msg, error) {
 				continue
 			}
 			s.decrementPendingMsgs(msg)
+			s.incrementDeliveredMsgs()
 			return s.consumer.jetStream.toJSMsg(msg), nil
 		case err := <-s.errs:
 			if errors.Is(err, ErrNoHeartbeat) {

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -296,7 +296,7 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 						}
 						batchSize := sub.consumeOpts.MaxMessages
 						if sub.consumeOpts.AutoStopAfter > 0 {
-							min(batchSize, sub.consumeOpts.AutoStopAfter-sub.delivered)
+							batchSize = min(batchSize, sub.consumeOpts.AutoStopAfter-sub.delivered)
 						}
 						sub.fetchNext <- &pullRequest{
 							Expires:   sub.consumeOpts.Expires,
@@ -316,7 +316,7 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 				if errors.Is(err, ErrNoHeartbeat) {
 					batchSize := sub.consumeOpts.MaxMessages
 					if sub.consumeOpts.AutoStopAfter > 0 {
-						min(batchSize, sub.consumeOpts.AutoStopAfter-sub.delivered)
+						batchSize = min(batchSize, sub.consumeOpts.AutoStopAfter-sub.delivered)
 					}
 					sub.fetchNext <- &pullRequest{
 						Expires:   sub.consumeOpts.Expires,

--- a/jetstream/test/ordered_test.go
+++ b/jetstream/test/ordered_test.go
@@ -193,7 +193,7 @@ func TestOrderedConsumerConsume(t *testing.T) {
 			msgs = append(msgs, msg)
 			msg.Ack()
 			wg.Done()
-		}, jetstream.AutoStopAfter(50), jetstream.PullMaxMessages(40))
+		}, jetstream.StopAfter(50), jetstream.PullMaxMessages(40))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -253,7 +253,7 @@ func TestOrderedConsumerConsume(t *testing.T) {
 			msgs = append(msgs, msg)
 			msg.Ack()
 			wg.Done()
-		}, jetstream.AutoStopAfter(150), jetstream.PullMaxMessages(40))
+		}, jetstream.StopAfter(150), jetstream.PullMaxMessages(40))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -385,7 +385,7 @@ func TestOrderedConsumerMessages(t *testing.T) {
 		}
 
 		msgs := make([]jetstream.Msg, 0)
-		it, err := c.Messages(jetstream.AutoStopAfter(50), jetstream.PullMaxMessages(40))
+		it, err := c.Messages(jetstream.StopAfter(50), jetstream.PullMaxMessages(40))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -456,7 +456,7 @@ func TestOrderedConsumerMessages(t *testing.T) {
 		}
 
 		msgs := make([]jetstream.Msg, 0)
-		it, err := c.Messages(jetstream.AutoStopAfter(150), jetstream.PullMaxMessages(40))
+		it, err := c.Messages(jetstream.StopAfter(150), jetstream.PullMaxMessages(40))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}

--- a/jetstream/test/pull_test.go
+++ b/jetstream/test/pull_test.go
@@ -1082,7 +1082,7 @@ func TestPullConsumerMessages(t *testing.T) {
 		}
 
 		msgs := make([]jetstream.Msg, 0)
-		it, err := c.Messages(jetstream.AutoStopAfter(50), jetstream.PullMaxMessages(40))
+		it, err := c.Messages(jetstream.StopAfter(50), jetstream.PullMaxMessages(40))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1811,7 +1811,7 @@ func TestPullConsumerConsume(t *testing.T) {
 			msgs = append(msgs, msg)
 			msg.Ack()
 			wg.Done()
-		}, jetstream.AutoStopAfter(50), jetstream.PullMaxMessages(40))
+		}, jetstream.StopAfter(50), jetstream.PullMaxMessages(40))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}


### PR DESCRIPTION
Adds the ability to have the consuming of messages automatically be stopped after a certain number of messages is reached (preventing for example the automated fetching to fetch more messages than you need) specified with an AutoStopAfter option. This is the new JS API's equivalent to AutoUnsubscribeAfter() in core NATS (which can be used for push consumers).