### PR TITLE
[IMPROVED] Fixed flaky tests in js.Subscribe() and kv

### DIFF
--- a/test/js_test.go
+++ b/test/js_test.go
@@ -4155,12 +4155,11 @@ func TestJetStreamSubscribe_AckPolicy(t *testing.T) {
 			}
 
 			<-ctx.Done()
-			sub.Drain()
-
 			if got != totalMsgs {
 				t.Fatalf("Expected %d, got %d", totalMsgs, got)
 			}
 
+			// check if consumer is configured properly
 			ci, err := js.ConsumerInfo("TEST", test.name)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
@@ -4168,6 +4167,9 @@ func TestJetStreamSubscribe_AckPolicy(t *testing.T) {
 			if ci.Config.AckPolicy != test.expected {
 				t.Fatalf("Expected %v, got %v", test.expected, ci.Config.AckPolicy)
 			}
+
+			// drain the subscription. This will remove the consumer
+			sub.Drain()
 		})
 	}
 

--- a/test/kv_test.go
+++ b/test/kv_test.go
@@ -952,6 +952,8 @@ func TestKeyValueMirrorCrossDomains(t *testing.T) {
 
 	_, err = mkv.PutString("v", "vv")
 	expectOk(t, err)
+	// wait for the key to be propagated to the mirror
+	time.Sleep(10 * time.Millisecond)
 	e, err := mkv.Get("v")
 	expectOk(t, err)
 	if e.Operation() != nats.KeyValuePut {
@@ -959,6 +961,7 @@ func TestKeyValueMirrorCrossDomains(t *testing.T) {
 	}
 	err = mkv.Delete("v")
 	expectOk(t, err)
+	time.Sleep(10 * time.Millisecond)
 	_, err = mkv.Get("v")
 	expectErr(t, err, nats.ErrKeyNotFound)
 
@@ -983,6 +986,7 @@ func TestKeyValueMirrorCrossDomains(t *testing.T) {
 	_, err = rkv.PutString("name", "ivan")
 	expectOk(t, err)
 
+	time.Sleep(10 * time.Millisecond)
 	e, err = rkv.Get("name")
 	expectOk(t, err)
 	if string(e.Value()) != "ivan" {
@@ -990,6 +994,7 @@ func TestKeyValueMirrorCrossDomains(t *testing.T) {
 	}
 	_, err = rkv.PutString("v", "vv")
 	expectOk(t, err)
+	time.Sleep(10 * time.Millisecond)
 	e, err = mkv.Get("v")
 	expectOk(t, err)
 	if e.Operation() != nats.KeyValuePut {
@@ -997,6 +1002,7 @@ func TestKeyValueMirrorCrossDomains(t *testing.T) {
 	}
 	err = rkv.Delete("v")
 	expectOk(t, err)
+	time.Sleep(10 * time.Millisecond)
 	_, err = rkv.Get("v")
 	expectErr(t, err, nats.ErrKeyNotFound)
 


### PR DESCRIPTION
This PR fixes 2 frequent flaky tests:
- `TestJetStreamSubscribe_AckPolicy()` - in this test `sub.Drain()` was executed before getting consumer info. Even though `nats.Durable()` option was used in `Subscribe()`, the consumer is still deleted if created by library
- `TestKeyValueMirrorCrossDomains()` - there were races in this test and it sometimes failed if values were not propagated to the mirror before attempting to get them