### PR TITLE
[IMPROVED] Fixed flaky tests

### DIFF
--- a/jetstream/test/kv_test.go
+++ b/jetstream/test/kv_test.go
@@ -985,7 +985,7 @@ func TestListKeyValueStores(t *testing.T) {
 
 			nc, js := jsClient(t, s)
 			defer nc.Close()
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
 			// create stream without the chunk subject, but with KV_ prefix

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -1424,7 +1424,7 @@ func TestPullSubscribeFetchBatch(t *testing.T) {
 			t.Fatalf("Unexpected error: %s", err)
 		}
 		go func() {
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(200 * time.Millisecond)
 			cancel()
 		}()
 		msgs := make([]*nats.Msg, 0)


### PR DESCRIPTION
This PR fixes 2 flaky tests:
- `TestPullSubscribeFetchBatch` somethimes failed on "cancel context during fetch" step because of too short wait before cancellation (messages were not fetched in time)
- `TestListKeyValueStores` failed when 1025 kv stores were not created before context timed out