### PR TITLE
[ADDED] Retry PublishAsync on no responders

### DIFF
--- a/jetstream/options.go
+++ b/jetstream/options.go
@@ -322,7 +322,7 @@ func WithExpectLastMsgID(id string) PublishOpt {
 }
 
 // WithRetryWait sets the retry wait time when ErrNoResponders is encountered.
-// Defaults to 2
+// Defaults to 250ms
 func WithRetryWait(dur time.Duration) PublishOpt {
 	return func(opts *pubOpts) error {
 		if dur <= 0 {
@@ -334,7 +334,7 @@ func WithRetryWait(dur time.Duration) PublishOpt {
 }
 
 // WithRetryAttempts sets the retry number of attempts when ErrNoResponders is encountered.
-// Defaults to 250ms
+// Defaults to 2
 func WithRetryAttempts(num int) PublishOpt {
 	return func(opts *pubOpts) error {
 		if num < 0 {

--- a/jetstream/options.go
+++ b/jetstream/options.go
@@ -322,16 +322,24 @@ func WithExpectLastMsgID(id string) PublishOpt {
 }
 
 // WithRetryWait sets the retry wait time when ErrNoResponders is encountered.
+// Defaults to 2
 func WithRetryWait(dur time.Duration) PublishOpt {
 	return func(opts *pubOpts) error {
+		if dur <= 0 {
+			return fmt.Errorf("%w: retry wait should be more than 0", ErrInvalidOption)
+		}
 		opts.retryWait = dur
 		return nil
 	}
 }
 
 // WithRetryAttempts sets the retry number of attempts when ErrNoResponders is encountered.
+// Defaults to 250ms
 func WithRetryAttempts(num int) PublishOpt {
 	return func(opts *pubOpts) error {
+		if num < 0 {
+			return fmt.Errorf("%w: retry attempts cannot be negative", ErrInvalidOption)
+		}
 		opts.retryAttempts = num
 		return nil
 	}


### PR DESCRIPTION
Adds retry logic similar to `Publish()` and `PublishMsg()` to async counterparts. Previously `WithRetryAttempts` and `WithRetryWait` options were ignored.

Fixes #1462

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>