### PR TITLE
Release v1.32.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ When using or transitioning to Go modules support:
 ```bash
 # Go client latest or explicit version
 go get github.com/nats-io/nats.go/@latest
-go get github.com/nats-io/nats.go/@v1.31.0
+go get github.com/nats-io/nats.go/@v1.32.0
 
 # For latest NATS Server, add /v2 at the end
 go get github.com/nats-io/nats-server/v2

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.31.0"
+	Version                   = "1.32.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
### Added
- JetStream:
  - ObjectStore is now available as part of `jetstream` package (#1450)
  - `Drain` method for `ConsumeContext` and `MessagesContext`. Unlike `Stop()`, in addition to unsubscribing and canceling the existing pull requests it will ensure that all messages already stored in client buffer will be available for processing (#1515)
  - Return account reservations on `AccountInfo`. **NOTE**: This is only available since nats-server@v2.10.8 (#1511)
  - Paging `Subjects` on `Stream.Info()` response when `WithSubjectFilter()` option is used (#1517)
- KeyValue:
  - `Compression` option on `KeyValueConfig` (#1451)
  - `ListKeys` method for efficiently iterating over all keys in KV bucket (#1490)
  - `ResumeFromRevision` option for KV watcher (#1489)

### Fixed
- Legacy JetStream:
  - Fixed and issue where ordered consumer was recreated with different name format than the original (#1449)
- JetStream:
  - Fixed an issue where `WithRetryAttempts()` and `WithRetryWait()` options were ignored in `PublishAsync()` (#1464)
  - Fixed invalid `PullExpiry` validation in `Consumer.Messages()` options (#1468)
  - Fixed race condition on `Stop()` method for `ConsumeContext` and `MessagesContext` . (#1454)
  - Fixed issues with `Next()` method for ordered consumers (#1471, #1472)
  - Fixed ignoring a private inbox prefix in `JetStream.Publish()` (#1474)
  - Fixed invalid PAF id for `PublishAsync()` (#1476)
  - Fixed race condition when getting pull subscriptions in ordered consumer (#1497)
  - Fixed several issues in `checkPending` logic (#1516)
- KeyValue:
  - Removed `KV_` prefix when listing KeyValue store names (#1487) 
- Service API:
  - Fixed race condition when adding endpoints concurrently (#1484) 

### Improved
- Bumped `nkeys` and `compress` dependencies to latest versions (#1458, #1514)
- Fixed broken link in `jetstream/README.md` (#1448)
- Improvements for code quality across the library (#1498, #1500)
- Legacy JetStream:
  - Library now attempts to delete ordered consumer before creating new one to avoid piling up consumers on reset (#1449)
- Service API:
  - Added compatibility tests for Service API (#1443)