### PR TITLE
Fix `Drain()` infinite loop and minimize lock scope in `Next()`

### DIFF
--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -116,7 +116,6 @@ type (
 		closed            uint32
 		draining          uint32
 		done              chan struct{}
-		drained           chan struct{}
 		connStatusChanged chan nats.Status
 		fetchNext         chan *pullRequest
 		consumeOpts       *consumeOpts
@@ -476,7 +475,6 @@ func (p *pullConsumer) Messages(opts ...PullMessagesOpt) (MessagesContext, error
 		id:          consumeID,
 		consumer:    p,
 		done:        make(chan struct{}, 1),
-		drained:     make(chan struct{}, 1),
 		msgs:        msgs,
 		errs:        make(chan error, 1),
 		fetchNext:   make(chan *pullRequest, 1),


### PR DESCRIPTION
This is a possible fix for #1524.

Previously when calling `Stop()` we were checking for the `done` channel to be closed to exit the loop in `Next()`, but as stated in #1524 this didn't work for `Drain()` as it also closes the `done` channel, so now we check the `msgs` channel if closed to exit the loop, but this required some changes to how locking was done to prevent a deadlock, as `Next()` was holding the lock until it returns (which might take a long time), that prevented `cleanup()` from executing (waiting for the lock) to unsubscribe (where the `msgs` channel is closed).

Changes in this pull request:
1. Added test for graceful shutdown for `Drain()`
2. Minimized the lock scope in `Next()`
3. Removed an unused `drained` channel from `pullSubscription`

I know that the lock and unlock calls are ugly but I didn't want to make a major refactor to the code, maybe a better solution would be to use multiple locks, for example one lock dedicated only for the subscription.