### PR TITLE
Release v1.30.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ When using or transitioning to Go modules support:
 ```bash
 # Go client latest or explicit version
 go get github.com/nats-io/nats.go/@latest
-go get github.com/nats-io/nats.go/@v1.29.0
+go get github.com/nats-io/nats.go/@v1.30.0
 
 # For latest NATS Server, add /v2 at the end
 go get github.com/nats-io/nats-server/v2

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.29.0"
+	Version                   = "1.30.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
### Overview

This release focuses on adding features introduced in nats-server@v2.10.0. Among other things, this includes setting multiple filter subjects for a consumer, configuring stream subject transform, as well as setting stream and consumer metadata.

### Added
- JetStream:
  - `SubjectTransform` support on streams (#1200)
  - `SubjectTransforms` on mirrors and sources (#1359, #1404)
  - Multiple subject filters on consumers (#1214)
  - Setting `Compression` type on `StreamConfig` (#1405)
  - Setting `FirstSeq` on `StreamConfig` (#1405)
  - Setting `ConsumerLimits` on `StreamConfig` (#1405)
  - `CreateConsumer` and `UpdateConsumer` methods (#1379)
  - Support for stream and consumer metadata (#1384)
- ObjectStore:
  - Support for object store and object metadata (#1385)
- Service API (`micro`):
  -  Customizing queue groups per service, group and endpoint (#1401)
- Legacy JetStream:
  - `SubjectTransform` support on streams (#1200)
  - `SubjectTransforms` on mirrors and sources (#1359)
  - Multiple subject filters on consumers (#1214)
  - Setting `Compression` type on `StreamConfig` (#1405)
  - Setting `FirstSeq` on `StreamConfig` (#1405)
  - Setting `ConsumerLimits` on `StreamConfig` (#1405)
  - Setting heartbeats in Fetch and FetchBatch in legacy API (#1402)
 