### PR TITLE
feat: implement CreateOrUpdateStream function

### DIFF
--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -425,16 +425,10 @@ func (js *jetStream) UpdateStream(ctx context.Context, cfg StreamConfig) (Stream
 func (js *jetStream) CreateOrUpdateStream(ctx context.Context, cfg StreamConfig) (Stream, error) {
 	s, err := js.UpdateStream(ctx, cfg)
 	if err != nil {
-		if err == ErrStreamNotFound {
-			s, err = js.CreateStream(ctx, cfg)
-			if err != nil {
-				return nil, err
-			}
-
-			return s, nil
+		if !errors.Is(err, ErrStreamNotFound) {
+			return nil, err
 		}
-
-		return nil, err
+		return js.CreateStream(ctx, cfg)
 	}
 
 	return s, nil

--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -69,6 +69,8 @@ type (
 		CreateStream(ctx context.Context, cfg StreamConfig) (Stream, error)
 		// UpdateStream updates an existing stream
 		UpdateStream(ctx context.Context, cfg StreamConfig) (Stream, error)
+		// CreateOrUpdateStream creates a stream with given config. If stream already exists, it will be updated (if possible).
+		CreateOrUpdateStream(ctx context.Context, cfg StreamConfig) (Stream, error)
 		// Stream returns a [Stream] hook for a given stream name
 		Stream(ctx context.Context, stream string) (Stream, error)
 		// StreamNameBySubject returns a stream name stream listening on given subject
@@ -418,6 +420,23 @@ func (js *jetStream) UpdateStream(ctx context.Context, cfg StreamConfig) (Stream
 		name:      cfg.Name,
 		info:      resp.StreamInfo,
 	}, nil
+}
+
+func (js *jetStream) CreateOrUpdateStream(ctx context.Context, cfg StreamConfig) (Stream, error) {
+	var s Stream
+	s, err := js.UpdateStream(ctx, cfg)
+	if err != nil {
+		if err == ErrStreamNotFound {
+			s, err = js.CreateStream(ctx, cfg)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return nil, err
+	}
+
+	return s, nil
 }
 
 // Stream returns a [Stream] hook for a given stream name

--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -423,7 +423,6 @@ func (js *jetStream) UpdateStream(ctx context.Context, cfg StreamConfig) (Stream
 }
 
 func (js *jetStream) CreateOrUpdateStream(ctx context.Context, cfg StreamConfig) (Stream, error) {
-	var s Stream
 	s, err := js.UpdateStream(ctx, cfg)
 	if err != nil {
 		if err == ErrStreamNotFound {
@@ -431,6 +430,8 @@ func (js *jetStream) CreateOrUpdateStream(ctx context.Context, cfg StreamConfig)
 			if err != nil {
 				return nil, err
 			}
+
+			return s, nil
 		}
 
 		return nil, err

--- a/jetstream/test/jetstream_test.go
+++ b/jetstream/test/jetstream_test.go
@@ -431,51 +431,88 @@ func TestCreateStreamMirrorCrossDomains(t *testing.T) {
 	}
 }
 
-func TestCreateOrUpdate_CreateStream(t *testing.T) {
+func TestCreateOrUpdate(t *testing.T) {
 	tests := []struct {
-		name      string
-		stream    string
-		subject   string
-		timeout   time.Duration
-		withError error
+		name          string
+		stream        string
+		subject       string
+		timeout       time.Duration
+		withError     error
+		withInfoCheck bool
 	}{
 		{
-			name:    "create stream, ok",
-			stream:  "foo",
-			timeout: 10 * time.Second,
-			subject: "FOO.1",
+			name:          "create stream, ok",
+			stream:        "foo",
+			timeout:       10 * time.Second,
+			subject:       "FOO.1",
+			withInfoCheck: false,
 		},
 		{
-			name:    "with empty context",
-			stream:  "foo-o",
-			subject: "FOO.12",
+			name:          "create stream, empty context",
+			stream:        "foo-o",
+			subject:       "FOO.12",
+			withInfoCheck: false,
 		},
 		{
-			name:      "invalid stream name",
-			stream:    "foo.123",
-			subject:   "FOO.123",
-			timeout:   10 * time.Second,
-			withError: jetstream.ErrInvalidStreamName,
+			name:          "create stream, invalid stream name",
+			stream:        "foo.123",
+			subject:       "FOO.123",
+			timeout:       10 * time.Second,
+			withError:     jetstream.ErrInvalidStreamName,
+			withInfoCheck: false,
 		},
 		{
-			name:      "stream name required",
-			stream:    "",
-			subject:   "FOO.1234",
-			timeout:   10 * time.Second,
-			withError: jetstream.ErrStreamNameRequired,
+			name:          "create stream, stream name required",
+			stream:        "",
+			subject:       "FOO.1234",
+			timeout:       10 * time.Second,
+			withError:     jetstream.ErrStreamNameRequired,
+			withInfoCheck: false,
 		},
 		{
-			name:    "update stream, ok",
-			stream:  "foo",
-			subject: "BAR.123",
-			timeout: 10 * time.Second,
+			name:          "update stream, ok",
+			stream:        "foo",
+			subject:       "BAR.123",
+			timeout:       10 * time.Second,
+			withInfoCheck: true,
 		},
 		{
-			name:      "context timeout",
-			stream:    "foo",
-			subject:   "BAR.1234",
-			timeout:   1 * time.Microsecond,
-			withError: context.DeadlineExceeded,
+			name:          "create stream, context timeout",
+			stream:        "foo",
+			subject:       "BAR.1234",
+			timeout:       1 * time.Microsecond,
+			withError:     context.DeadlineExceeded,
+			withInfoCheck: false,
+		},
+		{
+			name:          "update stream, with empty context",
+			stream:        "sample.foo",
+			subject:       "SAMPLE.FOO.123",
+			withInfoCheck: true,
+		},
+		{
+			name:          "update stream, invalid stream name",
+			stream:        "sample.foo.123",
+			subject:       "SAMPLE.FOO.1234",
+			timeout:       10 * time.Second,
+			withError:     jetstream.ErrInvalidStreamName,
+			withInfoCheck: true,
+		},
+		{
+			name:          "update stream, stream name required",
+			stream:        "",
+			subject:       "SAMPLE.FOO.123",
+			timeout:       10 * time.Second,
+			withError:     jetstream.ErrStreamNameRequired,
+			withInfoCheck: true,
+		},
+		{
+			name:          "update stream, context timeout",
+			stream:        "sample.foo",
+			subject:       "SAMPLE.FOO.123456",
+			timeout:       1 * time.Microsecond,
+			withError:     context.DeadlineExceeded,
+			withInfoCheck: true,
 		},
 	}
 
@@ -492,6 +529,11 @@ func TestCreateOrUpdate_CreateStream(t *testing.T) {
 	}
 	defer nc.Close()
 
+	_, err = js.CreateStream(context.Background(), jetstream.StreamConfig{Name: "sample.foo", Subjects: []string{"SAMPLE.FOO.123"}})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
@@ -500,7 +542,7 @@ func TestCreateOrUpdate_CreateStream(t *testing.T) {
 				ctx, cancel = context.WithTimeout(context.Background(), test.timeout)
 				defer cancel()
 			}
-			_, err = js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{Name: test.stream, Subjects: []string{test.subject}})
+			s, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{Name: test.stream, Subjects: []string{test.subject}})
 			if test.withError != nil {
 				if !errors.Is(err, test.withError) {
 					t.Fatalf("Expected error: %v; got: %v", test.withError, err)
@@ -510,152 +552,15 @@ func TestCreateOrUpdate_CreateStream(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
-		})
-	}
-}
 
-func TestCreateOrUpdateStream_CreateMirrorCrossDomains(t *testing.T) {
-	test := []struct {
-		name         string
-		streamConfig *jetstream.StreamConfig
-	}{
-		{
-			name: "create stream mirror cross domains",
-			streamConfig: &jetstream.StreamConfig{
-				Name: "MIRROR",
-				Mirror: &jetstream.StreamSource{
-					Name:   "TEST",
-					Domain: "HUB",
-				},
-			},
-		},
-		{
-			name: "create stream with source cross domains",
-			streamConfig: &jetstream.StreamConfig{
-				Name: "MIRROR",
-				Sources: []*jetstream.StreamSource{
-					{
-						Name:   "TEST",
-						Domain: "HUB",
-					},
-				},
-			},
-		},
-	}
-
-	for _, test := range test {
-		t.Run(test.name, func(t *testing.T) {
-			conf := createConfFile(t, []byte(`
-		server_name: HUB
-		listen: 127.0.0.1:-1
-		jetstream: { domain: HUB }
-		leafnodes { listen: 127.0.0.1:7422 }
-	}`))
-			defer os.Remove(conf)
-			srv, _ := RunServerWithConfig(conf)
-			defer shutdownJSServerAndRemoveStorage(t, srv)
-
-			lconf := createConfFile(t, []byte(`
-	server_name: LEAF
-	listen: 127.0.0.1:-1
-	 jetstream: { domain:LEAF }
-	 leafnodes {
-		  remotes = [ { url: "leaf://127.0.0.1" } ]
-	 }
-}`))
-			defer os.Remove(lconf)
-			ln, _ := RunServerWithConfig(lconf)
-			defer shutdownJSServerAndRemoveStorage(t, ln)
-
-			nc, err := nats.Connect(srv.ClientURL())
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			defer nc.Close()
-
-			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-			defer cancel()
-			js, err := jetstream.New(nc)
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			_, err = js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
-				Name:     "TEST",
-				Subjects: []string{"foo"},
-			})
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			if _, err := js.Publish(ctx, "foo", []byte("msg1")); err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			if _, err := js.Publish(ctx, "foo", []byte("msg2")); err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			lnc, err := nats.Connect(ln.ClientURL())
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			defer lnc.Close()
-			ljs, err := jetstream.New(lnc)
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			ccfg := *test.streamConfig
-			_, err = ljs.CreateOrUpdateStream(ctx, ccfg)
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			if !reflect.DeepEqual(test.streamConfig, &ccfg) {
-				t.Fatalf("Did not expect config to be altered: %+v vs %+v", test.streamConfig, ccfg)
-			}
-
-			// Make sure we sync.
-			checkFor(t, 2*time.Second, 15*time.Millisecond, func() error {
-				lStream, err := ljs.Stream(ctx, "MIRROR")
+			if test.withInfoCheck {
+				info, err := s.Info(ctx)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
-
-				if lStream.CachedInfo().State.Msgs == 2 {
-					return nil
+				if len(info.Config.Subjects) != 1 || info.Config.Subjects[0] != test.subject {
+					t.Fatalf("Invalid stream subjects after update: %v", info.Config.Subjects)
 				}
-				return fmt.Errorf("Did not get synced messages: %d", lStream.CachedInfo().State.Msgs)
-			})
-			if _, err := ljs.Publish(ctx, "foo", []byte("msg3")); err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			lStream, err := ljs.Stream(ctx, "MIRROR")
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			if lStream.CachedInfo().State.Msgs != 3 {
-				t.Fatalf("Expected 3 msgs in stream; got: %d", lStream.CachedInfo().State.Msgs)
-			}
-
-			rjs, err := jetstream.NewWithDomain(lnc, "HUB")
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			_, err = rjs.Stream(ctx, "TEST")
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			if _, err := rjs.Publish(ctx, "foo", []byte("msg4")); err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			rStream, err := rjs.Stream(ctx, "TEST")
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			if rStream.CachedInfo().State.Msgs != 4 {
-				t.Fatalf("Expected 3 msgs in stream; got: %d", rStream.CachedInfo().State.Msgs)
 			}
 		})
 	}
@@ -735,99 +640,6 @@ func TestUpdateStream(t *testing.T) {
 				defer cancel()
 			}
 			s, err := js.UpdateStream(ctx, jetstream.StreamConfig{Name: test.stream, Subjects: []string{test.subject}})
-			if test.withError != nil {
-				if !errors.Is(err, test.withError) {
-					t.Fatalf("Expected error: %v; got: %v", test.withError, err)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			info, err := s.Info(ctx)
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			if len(info.Config.Subjects) != 1 || info.Config.Subjects[0] != test.subject {
-				t.Fatalf("Invalid stream subjects after update: %v", info.Config.Subjects)
-			}
-		})
-	}
-}
-
-func TestCreateOrUpdate_UpdateStream(t *testing.T) {
-	tests := []struct {
-		name      string
-		stream    string
-		subject   string
-		timeout   time.Duration
-		withError error
-	}{
-		{
-			name:    "update existing stream",
-			stream:  "foo",
-			subject: "BAR.123",
-			timeout: 10 * time.Second,
-		},
-		{
-			name:    "with empty context",
-			stream:  "foo",
-			subject: "FOO.123",
-		},
-		{
-			name:      "invalid stream name",
-			stream:    "foo.123",
-			subject:   "FOO.1234",
-			timeout:   10 * time.Second,
-			withError: jetstream.ErrInvalidStreamName,
-		},
-		{
-			name:      "stream name required",
-			stream:    "",
-			subject:   "FOO.123",
-			timeout:   10 * time.Second,
-			withError: jetstream.ErrStreamNameRequired,
-		},
-		{
-			name:    "create stream, ok",
-			stream:  "bar",
-			subject: "FOO.12345",
-			timeout: 10 * time.Second,
-		},
-		{
-			name:      "context timeout",
-			stream:    "foo",
-			subject:   "FOO.123456",
-			timeout:   1 * time.Microsecond,
-			withError: context.DeadlineExceeded,
-		},
-	}
-
-	srv := RunBasicJetStreamServer()
-	defer shutdownJSServerAndRemoveStorage(t, srv)
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	js, err := jetstream.New(nc)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	defer nc.Close()
-	_, err = js.CreateStream(context.Background(), jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.123"}})
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
-			if test.timeout > 0 {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(context.Background(), test.timeout)
-				defer cancel()
-			}
-			s, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{Name: test.stream, Subjects: []string{test.subject}})
 			if test.withError != nil {
 				if !errors.Is(err, test.withError) {
 					t.Fatalf("Expected error: %v; got: %v", test.withError, err)

--- a/jetstream/test/jetstream_test.go
+++ b/jetstream/test/jetstream_test.go
@@ -465,11 +465,10 @@ func TestCreateOrUpdate_CreateStream(t *testing.T) {
 			withError: jetstream.ErrStreamNameRequired,
 		},
 		{
-			name:      "update stream, ok",
-			stream:    "foo",
-			subject:   "BAR.123",
-			timeout:   10 * time.Second,
-			withError: jetstream.ErrStreamNameAlreadyInUse,
+			name:    "update stream, ok",
+			stream:  "foo",
+			subject: "BAR.123",
+			timeout: 10 * time.Second,
 		},
 		{
 			name:      "context timeout",

--- a/jetstream/test/jetstream_test.go
+++ b/jetstream/test/jetstream_test.go
@@ -789,11 +789,10 @@ func TestCreateOrUpdate_UpdateStream(t *testing.T) {
 			withError: jetstream.ErrStreamNameRequired,
 		},
 		{
-			name:      "stream not found",
-			stream:    "bar",
-			subject:   "FOO.12345",
-			timeout:   10 * time.Second,
-			withError: jetstream.ErrStreamNotFound,
+			name:    "create stream, ok",
+			stream:  "bar",
+			subject: "FOO.12345",
+			timeout: 10 * time.Second,
 		},
 		{
 			name:      "context timeout",

--- a/jetstream/test/jetstream_test.go
+++ b/jetstream/test/jetstream_test.go
@@ -443,12 +443,12 @@ func TestCreateOrUpdate_CreateStream(t *testing.T) {
 			name:    "create stream, ok",
 			stream:  "foo",
 			timeout: 10 * time.Second,
-			subject: "FOO.123",
+			subject: "FOO.1",
 		},
 		{
 			name:    "with empty context",
 			stream:  "foo-o",
-			subject: "FOO.123",
+			subject: "FOO.12",
 		},
 		{
 			name:      "invalid stream name",
@@ -460,7 +460,7 @@ func TestCreateOrUpdate_CreateStream(t *testing.T) {
 		{
 			name:      "stream name required",
 			stream:    "",
-			subject:   "FOO.123",
+			subject:   "FOO.1234",
 			timeout:   10 * time.Second,
 			withError: jetstream.ErrStreamNameRequired,
 		},
@@ -473,7 +473,7 @@ func TestCreateOrUpdate_CreateStream(t *testing.T) {
 		{
 			name:      "context timeout",
 			stream:    "foo",
-			subject:   "BAR.123",
+			subject:   "BAR.1234",
 			timeout:   1 * time.Microsecond,
 			withError: context.DeadlineExceeded,
 		},

--- a/jetstream/test/jetstream_test.go
+++ b/jetstream/test/jetstream_test.go
@@ -431,7 +431,7 @@ func TestCreateStreamMirrorCrossDomains(t *testing.T) {
 	}
 }
 
-func TestCreateOrUpdate(t *testing.T) {
+func TestCreateOrUpdateStream(t *testing.T) {
 	tests := []struct {
 		name          string
 		stream        string
@@ -441,20 +441,20 @@ func TestCreateOrUpdate(t *testing.T) {
 		withInfoCheck bool
 	}{
 		{
-			name:          "create stream, ok",
+			name:          "create stream ok",
 			stream:        "foo",
 			timeout:       10 * time.Second,
 			subject:       "FOO.1",
 			withInfoCheck: false,
 		},
 		{
-			name:          "create stream, empty context",
+			name:          "create stream empty context",
 			stream:        "foo-o",
 			subject:       "FOO.12",
 			withInfoCheck: false,
 		},
 		{
-			name:          "create stream, invalid stream name",
+			name:          "create stream invalid stream name",
 			stream:        "foo.123",
 			subject:       "FOO.123",
 			timeout:       10 * time.Second,
@@ -462,7 +462,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			withInfoCheck: false,
 		},
 		{
-			name:          "create stream, stream name required",
+			name:          "create stream stream name required",
 			stream:        "",
 			subject:       "FOO.1234",
 			timeout:       10 * time.Second,
@@ -470,14 +470,14 @@ func TestCreateOrUpdate(t *testing.T) {
 			withInfoCheck: false,
 		},
 		{
-			name:          "update stream, ok",
+			name:          "update stream ok",
 			stream:        "foo",
 			subject:       "BAR.123",
 			timeout:       10 * time.Second,
 			withInfoCheck: true,
 		},
 		{
-			name:          "create stream, context timeout",
+			name:          "create stream context timeout",
 			stream:        "foo",
 			subject:       "BAR.1234",
 			timeout:       1 * time.Microsecond,
@@ -485,31 +485,31 @@ func TestCreateOrUpdate(t *testing.T) {
 			withInfoCheck: false,
 		},
 		{
-			name:          "update stream, with empty context",
-			stream:        "sample.foo",
+			name:          "update stream with empty context",
+			stream:        "sample-foo",
 			subject:       "SAMPLE.FOO.123",
 			withInfoCheck: true,
 		},
 		{
-			name:          "update stream, invalid stream name",
-			stream:        "sample.foo.123",
-			subject:       "SAMPLE.FOO.1234",
+			name:          "update stream invalid stream name",
+			stream:        "sample-foo.123",
+			subject:       "SAMPLE-FOO.1234",
 			timeout:       10 * time.Second,
 			withError:     jetstream.ErrInvalidStreamName,
 			withInfoCheck: true,
 		},
 		{
-			name:          "update stream, stream name required",
+			name:          "update stream stream name required",
 			stream:        "",
-			subject:       "SAMPLE.FOO.123",
+			subject:       "SAMPLE-FOO.123",
 			timeout:       10 * time.Second,
 			withError:     jetstream.ErrStreamNameRequired,
 			withInfoCheck: true,
 		},
 		{
-			name:          "update stream, context timeout",
-			stream:        "sample.foo",
-			subject:       "SAMPLE.FOO.123456",
+			name:          "update stream context timeout",
+			stream:        "sample-foo",
+			subject:       "SAMPLE-FOO.123456",
 			timeout:       1 * time.Microsecond,
 			withError:     context.DeadlineExceeded,
 			withInfoCheck: true,
@@ -529,7 +529,7 @@ func TestCreateOrUpdate(t *testing.T) {
 	}
 	defer nc.Close()
 
-	_, err = js.CreateStream(context.Background(), jetstream.StreamConfig{Name: "sample.foo", Subjects: []string{"SAMPLE.FOO.123"}})
+	_, err = js.CreateStream(context.Background(), jetstream.StreamConfig{Name: "sample-foo", Subjects: []string{"SAMPLE-FOO.123"}})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/jetstream/test/jetstream_test.go
+++ b/jetstream/test/jetstream_test.go
@@ -777,7 +777,7 @@ func TestCreateOrUpdate_UpdateStream(t *testing.T) {
 		{
 			name:      "invalid stream name",
 			stream:    "foo.123",
-			subject:   "FOO.123",
+			subject:   "FOO.1234",
 			timeout:   10 * time.Second,
 			withError: jetstream.ErrInvalidStreamName,
 		},
@@ -791,14 +791,14 @@ func TestCreateOrUpdate_UpdateStream(t *testing.T) {
 		{
 			name:      "stream not found",
 			stream:    "bar",
-			subject:   "FOO.123",
+			subject:   "FOO.12345",
 			timeout:   10 * time.Second,
 			withError: jetstream.ErrStreamNotFound,
 		},
 		{
 			name:      "context timeout",
 			stream:    "foo",
-			subject:   "FOO.123",
+			subject:   "FOO.123456",
 			timeout:   1 * time.Microsecond,
 			withError: context.DeadlineExceeded,
 		},

--- a/jetstream/test/jetstream_test.go
+++ b/jetstream/test/jetstream_test.go
@@ -487,13 +487,13 @@ func TestCreateOrUpdateStream(t *testing.T) {
 		{
 			name:          "update stream with empty context",
 			stream:        "sample-foo",
-			subject:       "SAMPLE.FOO.123",
+			subject:       "SAMPLE-FOO-123",
 			withInfoCheck: true,
 		},
 		{
 			name:          "update stream invalid stream name",
-			stream:        "sample-foo.123",
-			subject:       "SAMPLE-FOO.1234",
+			stream:        "sample-foo-123",
+			subject:       "SAMPLE-FOO-1234",
 			timeout:       10 * time.Second,
 			withError:     jetstream.ErrInvalidStreamName,
 			withInfoCheck: true,
@@ -501,7 +501,7 @@ func TestCreateOrUpdateStream(t *testing.T) {
 		{
 			name:          "update stream stream name required",
 			stream:        "",
-			subject:       "SAMPLE-FOO.123",
+			subject:       "SAMPLE-FOO-123",
 			timeout:       10 * time.Second,
 			withError:     jetstream.ErrStreamNameRequired,
 			withInfoCheck: true,
@@ -509,7 +509,7 @@ func TestCreateOrUpdateStream(t *testing.T) {
 		{
 			name:          "update stream context timeout",
 			stream:        "sample-foo",
-			subject:       "SAMPLE-FOO.123456",
+			subject:       "SAMPLE-FOO-123456",
 			timeout:       1 * time.Microsecond,
 			withError:     context.DeadlineExceeded,
 			withInfoCheck: true,
@@ -529,7 +529,7 @@ func TestCreateOrUpdateStream(t *testing.T) {
 	}
 	defer nc.Close()
 
-	_, err = js.CreateStream(context.Background(), jetstream.StreamConfig{Name: "sample-foo", Subjects: []string{"SAMPLE-FOO.123"}})
+	_, err = js.CreateStream(context.Background(), jetstream.StreamConfig{Name: "sample-foo", Subjects: []string{"SAMPLE-FOO-123"}})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/jetstream/test/jetstream_test.go
+++ b/jetstream/test/jetstream_test.go
@@ -456,7 +456,7 @@ func TestCreateOrUpdateStream(t *testing.T) {
 		{
 			name:          "create stream invalid stream name",
 			stream:        "foo.123",
-			subject:       "FOO.123",
+			subject:       "FOO-123",
 			timeout:       10 * time.Second,
 			withError:     jetstream.ErrInvalidStreamName,
 			withInfoCheck: false,
@@ -464,7 +464,7 @@ func TestCreateOrUpdateStream(t *testing.T) {
 		{
 			name:          "create stream stream name required",
 			stream:        "",
-			subject:       "FOO.1234",
+			subject:       "FOO-1234",
 			timeout:       10 * time.Second,
 			withError:     jetstream.ErrStreamNameRequired,
 			withInfoCheck: false,
@@ -472,27 +472,27 @@ func TestCreateOrUpdateStream(t *testing.T) {
 		{
 			name:          "update stream ok",
 			stream:        "foo",
-			subject:       "BAR.123",
+			subject:       "BAR-123",
 			timeout:       10 * time.Second,
 			withInfoCheck: true,
 		},
 		{
 			name:          "create stream context timeout",
 			stream:        "foo",
-			subject:       "BAR.1234",
+			subject:       "BAR-1234",
 			timeout:       1 * time.Microsecond,
 			withError:     context.DeadlineExceeded,
 			withInfoCheck: false,
 		},
 		{
 			name:          "update stream with empty context",
-			stream:        "sample-foo",
+			stream:        "sample-foo-1",
 			subject:       "SAMPLE-FOO-123",
 			withInfoCheck: true,
 		},
 		{
 			name:          "update stream invalid stream name",
-			stream:        "sample-foo-123",
+			stream:        "sample-foo.123",
 			subject:       "SAMPLE-FOO-1234",
 			timeout:       10 * time.Second,
 			withError:     jetstream.ErrInvalidStreamName,
@@ -508,7 +508,7 @@ func TestCreateOrUpdateStream(t *testing.T) {
 		},
 		{
 			name:          "update stream context timeout",
-			stream:        "sample-foo",
+			stream:        "sample-foo-2",
 			subject:       "SAMPLE-FOO-123456",
 			timeout:       1 * time.Microsecond,
 			withError:     context.DeadlineExceeded,
@@ -528,11 +528,6 @@ func TestCreateOrUpdateStream(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	defer nc.Close()
-
-	_, err = js.CreateStream(context.Background(), jetstream.StreamConfig{Name: "sample-foo", Subjects: []string{"SAMPLE-FOO-123"}})
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
After using JetStream on a private project I felt the need for CreateOrUpdateStream like CreateOrUpdateConsumer. This function updates if stream exists, otherwise it creates the stream. 