### PR TITLE
[ADDED] Paging subjects in stream info

### DIFF
--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -158,6 +158,7 @@ type (
 	}
 	streamInfoResponse struct {
 		apiResponse
+		apiPaged
 		*StreamInfo
 	}
 

--- a/jetstream/options.go
+++ b/jetstream/options.go
@@ -264,7 +264,11 @@ func WithDeletedDetails(deletedDetails bool) StreamInfoOpt {
 	}
 }
 
-// WithSubjectFilter can be used to display the information about messages stored on given subjects
+// WithSubjectFilter can be used to display the information about messages
+// stored on given subjects.
+// NOTE: if the subject filter matches over 100k
+// subjects, this will result in multiple requests to the server to retrieve all
+// the information, and all of the returned subjects will be kept in memory.
 func WithSubjectFilter(subject string) StreamInfoOpt {
 	return func(req *streamInfoRequest) error {
 		req.SubjectFilter = subject

--- a/jetstream/test/stream_test.go
+++ b/jetstream/test/stream_test.go
@@ -610,6 +610,48 @@ func TestStreamInfo(t *testing.T) {
 	}
 }
 
+func TestSubjectsFilterPaging(t *testing.T) {
+	srv := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, srv)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer nc.Close()
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	s, err := js.CreateStream(context.Background(), jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	for i := 0; i < 110000; i++ {
+		if _, err := js.PublishAsync(fmt.Sprintf("FOO.%d", i), nil); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	}
+	select {
+	case <-js.PublishAsyncComplete():
+	case <-time.After(5 * time.Second):
+		t.Fatal("PublishAsyncComplete timeout")
+	}
+
+	info, err := s.Info(context.Background(), jetstream.WithSubjectFilter("FOO.*"))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(info.State.Subjects) != 110000 {
+		t.Fatalf("Unexpected number of subjects; want: 110000; got: %d", len(info.State.Subjects))
+	}
+	cInfo := s.CachedInfo()
+	if len(cInfo.State.Subjects) != 110000 {
+		t.Fatalf("Unexpected number of subjects; want: 110000; got: %d", len(cInfo.State.Subjects))
+	}
+}
+
 func TestStreamCachedInfo(t *testing.T) {
 	srv := RunBasicJetStreamServer()
 	defer shutdownJSServerAndRemoveStorage(t, srv)

--- a/jetstream/test/stream_test.go
+++ b/jetstream/test/stream_test.go
@@ -647,8 +647,8 @@ func TestSubjectsFilterPaging(t *testing.T) {
 		t.Fatalf("Unexpected number of subjects; want: 110000; got: %d", len(info.State.Subjects))
 	}
 	cInfo := s.CachedInfo()
-	if len(cInfo.State.Subjects) != 110000 {
-		t.Fatalf("Unexpected number of subjects; want: 110000; got: %d", len(cInfo.State.Subjects))
+	if len(cInfo.State.Subjects) != 0 {
+		t.Fatalf("Unexpected number of subjects; want: 0; got: %d", len(cInfo.State.Subjects))
 	}
 }
 


### PR DESCRIPTION
This functionality has been available in legacy API but not in the new one. It addresses https://github.com/nats-io/nats-architecture-and-design/issues/153

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>