### PR TITLE
[FIXED] Race condition when getting pull subscriptions in ordered consumer

### DIFF
--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -1042,3 +1042,10 @@ func retryWithBackoff(f func(int) (bool, error), opts backoffOpts) error {
 	}
 	return err
 }
+
+func (c *pullConsumer) getSubscription(id string) (*pullSubscription, bool) {
+	c.Lock()
+	defer c.Unlock()
+	sub, ok := c.subscriptions[id]
+	return sub, ok
+}


### PR DESCRIPTION
Fixes concurrent read/write to subscriptions map

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>