### PR TITLE
[ADDED] Return account reservations on AccountInfo

### DIFF
--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -111,13 +111,20 @@ type (
 
 	// AccountInfo contains info about the JetStream usage from the current account.
 	AccountInfo struct {
-		Memory    uint64        `json:"memory"`
-		Store     uint64        `json:"storage"`
-		Streams   int           `json:"streams"`
-		Consumers int           `json:"consumers"`
-		Domain    string        `json:"domain"`
-		API       APIStats      `json:"api"`
-		Limits    AccountLimits `json:"limits"`
+		Tier
+		Domain string          `json:"domain"`
+		API    APIStats        `json:"api"`
+		Tiers  map[string]Tier `json:"tiers"`
+	}
+
+	Tier struct {
+		Memory         uint64        `json:"memory"`
+		Store          uint64        `json:"storage"`
+		ReservedMemory uint64        `json:"reserved_memory"`
+		ReservedStore  uint64        `json:"reserved_storage"`
+		Streams        int           `json:"streams"`
+		Consumers      int           `json:"consumers"`
+		Limits         AccountLimits `json:"limits"`
 	}
 
 	// APIStats reports on API calls to JetStream for this account.

--- a/jsm.go
+++ b/jsm.go
@@ -252,11 +252,13 @@ type AccountInfo struct {
 }
 
 type Tier struct {
-	Memory    uint64        `json:"memory"`
-	Store     uint64        `json:"storage"`
-	Streams   int           `json:"streams"`
-	Consumers int           `json:"consumers"`
-	Limits    AccountLimits `json:"limits"`
+	Memory         uint64        `json:"memory"`
+	Store          uint64        `json:"storage"`
+	ReservedMemory uint64        `json:"reserved_memory"`
+	ReservedStore  uint64        `json:"reserved_storage"`
+	Streams        int           `json:"streams"`
+	Consumers      int           `json:"consumers"`
+	Limits         AccountLimits `json:"limits"`
 }
 
 // APIStats reports on API calls to JetStream for this account.


### PR DESCRIPTION
This adds reservations to AccountInfo and fixes missing Tiers map in new JetStream API. Reservations on AccountInfo will be available in the next server release.

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>