### PR TITLE
wrap js publish error

### DIFF
--- a/js.go
+++ b/js.go
@@ -575,14 +575,14 @@ func (js *js) PublishMsg(m *Msg, opts ...PubOpt) (*PubAck, error) {
 	}
 
 	var pa pubAckResponse
-	if err := json.Unmarshal(resp.Data, &pa); err != nil {
-		return nil, ErrInvalidJSAck
+	if err = json.Unmarshal(resp.Data, &pa); err != nil {
+		return nil, wrapError(ErrInvalidJSAck, err.Error())
 	}
 	if pa.Error != nil {
 		return nil, pa.Error
 	}
 	if pa.PubAck == nil || pa.PubAck.Stream == _EMPTY_ {
-		return nil, ErrInvalidJSAck
+		return nil, wrapError(ErrInvalidJSAck, "missing stream or sequence")
 	}
 	return pa.PubAck, nil
 }
@@ -3638,7 +3638,7 @@ const (
 	// DiscardOld will remove older messages to return to the limits. This is
 	// the default.
 	DiscardOld DiscardPolicy = iota
-	//DiscardNew will fail to store new messages.
+	// DiscardNew will fail to store new messages.
 	DiscardNew
 )
 

--- a/jserrors.go
+++ b/jserrors.go
@@ -233,3 +233,11 @@ func (err *jsError) Unwrap() error {
 	}
 	return err.apiErr
 }
+
+func wrapError(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("%w: %s", err, message)
+}

--- a/jserrors_test.go
+++ b/jserrors_test.go
@@ -1,0 +1,74 @@
+package nats
+
+import (
+	"testing"
+	"errors"
+)
+
+func Test_wrapError_Unwrap(t *testing.T) {
+	err := wrapError(ErrInvalidJSAck, "external error message")
+	if !errors.Is(err, ErrInvalidJSAck) {
+		t.Errorf("wrapError() = %v, want %v", err, ErrInvalidJSAck)
+	}
+
+	err = wrapError(err, "")
+	if !errors.Is(err, ErrInvalidJSAck) {
+		t.Errorf("wrapError() = %v, want %v", err, ErrInvalidJSAck)
+	}
+}
+
+func Test_wrapError(t *testing.T) {
+	type args struct {
+		err     error
+		message string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantNil   bool
+		wantError string
+	}{
+		{
+			name:      "test1",
+			args:      args{err: nil},
+			wantNil:   true,
+			wantError: "",
+		},
+		{
+			name: "test2",
+			args: args{
+				err:     ErrInvalidJSAck,
+				message: "test",
+			},
+			wantNil:   false,
+			wantError: "nats: invalid jetstream publish response: test",
+		},
+		{
+			name: "test2",
+			args: args{
+				err:     ErrInvalidJSAck,
+				message: "",
+			},
+			wantNil:   false,
+			wantError: "nats: invalid jetstream publish response: ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapError(tt.args.err, tt.args.message)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("wrapError() = %v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Errorf("wrapError() = %v, want not nil", got)
+			} else if got.Error() != tt.wantError {
+				t.Errorf("wrapError() = %v, want %v", got, tt.wantError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
ErrInvalidJsAck is not explicit in analysing or locating the error cause, so add an external message makes error clear.

helpful in issue #1512