### PR TITLE
Release v1.31.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ When using or transitioning to Go modules support:
 ```bash
 # Go client latest or explicit version
 go get github.com/nats-io/nats.go/@latest
-go get github.com/nats-io/nats.go/@v1.30.2
+go get github.com/nats-io/nats.go/@v1.31.0
 
 # For latest NATS Server, add /v2 at the end
 go get github.com/nats-io/nats-server/v2

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.30.2"
+	Version                   = "1.31.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
### Added
- Core NATS:
  - `TLSHandshakeFirst` option to perform TLS handshake before receiving the `INFO` protocol message. **Note**: This option is not yet available in `nats-server` (#1433)
  
### Fixed
- Test (dev) dependencies are no longer added to `go.mod` when using `nats.go` (#1441)
- JetStream:
  - Panic on `Consumer.Info()` when empty response and errors are returned (#1426)
  - Invalid handling of heartbeats in `Consume` and `Messages` (#1428)
- Legacy JetStream:
  - Panic on `ConsumerInfo()` when empty response and errors are returned (#1426)

### Improved
- Fixed typos in `jetstream/README.md` (#1436)
- Updated client dependencies list (#1439, #1440)
