### PR TITLE
Release v1.30.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ When using or transitioning to Go modules support:
 ```bash
 # Go client latest or explicit version
 go get github.com/nats-io/nats.go/@latest
-go get github.com/nats-io/nats.go/@v1.30.1
+go get github.com/nats-io/nats.go/@v1.30.2
 
 # For latest NATS Server, add /v2 at the end
 go get github.com/nats-io/nats-server/v2

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.30.1"
+	Version                   = "1.30.2"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
### Fixed
- JetStream:
  - Fixed backwards compatibility issue when creating streams with sources on nats-server 2.9.x (#1420)