### PR TITLE
[FIXED] Invalid PullExpiry validation

### DIFF
--- a/jetstream/options.go
+++ b/jetstream/options.go
@@ -122,7 +122,7 @@ type PullExpiry time.Duration
 
 func (exp PullExpiry) configureConsume(opts *consumeOpts) error {
 	expiry := time.Duration(exp)
-	if expiry < 1*time.Second {
+	if expiry < time.Second {
 		return fmt.Errorf("%w: expires value must be at least 1s", ErrInvalidOption)
 	}
 	opts.Expires = expiry
@@ -131,7 +131,7 @@ func (exp PullExpiry) configureConsume(opts *consumeOpts) error {
 
 func (exp PullExpiry) configureMessages(opts *consumeOpts) error {
 	expiry := time.Duration(exp)
-	if expiry < 0 {
+	if expiry < time.Second {
 		return fmt.Errorf("%w: expires value must be at least 1s", ErrInvalidOption)
 	}
 	opts.Expires = expiry


### PR DESCRIPTION
Fixed invalid option validation where pull expiry could be set to < 1s. This bug was only present in `consumer.Messages()`

Fixes #1467

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>