### PR TITLE
[FIXED] Stream create response test for sources being present in the response.

### DIFF
--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -364,7 +364,7 @@ func (js *jetStream) CreateStream(ctx context.Context, cfg StreamConfig) (Stream
 	}
 
 	if len(cfg.Sources) != 0 {
-		if len(cfg.Sources) != len(resp.Sources) {
+		if len(cfg.Sources) != len(resp.Config.Sources) {
 			return nil, ErrStreamSourceNotSupported
 		}
 		for i := range cfg.Sources {
@@ -443,7 +443,7 @@ func (js *jetStream) UpdateStream(ctx context.Context, cfg StreamConfig) (Stream
 	}
 
 	if len(cfg.Sources) != 0 {
-		if len(cfg.Sources) != len(resp.Sources) {
+		if len(cfg.Sources) != len(resp.Config.Sources) {
 			return nil, ErrStreamSourceNotSupported
 		}
 		for i := range cfg.Sources {

--- a/jsm.go
+++ b/jsm.go
@@ -1029,7 +1029,7 @@ func (js *js) UpdateStream(cfg *StreamConfig, opts ...JSOpt) (*StreamInfo, error
 	}
 
 	if len(cfg.Sources) != 0 {
-		if len(cfg.Sources) != len(resp.Sources) {
+		if len(cfg.Sources) != len(resp.Config.Sources) {
 			return nil, ErrStreamSourceNotSupported
 		}
 		for i := range cfg.Sources {

--- a/jsm.go
+++ b/jsm.go
@@ -817,7 +817,7 @@ func (js *js) AddStream(cfg *StreamConfig, opts ...JSOpt) (*StreamInfo, error) {
 		return nil, ErrStreamSubjectTransformNotSupported
 	}
 	if len(cfg.Sources) != 0 {
-		if len(cfg.Sources) != len(resp.Sources) {
+		if len(cfg.Sources) != len(resp.Config.Sources) {
 			return nil, ErrStreamSourceNotSupported
 		}
 		for i := range cfg.Sources {


### PR DESCRIPTION
Server 2.10 now returns source infos (as well as the config) so you can for example tell which sources where successfully added for the stream, and what their current state is) but 2.9 would only return the source config info inside the stream info.

nats.go 2.10 added a check that all of the sources defined in the config where indeed added to the stream in the stream create transform, which would work with a 2.10 server but not with a 2.9.

This fixes the test by downgrading it to the best you can do with a 2.9 server which is check against the stream config returned in the create response message.