### PR TITLE
[ADDED] UpdatesOnly() option for object store watchers

### DIFF
--- a/jetstream/test/kv_test.go
+++ b/jetstream/test/kv_test.go
@@ -365,11 +365,8 @@ func TestKeyValueWatch(t *testing.T) {
 		watcher, err := kv.WatchAll(ctx, jetstream.UpdatesOnly())
 		expectOk(t, err)
 		defer watcher.Stop()
-		expectInitDone := expectInitDoneF(t, watcher)
 		expectUpdate := expectUpdateF(t, watcher)
 		expectDelete := expectDeleteF(t, watcher)
-		// make sure we do not get any values here
-		expectInitDone()
 
 		// now update some keys and expect updates
 		_, err = kv.Put(ctx, "name", []byte("pp"))
@@ -397,10 +394,7 @@ func TestKeyValueWatch(t *testing.T) {
 		watcher, err = kv.Watch(ctx, "t.*", jetstream.UpdatesOnly())
 		expectOk(t, err)
 		defer watcher.Stop()
-		expectInitDone = expectInitDoneF(t, watcher)
 		expectUpdate = expectUpdateF(t, watcher)
-
-		expectInitDone()
 
 		// update some keys and expect updates
 		_, err = kv.Put(ctx, "t.name", []byte("pp"))

--- a/kv.go
+++ b/kv.go
@@ -941,7 +941,8 @@ func (kv *kvs) Watch(keys string, opts ...WatchOpt) (KeyWatcher, error) {
 			w.updates <- entry
 		}
 		// Check if done and initial values.
-		if !w.initDone {
+		// Skip if UpdatesOnly() is set, since there will never be updates initially.
+		if !o.updatesOnly && !w.initDone {
 			w.received++
 			// We set this on the first trip through..
 			if w.initPending == 0 {
@@ -980,7 +981,8 @@ func (kv *kvs) Watch(keys string, opts ...WatchOpt) (KeyWatcher, error) {
 	sub.mu.Lock()
 	// If there were no pending messages at the time of the creation
 	// of the consumer, send the marker.
-	if sub.jsi != nil && sub.jsi.pending == 0 {
+	// Skip if UpdatesOnly() is set, since there will never be updates initially.
+	if !o.updatesOnly && sub.jsi != nil && sub.jsi.pending == 0 {
 		w.initDone = true
 		w.updates <- nil
 	}

--- a/test/kv_test.go
+++ b/test/kv_test.go
@@ -330,11 +330,8 @@ func TestKeyValueWatch(t *testing.T) {
 		watcher, err := kv.WatchAll(nats.UpdatesOnly())
 		expectOk(t, err)
 		defer watcher.Stop()
-		expectInitDone := expectInitDoneF(t, watcher)
 		expectUpdate := expectUpdateF(t, watcher)
 		expectDelete := expectDeleteF(t, watcher)
-		// make sure we do not get any values here
-		expectInitDone()
 
 		// now update some keys and expect updates
 		kv.Put("name", []byte("pp"))
@@ -356,10 +353,7 @@ func TestKeyValueWatch(t *testing.T) {
 		watcher, err = kv.Watch("t.*", nats.UpdatesOnly())
 		expectOk(t, err)
 		defer watcher.Stop()
-		expectInitDone = expectInitDoneF(t, watcher)
 		expectUpdate = expectUpdateF(t, watcher)
-
-		expectInitDone()
 
 		// update some keys and expect updates
 		kv.Put("t.name", []byte("pp"))


### PR DESCRIPTION
- Added `UpdatesOnly()` option to object store watchers
- Modify KV watcher behavior for `UpdatesOnly()` so that it does not send `nil` update after creating the watcher