### PR TITLE
Improve `jetstream` documentation

### DIFF
--- a/jetstream/consumer.go
+++ b/jetstream/consumer.go
@@ -57,7 +57,7 @@ type (
 		FetchBytes(maxBytes int, opts ...FetchOpt) (MessageBatch, error)
 
 		// FetchNoWait is used to retrieve up to a provided number of messages
-		// from a stream. This method will always send a single request and
+		// from a stream. This method will send a single request and
 		// immediately return up to a provided number of messages or wait until
 		// at least one message is available or request times out.
 		FetchNoWait(batch int) (MessageBatch, error)

--- a/jetstream/consumer_config.go
+++ b/jetstream/consumer_config.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The NATS Authors
+// Copyright 2022-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,85 +20,243 @@ import (
 )
 
 type (
-	// ConsumerInfo is the info from a JetStream consumer.
+	// ConsumerInfo is the detailed information about a JetStream consumer.
 	ConsumerInfo struct {
-		Stream         string         `json:"stream_name"`
-		Name           string         `json:"name"`
-		Created        time.Time      `json:"created"`
-		Config         ConsumerConfig `json:"config"`
-		Delivered      SequenceInfo   `json:"delivered"`
-		AckFloor       SequenceInfo   `json:"ack_floor"`
-		NumAckPending  int            `json:"num_ack_pending"`
-		NumRedelivered int            `json:"num_redelivered"`
-		NumWaiting     int            `json:"num_waiting"`
-		NumPending     uint64         `json:"num_pending"`
-		Cluster        *ClusterInfo   `json:"cluster,omitempty"`
-		PushBound      bool           `json:"push_bound,omitempty"`
+		// Stream specifies the name of the stream that the consumer is bound
+		// to.
+		Stream string `json:"stream_name"`
+
+		// Name represents the unique identifier for the consumer. This can be
+		// either set explicitly by the client or generated automatically if not
+		// set.
+		Name string `json:"name"`
+
+		// Created is the timestamp when the consumer was created.
+		Created time.Time `json:"created"`
+
+		// Config contains the configuration settings of the consumer, set when
+		// creating or updating the consumer.
+		Config ConsumerConfig `json:"config"`
+
+		// Delivered holds information about the most recently delivered
+		// message, including its sequence numbers and timestamp.
+		Delivered SequenceInfo `json:"delivered"`
+
+		// AckFloor tracks the highest sequence number of a message that has
+		// been acknowledged.
+		AckFloor SequenceInfo `json:"ack_floor"`
+
+		// NumAckPending is the number of messages that have been delivered but
+		// not yet acknowledged.
+		NumAckPending int `json:"num_ack_pending"`
+
+		// NumRedelivered counts the number of messages that have been
+		// redelivered and not yet acknowledged. Each message is counted only
+		// once, even if it has been redelivered multiple times. This count is
+		// reset when the message is eventually acknowledged.
+		NumRedelivered int `json:"num_redelivered"`
+
+		// NumWaiting is the count of active pull requests. It is only relevant
+		// for pull-based consumers.
+		NumWaiting int `json:"num_waiting"`
+
+		// NumPending is the number of messages that are pending to be delivered
+		// to this consumer.
+		NumPending uint64 `json:"num_pending"`
+
+		// Cluster contains information about the cluster to which this consumer
+		// belongs (if applicable).
+		Cluster *ClusterInfo `json:"cluster,omitempty"`
+
+		// PushBound indicates whether at least one subscription exists for the
+		// delivery subject of this consumer. This is only applicable to
+		// push-based consumers.
+		PushBound bool `json:"push_bound,omitempty"`
 	}
 
 	// ConsumerConfig is the configuration of a JetStream consumer.
 	ConsumerConfig struct {
-		Name               string          `json:"name,omitempty"`
-		Durable            string          `json:"durable_name,omitempty"`
-		Description        string          `json:"description,omitempty"`
-		DeliverPolicy      DeliverPolicy   `json:"deliver_policy"`
-		OptStartSeq        uint64          `json:"opt_start_seq,omitempty"`
-		OptStartTime       *time.Time      `json:"opt_start_time,omitempty"`
-		AckPolicy          AckPolicy       `json:"ack_policy"`
-		AckWait            time.Duration   `json:"ack_wait,omitempty"`
-		MaxDeliver         int             `json:"max_deliver,omitempty"`
-		BackOff            []time.Duration `json:"backoff,omitempty"`
-		FilterSubject      string          `json:"filter_subject,omitempty"`
-		ReplayPolicy       ReplayPolicy    `json:"replay_policy"`
-		RateLimit          uint64          `json:"rate_limit_bps,omitempty"` // Bits per sec
-		SampleFrequency    string          `json:"sample_freq,omitempty"`
-		MaxWaiting         int             `json:"max_waiting,omitempty"`
-		MaxAckPending      int             `json:"max_ack_pending,omitempty"`
-		HeadersOnly        bool            `json:"headers_only,omitempty"`
-		MaxRequestBatch    int             `json:"max_batch,omitempty"`
-		MaxRequestExpires  time.Duration   `json:"max_expires,omitempty"`
-		MaxRequestMaxBytes int             `json:"max_bytes,omitempty"`
+		// Name is an optional name for the consumer. If not set, one is
+		// generated automatically.
+		Name string `json:"name,omitempty"`
 
-		// Inactivity threshold.
+		// Durable is an optional durable name for the consumer. If both Durable
+		// and Name are set, they have to be equal. If Durable is set and Name
+		// is not, Name is set to Durable. Unless InactiveThreshold is set, a
+		// durable consumer will not be cleaned up automatically.
+		Durable string `json:"durable_name,omitempty"`
+
+		// Description provides an optional description of the consumer.
+		Description string `json:"description,omitempty"`
+
+		// DeliverPolicy defines from which point to start delivering messages
+		// from the stream. Defaults to DeliverAllPolicy.
+		DeliverPolicy DeliverPolicy `json:"deliver_policy"`
+
+		// OptStartSeq is an optional sequence number from which to start
+		// message delivery. Only applicable when DeliverPolicy is set to
+		// DeliverByStartSequencePolicy.
+		OptStartSeq uint64 `json:"opt_start_seq,omitempty"`
+
+		// OptStartTime is an optional time from which to start message
+		// delivery. Only applicable when DeliverPolicy is set to
+		// DeliverByStartTimePolicy.
+		OptStartTime *time.Time `json:"opt_start_time,omitempty"`
+
+		// AckPolicy defines the acknowledgement policy for the consumer.
+		// Defaults to AckExplicitPolicy.
+		AckPolicy AckPolicy `json:"ack_policy"`
+
+		// AckWait defines how long the server will wait for an acknowledgement
+		// before resending a message. Defaults to 30 seconds.
+		AckWait time.Duration `json:"ack_wait,omitempty"`
+
+		// MaxDeliver defines the maximum number of delivery attempts for a
+		// message. Applies to any message that is re-sent due to ack policy.
+		// Defaults to -1 (unlimited).
+		MaxDeliver int `json:"max_deliver,omitempty"`
+
+		// BackOff specifies the optional back-off intervals for retrying
+		// message delivery after a failed acknowledgement. It overrides
+		// AckWait.
+		//
+		// The number of intervals specified must be lower or equal to
+		// MaxDeliver. If the number of intervals is lower, the last interval is
+		// used for all remaining attempts.
+		BackOff []time.Duration `json:"backoff,omitempty"`
+
+		// FilterSubject can be used to filter messages delivered form the
+		// stream. It has to overlap with the subjects defined on the stream.
+		// FilterSubject is exclusive with FilterSubjects.
+		FilterSubject string `json:"filter_subject,omitempty"`
+
+		// ReplayPolicy defines the rate at which messages are sent to the
+		// consumer. If ReplayOriginalPolicy is set, messages are sent at the
+		// same rate as they were stored in the stream. If ReplayInstantPolicy
+		// is set, messages are sent as fast as possible. Defaults to
+		// ReplayInstantPolicy.
+		ReplayPolicy ReplayPolicy `json:"replay_policy"`
+
+		// RateLimit specifies an optional maximum rate of message delivery in
+		// bits per second.
+		RateLimit uint64 `json:"rate_limit_bps,omitempty"`
+
+		// SampleFrequency is an optional frequency for sampling how often
+		// acknowledgements are sampled for observability. See
+		// https://docs.nats.io/running-a-nats-service/nats_admin/monitoring/monitoring_jetstream
+		SampleFrequency string `json:"sample_freq,omitempty"`
+
+		// MaxWaiting is a maximum number of pull requests waiting to be
+		// fulfilled. Defaults to 512.
+		MaxWaiting int `json:"max_waiting,omitempty"`
+
+		// MaxAckPending is a maximum number of outstanding unacknowledged
+		// messages. Once this limit is reached, the server will suspend sending
+		// messages to the consumer. Defaults to 1000. Set to -1 for unlimited.
+		MaxAckPending int `json:"max_ack_pending,omitempty"`
+
+		// HeadersOnly indicates whether only headers of messages should be sent
+		// (and no payload). Defaults to false.
+		HeadersOnly bool `json:"headers_only,omitempty"`
+
+		// MaxRequestBatch is the optional maximum batch size a single pull
+		// request can make. When set with MaxRequestMaxBytes, the batch size
+		// will be constrained by whichever limit is hit first.
+		MaxRequestBatch int `json:"max_batch,omitempty"`
+
+		// MaxRequestExpires is the maximum duration a single pull request will
+		// wait for messages to be available to pull.
+		MaxRequestExpires time.Duration `json:"max_expires,omitempty"`
+
+		// MaxRequestMaxBytes is the optional maximum total bytes that can be
+		// requested in a given batch. When set with MaxRequestBatch, the batch
+		// size will be constrained by whichever limit is hit first.
+		MaxRequestMaxBytes int `json:"max_bytes,omitempty"`
+
+		// InactiveThreshold is a duration which instructs the server to clean
+		// up the consumer if it has been inactive for the specified duration.
+		// Defaults to 5s for non-durable consumers. Durable consumers will not
+		// be cleaned up by default, but if InactiveThreshold is set, they will
+		// be.
 		InactiveThreshold time.Duration `json:"inactive_threshold,omitempty"`
 
-		// Generally inherited by parent stream and other markers, now can be configured directly.
+		// Replicas the number of replicas for the consumer's state. By default,
+		// consumers inherit the number of replicas from the stream.
 		Replicas int `json:"num_replicas"`
-		// Force memory storage.
+
+		// MemoryStorage is a flag to force the consumer to use memory storage
+		// rather than inherit the storage type from the stream.
 		MemoryStorage bool `json:"mem_storage,omitempty"`
 
-		// NOTE: FilterSubjects requires nats-server v2.10.0+
+		// FilterSubjects is a set of subjects that overlap with the subjects
+		// bound to the stream to filter delivered messages. This field is
+		// exclusive with FilterSubject. Requires nats-server v2.10.0 or later.
 		FilterSubjects []string `json:"filter_subjects,omitempty"`
 
-		// Metadata is additional metadata for the Consumer.
-		// Keys starting with `_nats` are reserved.
-		// NOTE: Metadata requires nats-server v2.10.0+
+		// Metadata is a set of application-defined key-value pairs for
+		// associating metadata on the consumer. This feature requires
+		// nats-server v2.10.0 or later.
 		Metadata map[string]string `json:"metadata,omitempty"`
 	}
 
+	// OrderedConsumerConfig is the configuration of an ordered JetStream
+	// consumer. For more information, see [Ordered Consumers] in README
+	//
+	// [Ordered Consumers]: https://github.com/nats-io/nats.go/blob/main/jetstream/README.md#ordered-consumers
 	OrderedConsumerConfig struct {
-		FilterSubjects    []string      `json:"filter_subjects,omitempty"`
-		DeliverPolicy     DeliverPolicy `json:"deliver_policy"`
-		OptStartSeq       uint64        `json:"opt_start_seq,omitempty"`
-		OptStartTime      *time.Time    `json:"opt_start_time,omitempty"`
-		ReplayPolicy      ReplayPolicy  `json:"replay_policy"`
-		InactiveThreshold time.Duration `json:"inactive_threshold,omitempty"`
-		HeadersOnly       bool          `json:"headers_only,omitempty"`
+		// FilterSubjects is a set of subjects that overlap with the subjects
+		// bound to the stream to filter delivered messages. Requires
+		// nats-server v2.10.0 or later.
+		FilterSubjects []string `json:"filter_subjects,omitempty"`
 
-		// Maximum number of attempts for the consumer to be recreated
-		// Defaults to unlimited
+		// DeliverPolicy defines from which point to start delivering messages
+		// from the stream. Defaults to DeliverAllPolicy.
+		DeliverPolicy DeliverPolicy `json:"deliver_policy"`
+
+		// OptStartSeq is an optional sequence number from which to start
+		// message delivery. Only applicable when DeliverPolicy is set to
+		// DeliverByStartSequencePolicy.
+		OptStartSeq uint64 `json:"opt_start_seq,omitempty"`
+
+		// OptStartTime is an optional time from which to start message
+		// delivery. Only applicable when DeliverPolicy is set to
+		// DeliverByStartTimePolicy.
+		OptStartTime *time.Time `json:"opt_start_time,omitempty"`
+
+		// ReplayPolicy defines the rate at which messages are sent to the
+		// consumer. If ReplayOriginalPolicy is set, messages are sent at the
+		// same rate as they were stored in the stream. If ReplayInstantPolicy
+		// is set, messages are sent as fast as possible. Defaults to
+		// ReplayInstantPolicy.
+		ReplayPolicy ReplayPolicy `json:"replay_policy"`
+
+		// InactiveThreshold is a duration which instructs the server to clean
+		// up the consumer if it has been inactive for the specified duration.
+		// Defaults to 5s.
+		InactiveThreshold time.Duration `json:"inactive_threshold,omitempty"`
+
+		// HeadersOnly indicates whether only headers of messages should be sent
+		// (and no payload). Defaults to false.
+		HeadersOnly bool `json:"headers_only,omitempty"`
+
+		// Maximum number of attempts for the consumer to be recreated in a
+		// single recreation cycle. Defaults to unlimited.
 		MaxResetAttempts int
 	}
 
+	// DeliverPolicy determines from which point to start delivering messages.
 	DeliverPolicy int
 
-	// AckPolicy determines how the consumer should acknowledge delivered messages.
+	// AckPolicy determines how the consumer should acknowledge delivered
+	// messages.
 	AckPolicy int
 
-	// ReplayPolicy determines how the consumer should replay messages it already has queued in the stream.
+	// ReplayPolicy determines how the consumer should replay messages it
+	// already has queued in the stream.
 	ReplayPolicy int
 
-	// SequenceInfo has both the consumer and the stream sequence and last activity.
+	// SequenceInfo has both the consumer and the stream sequence and last
+	// activity.
 	SequenceInfo struct {
 		Consumer uint64     `json:"consumer_seq"`
 		Stream   uint64     `json:"stream_seq"`
@@ -120,11 +278,11 @@ const (
 	DeliverNewPolicy
 
 	// DeliverByStartSequencePolicy will deliver messages starting from a given
-	// sequence.
+	// sequence configured with OptStartSeq in ConsumerConfig.
 	DeliverByStartSequencePolicy
 
-	// DeliverByStartTimePolicy will deliver messages starting from a given
-	// time.
+	// DeliverByStartTimePolicy will deliver messages starting from a given time
+	// configured with OptStartTime in ConsumerConfig.
 	DeliverByStartTimePolicy
 
 	// DeliverLastPerSubjectPolicy will start the consumer with the last message
@@ -243,7 +401,8 @@ const (
 	// ReplayInstantPolicy will replay messages as fast as possible.
 	ReplayInstantPolicy ReplayPolicy = iota
 
-	// ReplayOriginalPolicy will maintain the same timing as the messages were received.
+	// ReplayOriginalPolicy will maintain the same timing as the messages were
+	// received.
 	ReplayOriginalPolicy
 )
 

--- a/jetstream/errors.go
+++ b/jetstream/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The NATS Authors
+// Copyright 2022-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,7 +20,7 @@ import (
 
 type (
 	// JetStreamError is an error result that happens when using JetStream.
-	// In case of client-side error, [APIError] returns nil
+	// In case of client-side error, [APIError] returns nil.
 	JetStreamError interface {
 		APIError() *APIError
 		error
@@ -38,7 +38,7 @@ type (
 		Description string    `json:"description,omitempty"`
 	}
 
-	// ErrorCode represents error_code returned in response from JetStream API
+	// ErrorCode represents error_code returned in response from JetStream API.
 	ErrorCode uint16
 )
 
@@ -69,60 +69,76 @@ const (
 var (
 	// API errors
 
-	// ErrJetStreamNotEnabled is an error returned when JetStream is not enabled.
+	// ErrJetStreamNotEnabled is an error returned when JetStream is not
+	// enabled.
 	ErrJetStreamNotEnabled JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeJetStreamNotEnabled, Description: "jetstream not enabled", Code: 503}}
 
-	// ErrJetStreamNotEnabledForAccount is an error returned when JetStream is not enabled for an account.
+	// ErrJetStreamNotEnabledForAccount is an error returned when JetStream is
+	// not enabled for an account.
 	ErrJetStreamNotEnabledForAccount JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeJetStreamNotEnabledForAccount, Description: "jetstream not enabled for account", Code: 503}}
 
-	// ErrStreamNotFound is an error returned when stream with given name does not exist.
+	// ErrStreamNotFound is an error returned when stream with given name does
+	// not exist.
 	ErrStreamNotFound JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeStreamNotFound, Description: "stream not found", Code: 404}}
 
-	// ErrStreamNameAlreadyInUse is returned when a stream with given name already exists and has a different configuration.
+	// ErrStreamNameAlreadyInUse is returned when a stream with given name
+	// already exists and has a different configuration.
 	ErrStreamNameAlreadyInUse JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeStreamNameInUse, Description: "stream name already in use", Code: 400}}
 
-	// ErrStreamSubjectTransformNotSupported is returned when the connected nats-server version does not support setting
-	// the stream subject transform. If this error is returned when executing CreateStream(), the stream with invalid
-	// configuration was already created in the server.
+	// ErrStreamSubjectTransformNotSupported is returned when the connected
+	// nats-server version does not support setting the stream subject
+	// transform. If this error is returned when executing CreateStream(), the
+	// stream with invalid configuration was already created in the server.
 	ErrStreamSubjectTransformNotSupported JetStreamError = &jsError{message: "stream subject transformation not supported by nats-server"}
 
-	// ErrStreamSourceSubjectTransformNotSupported is returned when the connected nats-server version does not support setting
-	// the stream source subject transform. If this error is returned when executing CreateStream(), the stream with invalid
-	// configuration was already created in the server.
+	// ErrStreamSourceSubjectTransformNotSupported is returned when the
+	// connected nats-server version does not support setting the stream source
+	// subject transform. If this error is returned when executing
+	// CreateStream(), the stream with invalid configuration was already created
+	// in the server.
 	ErrStreamSourceSubjectTransformNotSupported JetStreamError = &jsError{message: "stream subject transformation not supported by nats-server"}
 
-	// ErrStreamSourceNotSupported is returned when the connected nats-server version does not support setting
-	// the stream sources. If this error is returned when executing CreateStream(), the stream with invalid
+	// ErrStreamSourceNotSupported is returned when the connected nats-server
+	// version does not support setting the stream sources. If this error is
+	// returned when executing CreateStream(), the stream with invalid
 	// configuration was already created in the server.
 	ErrStreamSourceNotSupported JetStreamError = &jsError{message: "stream sourcing is not supported by nats-server"}
 
-	// ErrStreamSourceMultipleFilterSubjectsNotSupported is returned when the connected nats-server version does not support setting
-	// the stream sources. If this error is returned when executing CreateStream(), the stream with invalid
-	// configuration was already created in the server.
+	// ErrStreamSourceMultipleFilterSubjectsNotSupported is returned when the
+	// connected nats-server version does not support setting the stream
+	// sources. If this error is returned when executing CreateStream(), the
+	// stream with invalid configuration was already created in the server.
 	ErrStreamSourceMultipleFilterSubjectsNotSupported JetStreamError = &jsError{message: "stream sourcing with multiple subject filters not supported by nats-server"}
 
-	// ErrConsumerNotFound is an error returned when consumer with given name does not exist.
+	// ErrConsumerNotFound is an error returned when consumer with given name
+	// does not exist.
 	ErrConsumerNotFound JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeConsumerNotFound, Description: "consumer not found", Code: 404}}
 
-	// ErrConsumerExists is returned when attempting to create a consumer with CreateConsumer but a consumer with given name already exists.
+	// ErrConsumerExists is returned when attempting to create a consumer with
+	// CreateConsumer but a consumer with given name already exists.
 	ErrConsumerExists JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeConsumerExists, Description: "consumer already exists", Code: 400}}
 
-	// ErrConsumerNameExists is returned when attempting to update a consumer with UpdateConsumer but a consumer with given name does not exist.
+	// ErrConsumerNameExists is returned when attempting to update a consumer
+	// with UpdateConsumer but a consumer with given name does not exist.
 	ErrConsumerDoesNotExist JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeConsumerDoesNotExist, Description: "consumer does not exist", Code: 400}}
 
-	// ErrMsgNotFound is returned when message with provided sequence number does not exist.
+	// ErrMsgNotFound is returned when message with provided sequence number
+	// does not exist.
 	ErrMsgNotFound JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeMessageNotFound, Description: "message not found", Code: 404}}
 
 	// ErrBadRequest is returned when invalid request is sent to JetStream API.
 	ErrBadRequest JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeBadRequest, Description: "bad request", Code: 400}}
 
-	// ErrConsumerCreate is returned when nats-server reports error when creating consumer (e.g. illegal update).
+	// ErrConsumerCreate is returned when nats-server reports error when
+	// creating consumer (e.g. illegal update).
 	ErrConsumerCreate JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeConsumerCreate, Description: "could not create consumer", Code: 500}}
 
-	// ErrDuplicateFilterSubjects is returned when both FilterSubject and FilterSubjects are specified when creating consumer.
+	// ErrDuplicateFilterSubjects is returned when both FilterSubject and
+	// FilterSubjects are specified when creating consumer.
 	ErrDuplicateFilterSubjects JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeDuplicateFilterSubjects, Description: "consumer cannot have both FilterSubject and FilterSubjects specified", Code: 500}}
 
-	// ErrDuplicateFilterSubjects is returned when filter subjects overlap when creating consumer.
+	// ErrDuplicateFilterSubjects is returned when filter subjects overlap when
+	// creating consumer.
 	ErrOverlappingFilterSubjects JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeOverlappingFilterSubjects, Description: "consumer subject filters cannot overlap", Code: 500}}
 
 	// ErrEmptyFilter is returned when a filter in FilterSubjects is empty.
@@ -130,187 +146,230 @@ var (
 
 	// Client errors
 
-	// ErrConsumerMultipleFilterSubjectsNotSupported is returned when the connected nats-server version does not support setting
-	// multiple filter subjects with filter_subjects field. If this error is returned when executing AddConsumer(), the consumer with invalid
-	// configuration was already created in the server.
+	// ErrConsumerMultipleFilterSubjectsNotSupported is returned when the
+	// connected nats-server version does not support setting multiple filter
+	// subjects with filter_subjects field. If this error is returned when
+	// executing AddConsumer(), the consumer with invalid configuration was
+	// already created in the server.
 	ErrConsumerMultipleFilterSubjectsNotSupported JetStreamError = &jsError{message: "multiple consumer filter subjects not supported by nats-server"}
 
-	// ErrConsumerNotFound is an error returned when consumer with given name does not exist.
+	// ErrConsumerNotFound is an error returned when consumer with given name
+	// does not exist.
 	ErrConsumerNameAlreadyInUse JetStreamError = &jsError{message: "consumer name already in use"}
 
-	// ErrInvalidJSAck is returned when JetStream ack from message publish is invalid.
+	// ErrInvalidJSAck is returned when JetStream ack from message publish is
+	// invalid.
 	ErrInvalidJSAck JetStreamError = &jsError{message: "invalid jetstream publish response"}
 
 	// ErrStreamNameRequired is returned when the provided stream name is empty.
 	ErrStreamNameRequired JetStreamError = &jsError{message: "stream name is required"}
 
-	// ErrMsgAlreadyAckd is returned when attempting to acknowledge message more than once.
+	// ErrMsgAlreadyAckd is returned when attempting to acknowledge message more
+	// than once.
 	ErrMsgAlreadyAckd JetStreamError = &jsError{message: "message was already acknowledged"}
 
-	// ErrNoStreamResponse is returned when there is no response from stream (e.g. no responders error).
+	// ErrNoStreamResponse is returned when there is no response from stream
+	// (e.g. no responders error).
 	ErrNoStreamResponse JetStreamError = &jsError{message: "no response from stream"}
 
-	// ErrNotJSMessage is returned when attempting to get metadata from non JetStream message.
+	// ErrNotJSMessage is returned when attempting to get metadata from non
+	// JetStream message.
 	ErrNotJSMessage JetStreamError = &jsError{message: "not a jetstream message"}
 
-	// ErrInvalidStreamName is returned when the provided stream name is invalid (contains '.').
+	// ErrInvalidStreamName is returned when the provided stream name is invalid
+	// (contains '.').
 	ErrInvalidStreamName JetStreamError = &jsError{message: "invalid stream name"}
 
 	// ErrInvalidSubject is returned when the provided subject name is invalid.
 	ErrInvalidSubject JetStreamError = &jsError{message: "invalid subject name"}
 
-	// ErrInvalidConsumerName is returned when the provided consumer name is invalid (contains '.').
+	// ErrInvalidConsumerName is returned when the provided consumer name is
+	// invalid (contains '.').
 	ErrInvalidConsumerName JetStreamError = &jsError{message: "invalid consumer name"}
 
-	// ErrNoMessages is returned when no messages are currently available for a consumer.
-	ErrNoMessages = &jsError{message: "no messages"}
+	// ErrNoMessages is returned when no messages are currently available for a
+	// consumer.
+	ErrNoMessages JetStreamError = &jsError{message: "no messages"}
 
-	// ErrMaxBytesExceeded is returned when a message would exceed MaxBytes set on a pull request.
-	ErrMaxBytesExceeded = &jsError{message: "message size exceeds max bytes"}
+	// ErrMaxBytesExceeded is returned when a message would exceed MaxBytes set
+	// on a pull request.
+	ErrMaxBytesExceeded JetStreamError = &jsError{message: "message size exceeds max bytes"}
 
-	// ErrConsumerDeleted is returned when attempting to send pull request to a consumer which does not exist.
+	// ErrConsumerDeleted is returned when attempting to send pull request to a
+	// consumer which does not exist.
 	ErrConsumerDeleted JetStreamError = &jsError{message: "consumer deleted"}
 
-	// ErrConsumerLeadershipChanged is returned when pending requests are no longer valid after leadership has changed.
+	// ErrConsumerLeadershipChanged is returned when pending requests are no
+	// longer valid after leadership has changed.
 	ErrConsumerLeadershipChanged JetStreamError = &jsError{message: "leadership change"}
 
-	// ErrHandlerRequired is returned when no handler func is provided in Stream().
-	ErrHandlerRequired = &jsError{message: "handler cannot be empty"}
+	// ErrHandlerRequired is returned when no handler func is provided in
+	// Stream().
+	ErrHandlerRequired JetStreamError = &jsError{message: "handler cannot be empty"}
 
-	// ErrEndOfData is returned when iterating over paged API from JetStream reaches end of data.
-	ErrEndOfData = &jsError{message: "end of data reached"}
+	// ErrEndOfData is returned when iterating over paged API from JetStream
+	// reaches end of data.
+	ErrEndOfData JetStreamError = &jsError{message: "end of data reached"}
 
-	// ErrNoHeartbeat is received when no message is received in IdleHeartbeat time (if set).
-	ErrNoHeartbeat = &jsError{message: "no heartbeat received"}
+	// ErrNoHeartbeat is received when no message is received in IdleHeartbeat
+	// time (if set).
+	ErrNoHeartbeat JetStreamError = &jsError{message: "no heartbeat received"}
 
-	// ErrConsumerHasActiveSubscription is returned when a consumer is already subscribed to a stream.
-	ErrConsumerHasActiveSubscription = &jsError{message: "consumer has active subscription"}
+	// ErrConsumerHasActiveSubscription is returned when a consumer is already
+	// subscribed to a stream.
+	ErrConsumerHasActiveSubscription JetStreamError = &jsError{message: "consumer has active subscription"}
 
-	// ErrMsgNotBound is returned when given message is not bound to any subscription.
-	ErrMsgNotBound = &jsError{message: "message is not bound to subscription/connection"}
+	// ErrMsgNotBound is returned when given message is not bound to any
+	// subscription.
+	ErrMsgNotBound JetStreamError = &jsError{message: "message is not bound to subscription/connection"}
 
-	// ErrMsgNoReply is returned when attempting to reply to a message without a reply subject.
-	ErrMsgNoReply = &jsError{message: "message does not have a reply"}
+	// ErrMsgNoReply is returned when attempting to reply to a message without a
+	// reply subject.
+	ErrMsgNoReply JetStreamError = &jsError{message: "message does not have a reply"}
 
-	// ErrMsgDeleteUnsuccessful is returned when an attempt to delete a message is unsuccessful.
-	ErrMsgDeleteUnsuccessful = &jsError{message: "message deletion unsuccessful"}
+	// ErrMsgDeleteUnsuccessful is returned when an attempt to delete a message
+	// is unsuccessful.
+	ErrMsgDeleteUnsuccessful JetStreamError = &jsError{message: "message deletion unsuccessful"}
 
-	// ErrAsyncPublishReplySubjectSet is returned when reply subject is set on async message publish.
-	ErrAsyncPublishReplySubjectSet = &jsError{message: "reply subject should be empty"}
+	// ErrAsyncPublishReplySubjectSet is returned when reply subject is set on
+	// async message publish.
+	ErrAsyncPublishReplySubjectSet JetStreamError = &jsError{message: "reply subject should be empty"}
 
-	// ErrTooManyStalledMsgs is returned when too many outstanding async messages are waiting for ack.
-	ErrTooManyStalledMsgs = &jsError{message: "stalled with too many outstanding async published messages"}
+	// ErrTooManyStalledMsgs is returned when too many outstanding async
+	// messages are waiting for ack.
+	ErrTooManyStalledMsgs JetStreamError = &jsError{message: "stalled with too many outstanding async published messages"}
 
 	// ErrInvalidOption is returned when there is a collision between options.
-	ErrInvalidOption = &jsError{message: "invalid jetstream option"}
+	ErrInvalidOption JetStreamError = &jsError{message: "invalid jetstream option"}
 
-	// ErrMsgIteratorClosed is returned when attempting to get message from a closed iterator.
-	ErrMsgIteratorClosed = &jsError{message: "messages iterator closed"}
+	// ErrMsgIteratorClosed is returned when attempting to get message from a
+	// closed iterator.
+	ErrMsgIteratorClosed JetStreamError = &jsError{message: "messages iterator closed"}
 
-	// ErrOrderedConsumerReset is returned when resetting ordered consumer fails due to too many attempts.
-	ErrOrderedConsumerReset = &jsError{message: "recreating ordered consumer"}
+	// ErrOrderedConsumerReset is returned when resetting ordered consumer fails
+	// due to too many attempts.
+	ErrOrderedConsumerReset JetStreamError = &jsError{message: "recreating ordered consumer"}
 
-	// ErrOrderConsumerUsedAsFetch is returned when ordered consumer was already used to process
-	// messages using Fetch (or FetchBytes).
-	ErrOrderConsumerUsedAsFetch = &jsError{message: "ordered consumer initialized as fetch"}
+	// ErrOrderConsumerUsedAsFetch is returned when ordered consumer was already
+	// used to process messages using Fetch (or FetchBytes).
+	ErrOrderConsumerUsedAsFetch JetStreamError = &jsError{message: "ordered consumer initialized as fetch"}
 
-	// ErrOrderConsumerUsedAsConsume is returned when ordered consumer was already used to process
-	// messages using Consume or Messages.
-	ErrOrderConsumerUsedAsConsume = &jsError{message: "ordered consumer initialized as consume"}
+	// ErrOrderConsumerUsedAsConsume is returned when ordered consumer was
+	// already used to process messages using Consume or Messages.
+	ErrOrderConsumerUsedAsConsume JetStreamError = &jsError{message: "ordered consumer initialized as consume"}
 
-	// ErrOrderedConsumerConcurrentRequests is returned when attempting to run concurrent operations
-	// on ordered consumers.
-	ErrOrderedConsumerConcurrentRequests = &jsError{message: "cannot run concurrent processing using ordered consumer"}
+	// ErrOrderedConsumerConcurrentRequests is returned when attempting to run
+	// concurrent operations on ordered consumers.
+	ErrOrderedConsumerConcurrentRequests JetStreamError = &jsError{message: "cannot run concurrent processing using ordered consumer"}
 
-	// ErrOrderedConsumerNotCreated is returned when trying to get consumer info of an
-	// ordered consumer which was not yet created.
-	ErrOrderedConsumerNotCreated = &jsError{message: "consumer instance not yet created"}
+	// ErrOrderedConsumerNotCreated is returned when trying to get consumer info
+	// of an ordered consumer which was not yet created.
+	ErrOrderedConsumerNotCreated JetStreamError = &jsError{message: "consumer instance not yet created"}
 
 	// KeyValue Errors
 
-	// ErrKeyExists is returned when attempting to create a key that already exists.
+	// ErrKeyExists is returned when attempting to create a key that already
+	// exists.
 	ErrKeyExists JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeStreamWrongLastSequence, Code: 400}, message: "key exists"}
 
-	// ErrKeyValueConfigRequired is returned when attempting to create a bucket without a config.
-	ErrKeyValueConfigRequired = &jsError{message: "config required"}
+	// ErrKeyValueConfigRequired is returned when attempting to create a bucket
+	// without a config.
+	ErrKeyValueConfigRequired JetStreamError = &jsError{message: "config required"}
 
-	// ErrInvalidBucketName is returned when attempting to create a bucket with an invalid name.
-	ErrInvalidBucketName = &jsError{message: "invalid bucket name"}
+	// ErrInvalidBucketName is returned when attempting to create a bucket with
+	// an invalid name.
+	ErrInvalidBucketName JetStreamError = &jsError{message: "invalid bucket name"}
 
-	// ErrInvalidKey is returned when attempting to create a key with an invalid name.
-	ErrInvalidKey = &jsError{message: "invalid key"}
+	// ErrInvalidKey is returned when attempting to create a key with an invalid
+	// name.
+	ErrInvalidKey JetStreamError = &jsError{message: "invalid key"}
 
-	// ErrBucketNotFound is returned when attempting to access a bucket that does not exist.
-	ErrBucketNotFound = &jsError{message: "bucket not found"}
+	// ErrBucketNotFound is returned when attempting to access a bucket that
+	// does not exist.
+	ErrBucketNotFound JetStreamError = &jsError{message: "bucket not found"}
 
-	// ErrBadBucket is returned when attempting to access a bucket that is not a key-value store.
-	ErrBadBucket = &jsError{message: "bucket not valid key-value store"}
+	// ErrBadBucket is returned when attempting to access a bucket that is not a
+	// key-value store.
+	ErrBadBucket JetStreamError = &jsError{message: "bucket not valid key-value store"}
 
-	// ErrKeyNotFound is returned when attempting to access a key that does not exist.
-	ErrKeyNotFound = &jsError{message: "key not found"}
+	// ErrKeyNotFound is returned when attempting to access a key that does not
+	// exist.
+	ErrKeyNotFound JetStreamError = &jsError{message: "key not found"}
 
-	// ErrKeyDeleted is returned when attempting to access a key that was deleted.
-	ErrKeyDeleted = &jsError{message: "key was deleted"}
+	// ErrKeyDeleted is returned when attempting to access a key that was
+	// deleted.
+	ErrKeyDeleted JetStreamError = &jsError{message: "key was deleted"}
 
-	// ErrHistoryToLarge is returned when provided history limit is larger than 64.
-	ErrHistoryTooLarge = &jsError{message: "history limited to a max of 64"}
+	// ErrHistoryToLarge is returned when provided history limit is larger than
+	// 64.
+	ErrHistoryTooLarge JetStreamError = &jsError{message: "history limited to a max of 64"}
 
 	// ErrNoKeysFound is returned when no keys are found.
-	ErrNoKeysFound = &jsError{message: "no keys found"}
+	ErrNoKeysFound JetStreamError = &jsError{message: "no keys found"}
 
-	// ErrObjectConfigRequired is returned when attempting to create an object without a config.
-	ErrObjectConfigRequired = &jsError{message: "object-store config required"}
+	// ErrObjectConfigRequired is returned when attempting to create an object
+	// without a config.
+	ErrObjectConfigRequired JetStreamError = &jsError{message: "object-store config required"}
 
-	// ErrBadObjectMeta is returned when the meta information of an object is invalid.
-	ErrBadObjectMeta = &jsError{message: "object-store meta information invalid"}
+	// ErrBadObjectMeta is returned when the meta information of an object is
+	// invalid.
+	ErrBadObjectMeta JetStreamError = &jsError{message: "object-store meta information invalid"}
 
 	// ErrObjectNotFound is returned when an object is not found.
-	ErrObjectNotFound = &jsError{message: "object not found"}
+	ErrObjectNotFound JetStreamError = &jsError{message: "object not found"}
 
-	// ErrInvalidStoreName is returned when the name of an object-store is invalid.
-	ErrInvalidStoreName = &jsError{message: "invalid object-store name"}
+	// ErrInvalidStoreName is returned when the name of an object-store is
+	// invalid.
+	ErrInvalidStoreName JetStreamError = &jsError{message: "invalid object-store name"}
 
 	// ErrDigestMismatch is returned when the digests of an object do not match.
-	ErrDigestMismatch = &jsError{message: "received a corrupt object, digests do not match"}
+	ErrDigestMismatch JetStreamError = &jsError{message: "received a corrupt object, digests do not match"}
 
-	// ErrInvalidDigestFormat is returned when the digest hash of an object has an invalid format.
-	ErrInvalidDigestFormat = &jsError{message: "object digest hash has invalid format"}
+	// ErrInvalidDigestFormat is returned when the digest hash of an object has
+	// an invalid format.
+	ErrInvalidDigestFormat JetStreamError = &jsError{message: "object digest hash has invalid format"}
 
 	// ErrNoObjectsFound is returned when no objects are found.
-	ErrNoObjectsFound = &jsError{message: "no objects found"}
+	ErrNoObjectsFound JetStreamError = &jsError{message: "no objects found"}
 
-	// ErrObjectAlreadyExists is returned when an object with the same name already exists.
-	ErrObjectAlreadyExists = &jsError{message: "an object already exists with that name"}
+	// ErrObjectAlreadyExists is returned when an object with the same name
+	// already exists.
+	ErrObjectAlreadyExists JetStreamError = &jsError{message: "an object already exists with that name"}
 
 	// ErrNameRequired is returned when a name is required.
-	ErrNameRequired = &jsError{message: "name is required"}
+	ErrNameRequired JetStreamError = &jsError{message: "name is required"}
 
-	// ErrLinkNotAllowed is returned when a link cannot be set when putting the object in a bucket.
-	ErrLinkNotAllowed = &jsError{message: "link cannot be set when putting the object in bucket"}
+	// ErrLinkNotAllowed is returned when a link cannot be set when putting the
+	// object in a bucket.
+	ErrLinkNotAllowed JetStreamError = &jsError{message: "link cannot be set when putting the object in bucket"}
 
 	// ErrObjectRequired is returned when an object is required.
 	ErrObjectRequired = &jsError{message: "object required"}
 
-	// ErrNoLinkToDeleted is returned when it is not allowed to link to a deleted object.
-	ErrNoLinkToDeleted = &jsError{message: "not allowed to link to a deleted object"}
+	// ErrNoLinkToDeleted is returned when it is not allowed to link to a
+	// deleted object.
+	ErrNoLinkToDeleted JetStreamError = &jsError{message: "not allowed to link to a deleted object"}
 
-	// ErrNoLinkToLink is returned when it is not allowed to link to another link.
-	ErrNoLinkToLink = &jsError{message: "not allowed to link to another link"}
+	// ErrNoLinkToLink is returned when it is not allowed to link to another
+	// link.
+	ErrNoLinkToLink JetStreamError = &jsError{message: "not allowed to link to another link"}
 
-	// ErrCantGetBucket is returned when an invalid Get is attempted on an object that is a link to a bucket.
-	ErrCantGetBucket = &jsError{message: "invalid Get, object is a link to a bucket"}
+	// ErrCantGetBucket is returned when an invalid Get is attempted on an
+	// object that is a link to a bucket.
+	ErrCantGetBucket JetStreamError = &jsError{message: "invalid Get, object is a link to a bucket"}
 
 	// ErrBucketRequired is returned when a bucket is required.
-	ErrBucketRequired = &jsError{message: "bucket required"}
+	ErrBucketRequired JetStreamError = &jsError{message: "bucket required"}
 
 	// ErrBucketMalformed is returned when a bucket is malformed.
-	ErrBucketMalformed = &jsError{message: "bucket malformed"}
+	ErrBucketMalformed JetStreamError = &jsError{message: "bucket malformed"}
 
-	// ErrUpdateMetaDeleted is returned when the meta information of a deleted object cannot be updated.
-	ErrUpdateMetaDeleted = &jsError{message: "cannot update meta for a deleted object"}
+	// ErrUpdateMetaDeleted is returned when the meta information of a deleted
+	// object cannot be updated.
+	ErrUpdateMetaDeleted JetStreamError = &jsError{message: "cannot update meta for a deleted object"}
 )
 
-// Error prints the JetStream API error code and description
+// Error prints the JetStream API error code and description.
 func (e *APIError) Error() string {
 	return fmt.Sprintf("nats: API error: code=%d err_code=%d description=%s", e.Code, e.ErrorCode, e.Description)
 }

--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The NATS Authors
+// Copyright 2022-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -28,15 +28,24 @@ import (
 
 type (
 
-	// JetStream contains CRUD methods to operate on a stream
-	// Create, update and get operations return 'Stream' interface,
-	// allowing operations on consumers
+	// JetStream is the top-level interface for interacting with JetStream.
+	// The capabilities of JetStream include:
 	//
-	// CreateOrUpdateConsumer, Consumer and DeleteConsumer are helper methods used to create/fetch/remove consumer without fetching stream (bypassing stream API)
+	// - Publishing messages to a stream using [Publisher].
+	// - Managing streams using [StreamManager].
+	// - Managing consumers using [StreamConsumerManager]. Those are the same
+	//   methods as on [Stream], but are available as a shortcut to a consumer
+	//   bypassing stream lookup.
+	// - Managing KeyValue stores using [KeyValueManager].
+	// - Managing Object Stores using [ObjectStoreManager].
 	//
-	// Client returns a JetStremClient, used to publish messages on a stream or fetch messages by sequence number
+	// JetStream can be created using [New], [NewWithAPIPrefix] or
+	// [NewWithDomain] methods.
 	JetStream interface {
-		// Returns *AccountInfo, containing details about the account associated with this JetStream connection
+		// Returns *AccountInfo, containing details about the account associated
+		// with this JetStream connection. If account is not enabled for JetStream,
+		// ErrJetStreamNotEnabledForAccount is returned. If the server does not
+		// have JetStream enabled, ErrJetStreamNotEnabled is returned.
 		AccountInfo(ctx context.Context) (*AccountInfo, error)
 
 		StreamConsumerManager
@@ -46,100 +55,192 @@ type (
 		ObjectStoreManager
 	}
 
+	// Publisher provides methods for publishing messages to a stream.
+	// It is available as a part of [JetStream] interface.
+	// The behavior of Publisher can be customized using [PublishOpt] options.
 	Publisher interface {
-		// Publish performs a synchronous publish to a stream and waits for ack from server
-		// It accepts subject name (which must be bound to a stream) and message data
+		// Publish performs a synchronous publish to a stream and waits for ack
+		// from server. It accepts subject name (which must be bound to a stream)
+		// and message payload.
 		Publish(ctx context.Context, subject string, payload []byte, opts ...PublishOpt) (*PubAck, error)
-		// PublishMsg performs a synchronous publish to a stream and waits for ack from server
-		// It accepts subject name (which must be bound to a stream) and nats.Message
+
+		// PublishMsg performs a synchronous publish to a stream and waits for
+		// ack from server. It accepts subject name (which must be bound to a
+		// stream) and nats.Message.
 		PublishMsg(ctx context.Context, msg *nats.Msg, opts ...PublishOpt) (*PubAck, error)
-		// PublishAsync performs an asynchronous publish to a stream and returns [PubAckFuture] interface
-		// It accepts subject name (which must be bound to a stream) and message data
+
+		// PublishAsync performs an asynchronous publish to a stream and returns
+		// [PubAckFuture] interface. It accepts subject name (which must be bound
+		// to a stream) and message payload.
 		PublishAsync(subject string, payload []byte, opts ...PublishOpt) (PubAckFuture, error)
-		// PublishMsgAsync performs an asynchronous publish to a stream and returns [PubAckFuture] interface
-		// It accepts subject name (which must be bound to a stream) and nats.Message
+
+		// PublishMsgAsync performs an asynchronous publish to a stream and
+		// returns [PubAckFuture] interface. It accepts subject name (which must
+		// be bound to a stream) and nats.Message.
 		PublishMsgAsync(msg *nats.Msg, opts ...PublishOpt) (PubAckFuture, error)
-		// PublishAsyncPending returns the number of async publishes outstanding for this context
+
+		// PublishAsyncPending returns the number of async publishes outstanding
+		// for this context.
 		PublishAsyncPending() int
-		// PublishAsyncComplete returns a channel that will be closed when all outstanding messages are ack'd
+
+		// PublishAsyncComplete returns a channel that will be closed when all
+		// outstanding asynchronously published messages are acknowledged by the
+		// server.
 		PublishAsyncComplete() <-chan struct{}
 	}
 
+	// StreamManager provides CRUD API for managing streams. It is available as
+	// a part of [JetStream] interface. CreateStream, UpdateStream,
+	// CreateOrUpdateStream and Stream methods return a [Stream] hook, allowing
+	// to operate on a stream.
 	StreamManager interface {
-		// CreateStream creates a new stream with given config and returns a hook to operate on it
+		// CreateStream creates a new stream with given config and returns a
+		// hook to operate on it. If stream with given name already exists,
+		// ErrStreamNameAlreadyInUse is returned.
 		CreateStream(ctx context.Context, cfg StreamConfig) (Stream, error)
-		// UpdateStream updates an existing stream
+
+		// UpdateStream updates an existing stream. If stream does not exist,
+		// ErrStreamNotFound is returned.
 		UpdateStream(ctx context.Context, cfg StreamConfig) (Stream, error)
-		// CreateOrUpdateStream creates a stream with given config. If stream already exists, it will be updated (if possible).
+
+		// CreateOrUpdateStream creates a stream with given config. If stream
+		// already exists, it will be updated (if possible).
 		CreateOrUpdateStream(ctx context.Context, cfg StreamConfig) (Stream, error)
-		// Stream returns a [Stream] hook for a given stream name
+
+		// Stream fetches [StreamInfo] and returns a [Stream] hook for a given stream name.
+		// If stream does not exist, ErrStreamNotFound is returned.
 		Stream(ctx context.Context, stream string) (Stream, error)
-		// StreamNameBySubject returns a stream name stream listening on given subject
+
+		// StreamNameBySubject returns a stream name stream listening on given
+		// subject. If no stream is bound to given subject, ErrStreamNotFound
+		// is returned.
 		StreamNameBySubject(ctx context.Context, subject string) (string, error)
-		// DeleteStream removes a stream with given name
+
+		// DeleteStream removes a stream with given name. If stream does not
+		// exist, ErrStreamNotFound is returned.
 		DeleteStream(ctx context.Context, stream string) error
-		// ListStreams returns StreamInfoLister enabling iterating over a channel of stream infos
+
+		// ListStreams returns StreamInfoLister, enabling iterating over a
+		// channel of stream infos.
 		ListStreams(context.Context, ...StreamListOpt) StreamInfoLister
-		// StreamNames returns a  StreamNameLister enabling iterating over a channel of stream names
+
+		// StreamNames returns a  StreamNameLister, enabling iterating over a
+		// channel of stream names.
 		StreamNames(context.Context, ...StreamListOpt) StreamNameLister
 	}
 
+	// StreamConsumerManager provides CRUD API for managing consumers. It is
+	// available as a part of [JetStream] interface. This is an alternative to
+	// [Stream] interface, allowing to bypass stream lookup. CreateConsumer,
+	// UpdateConsumer, CreateOrUpdateConsumer and Consumer methods return a
+	// [Consumer] hook, allowing to operate on a consumer (e.g. consume
+	// messages).
 	StreamConsumerManager interface {
-		// CreateOrUpdateConsumer creates a consumer on a given stream with given config.
-		// If consumer already exists, it will be updated (if possible).
-		// Consumer interface is returned, serving as a hook to operate on a consumer (e.g. fetch messages)
+		// CreateOrUpdateConsumer creates a consumer on a given stream with
+		// given config. If consumer already exists, it will be updated (if
+		// possible). Consumer interface is returned, serving as a hook to
+		// operate on a consumer (e.g. fetch messages)
 		CreateOrUpdateConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (Consumer, error)
-		// CreateConsumer creates a consumer on a given stream with given config.
-		// If consumer already exists, ErrConsumerExists is returned.
-		// Consumer interface is returned, serving as a hook to operate on a consumer (e.g. fetch messages)
+
+		// CreateConsumer creates a consumer on a given stream with given
+		// config. If consumer already exists, ErrConsumerExists is returned.
+		// Consumer interface is returned, serving as a hook to operate on a
+		// consumer (e.g. fetch messages)
 		CreateConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (Consumer, error)
-		// UpdateConsumer updates an existing consumer.
-		// If consumer does not exist, ErrConsumerDoesNotExist is returned.
-		// Consumer interface is returned, serving as a hook to operate on a consumer (e.g. fetch messages)
+
+		// UpdateConsumer updates an existing consumer. If consumer does not
+		// exist, ErrConsumerDoesNotExist is returned. Consumer interface is
+		// returned, serving as a hook to operate on a consumer (e.g. fetch
+		// messages)
 		UpdateConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (Consumer, error)
-		// OrderedConsumer returns an OrderedConsumer instance.
-		// OrderedConsumer allows fetching messages from a stream (just like standard consumer),
-		// for in order delivery of messages. Underlying consumer is re-created when necessary,
-		// without additional client code.
+
+		// OrderedConsumer returns an OrderedConsumer instance. OrderedConsumer
+		// allows fetching messages from a stream (just like standard consumer),
+		// for in order delivery of messages. Underlying consumer is re-created
+		// when necessary, without additional client code.
 		OrderedConsumer(ctx context.Context, stream string, cfg OrderedConsumerConfig) (Consumer, error)
-		// Consumer returns a hook to an existing consumer, allowing processing of messages
+
+		// Consumer returns a hook to an existing consumer, allowing processing
+		// of messages. If consumer does not exist, ErrConsumerNotFound is
+		// returned.
 		Consumer(ctx context.Context, stream string, consumer string) (Consumer, error)
-		// DeleteConsumer removes a consumer with given name from a stream
+
+		// DeleteConsumer removes a consumer with given name from a stream.
+		// If consumer does not exist, ErrConsumerNotFound is returned.
 		DeleteConsumer(ctx context.Context, stream string, consumer string) error
 	}
 
+	// StreamListOpt is a functional option for [StreamManager.ListStreams] and
+	// [StreamManager.StreamNames] methods.
 	StreamListOpt func(*streamsRequest) error
 
-	// AccountInfo contains info about the JetStream usage from the current account.
+	// AccountInfo contains information about the JetStream usage from the
+	// current account.
 	AccountInfo struct {
+		// Tier is the current account usage tier.
 		Tier
-		Domain string          `json:"domain"`
-		API    APIStats        `json:"api"`
-		Tiers  map[string]Tier `json:"tiers"`
+
+		// Domain is the domain name associated with this account.
+		Domain string `json:"domain"`
+
+		// API is the API usage statistics for this account.
+		API APIStats `json:"api"`
+
+		// Tiers is the list of available tiers for this account.
+		Tiers map[string]Tier `json:"tiers"`
 	}
 
+	// Tier represents a JetStream account usage tier.
 	Tier struct {
-		Memory         uint64        `json:"memory"`
-		Store          uint64        `json:"storage"`
-		ReservedMemory uint64        `json:"reserved_memory"`
-		ReservedStore  uint64        `json:"reserved_storage"`
-		Streams        int           `json:"streams"`
-		Consumers      int           `json:"consumers"`
-		Limits         AccountLimits `json:"limits"`
+		// Memory is the memory storage being used for Stream Message storage.
+		Memory uint64 `json:"memory"`
+
+		// Store is the disk storage being used for Stream Message storage.
+		Store uint64 `json:"storage"`
+
+		// ReservedMemory is the number of bytes reserved for memory usage by
+		// this account on the server
+		ReservedMemory uint64 `json:"reserved_memory"`
+
+		// ReservedStore is the number of bytes reserved for disk usage by this
+		// account on the server
+		ReservedStore uint64 `json:"reserved_storage"`
+
+		// Streams is the number of streams currently defined for this account.
+		Streams int `json:"streams"`
+
+		// Consumers is the number of consumers currently defined for this
+		// account.
+		Consumers int `json:"consumers"`
+
+		// Limits are the JetStream limits for this account.
+		Limits AccountLimits `json:"limits"`
 	}
 
 	// APIStats reports on API calls to JetStream for this account.
 	APIStats struct {
-		Total  uint64 `json:"total"`
+		// Total is the total number of API calls.
+		Total uint64 `json:"total"`
+
+		// Errors is the total number of API errors.
 		Errors uint64 `json:"errors"`
 	}
 
 	// AccountLimits includes the JetStream limits of the current account.
 	AccountLimits struct {
-		MaxMemory    int64 `json:"max_memory"`
-		MaxStore     int64 `json:"max_storage"`
-		MaxStreams   int   `json:"max_streams"`
-		MaxConsumers int   `json:"max_consumers"`
+		// MaxMemory is the maximum amount of memory available for this account.
+		MaxMemory int64 `json:"max_memory"`
+
+		// MaxStore is the maximum amount of disk storage available for this
+		// account.
+		MaxStore int64 `json:"max_storage"`
+
+		// MaxStreams is the maximum number of streams allowed for this account.
+		MaxStreams int `json:"max_streams"`
+
+		// MaxConsumers is the maximum number of consumers allowed for this
+		// account.
+		MaxConsumers int `json:"max_consumers"`
 	}
 
 	jetStream struct {
@@ -149,6 +250,8 @@ type (
 		publisher *jetStreamClient
 	}
 
+	// JetStreamOpt is a functional option for [New], [NewWithAPIPrefix] and
+	// [NewWithDomain] methods.
 	JetStreamOpt func(*jsOpts) error
 
 	jsOpts struct {
@@ -159,9 +262,13 @@ type (
 		clientTrace    *ClientTrace
 	}
 
-	// ClientTrace can be used to trace API interactions for the JetStream Context.
+	// ClientTrace can be used to trace API interactions for [JetStream].
 	ClientTrace struct {
-		RequestSent      func(subj string, payload []byte)
+		// RequestSent is called when an API request is sent to the server.
+		RequestSent func(subj string, payload []byte)
+
+		// ResponseReceived is called when a response is received from the
+		// server.
 		ResponseReceived func(subj string, payload []byte, hdr nats.Header)
 	}
 	streamInfoResponse struct {
@@ -180,11 +287,17 @@ type (
 		Success bool `json:"success,omitempty"`
 	}
 
+	// StreamInfoLister is used to iterate over a channel of stream infos.
+	// Err method can be used to check for errors encountered during iteration.
+	// Info channel is always closed and therefore can be used in a range loop.
 	StreamInfoLister interface {
 		Info() <-chan *StreamInfo
 		Err() error
 	}
 
+	// StreamNameLister is used to iterate over a channel of stream names.
+	// Err method can be used to check for errors encountered during iteration.
+	// Name channel is always closed and therefore can be used in a range loop.
 	StreamNameLister interface {
 		Name() <-chan string
 		Err() error
@@ -193,6 +306,7 @@ type (
 	apiPagedRequest struct {
 		Offset int `json:"offset"`
 	}
+
 	streamLister struct {
 		js       *jetStream
 		offset   int
@@ -227,12 +341,14 @@ const defaultAPITimeout = 5 * time.Second
 var subjectRegexp = regexp.MustCompile(`^[^ >]*[>]?$`)
 
 // New returns a new JetStream instance.
+// It uses default API prefix ($JS.API) for JetStream API requests.
+// If a custom API prefix is required, use [NewWithAPIPrefix] or [NewWithDomain].
 //
 // Available options:
-// [WithClientTrace] - enables request/response tracing.
-// [WithPublishAsyncErrHandler] - sets error handler for async message publish.
-// [WithPublishAsyncMaxPending] - sets the maximum outstanding async publishes that can be inflight at one time.
-// [WithDirectGet] - specifies whether client should use direct get requests.
+//   - [WithClientTrace] - enables request/response tracing.
+//   - [WithPublishAsyncErrHandler] - sets error handler for async message publish.
+//   - [WithPublishAsyncMaxPending] - sets the maximum outstanding async publishes
+//     that can be inflight at one time.
 func New(nc *nats.Conn, opts ...JetStreamOpt) (JetStream, error) {
 	jsOpts := jsOpts{
 		apiPrefix: DefaultAPIPrefix,
@@ -270,13 +386,14 @@ func setReplyPrefix(nc *nats.Conn, jsOpts *jsOpts) {
 
 }
 
-// NewWithAPIPrefix returns a new JetStream instance and sets the API prefix to be used in requests to JetStream API
+// NewWithAPIPrefix returns a new JetStream instance and sets the API prefix to be used in requests to JetStream API.
+// The API prefix will be used in API requests to JetStream, e.g. <prefix>.STREAM.INFO.<stream>.
 //
 // Available options:
-// [WithClientTrace] - enables request/response tracing
-// [WithPublishAsyncErrHandler] - sets error handler for async message publish
-// [WithPublishAsyncMaxPending] - sets the maximum outstanding async publishes that can be inflight at one time.
-// [WithDirectGet] - specifies whether client should use direct get requests.
+//   - [WithClientTrace] - enables request/response tracing.
+//   - [WithPublishAsyncErrHandler] - sets error handler for async message publish.
+//   - [WithPublishAsyncMaxPending] - sets the maximum outstanding async publishes
+//     that can be inflight at one time.
 func NewWithAPIPrefix(nc *nats.Conn, apiPrefix string, opts ...JetStreamOpt) (JetStream, error) {
 	jsOpts := jsOpts{
 		publisherOpts: asyncPublisherOpts{
@@ -303,13 +420,14 @@ func NewWithAPIPrefix(nc *nats.Conn, apiPrefix string, opts ...JetStreamOpt) (Je
 	return js, nil
 }
 
-// NewWithDomain returns a new JetStream instance and sets the domain name token used when sending JetStream requests
+// NewWithDomain returns a new JetStream instance and sets the domain name token used when sending JetStream requests.
+// The domain name token will be used in API requests to JetStream, e.g. $JS.<domain>.API.STREAM.INFO.<stream>.
 //
 // Available options:
-// [WithClientTrace] - enables request/response tracing
-// [WithPublishAsyncErrHandler] - sets error handler for async message publish
-// [WithPublishAsyncMaxPending] - sets the maximum outstanding async publishes that can be inflight at one time.
-// [WithDirectGet] - specifies whether client should use direct get requests.
+//   - [WithClientTrace] - enables request/response tracing.
+//   - [WithPublishAsyncErrHandler] - sets error handler for async message publish.
+//   - [WithPublishAsyncMaxPending] - sets the maximum outstanding async publishes
+//     that can be inflight at one time.
 func NewWithDomain(nc *nats.Conn, domain string, opts ...JetStreamOpt) (JetStream, error) {
 	jsOpts := jsOpts{
 		publisherOpts: asyncPublisherOpts{
@@ -334,7 +452,9 @@ func NewWithDomain(nc *nats.Conn, domain string, opts ...JetStreamOpt) (JetStrea
 	return js, nil
 }
 
-// CreateStream creates a new stream with given config and returns a hook to operate on it
+// CreateStream creates a new stream with given config and returns a
+// hook to operate on it. If stream with given name already exists,
+// ErrStreamNameAlreadyInUse is returned.
 func (js *jetStream) CreateStream(ctx context.Context, cfg StreamConfig) (Stream, error) {
 	if err := validateStreamName(cfg.Name); err != nil {
 		return nil, err
@@ -435,7 +555,8 @@ func (ss *StreamSource) copy() *StreamSource {
 	return &nss
 }
 
-// UpdateStream updates an existing stream
+// UpdateStream updates an existing stream. If stream does not exist,
+// ErrStreamNotFound is returned.
 func (js *jetStream) UpdateStream(ctx context.Context, cfg StreamConfig) (Stream, error) {
 	if err := validateStreamName(cfg.Name); err != nil {
 		return nil, err
@@ -486,6 +607,8 @@ func (js *jetStream) UpdateStream(ctx context.Context, cfg StreamConfig) (Stream
 	}, nil
 }
 
+// CreateOrUpdateStream creates a stream with given config. If stream
+// already exists, it will be updated (if possible).
 func (js *jetStream) CreateOrUpdateStream(ctx context.Context, cfg StreamConfig) (Stream, error) {
 	s, err := js.UpdateStream(ctx, cfg)
 	if err != nil {
@@ -498,7 +621,8 @@ func (js *jetStream) CreateOrUpdateStream(ctx context.Context, cfg StreamConfig)
 	return s, nil
 }
 
-// Stream returns a [Stream] hook for a given stream name
+// Stream fetches [StreamInfo] and returns a [Stream] hook for a given stream name.
+// If stream does not exist, ErrStreamNotFound is returned.
 func (js *jetStream) Stream(ctx context.Context, name string) (Stream, error) {
 	if err := validateStreamName(name); err != nil {
 		return nil, err
@@ -561,6 +685,10 @@ func (js *jetStream) CreateOrUpdateConsumer(ctx context.Context, stream string, 
 	return upsertConsumer(ctx, js, stream, cfg, consumerActionCreateOrUpdate)
 }
 
+// CreateConsumer creates a consumer on a given stream with given
+// config. If consumer already exists, ErrConsumerExists is returned.
+// Consumer interface is returned, serving as a hook to operate on a
+// consumer (e.g. fetch messages)
 func (js *jetStream) CreateConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (Consumer, error) {
 	if err := validateStreamName(stream); err != nil {
 		return nil, err
@@ -568,6 +696,10 @@ func (js *jetStream) CreateConsumer(ctx context.Context, stream string, cfg Cons
 	return upsertConsumer(ctx, js, stream, cfg, consumerActionCreate)
 }
 
+// UpdateConsumer updates an existing consumer. If consumer does not
+// exist, ErrConsumerDoesNotExist is returned. Consumer interface is
+// returned, serving as a hook to operate on a consumer (e.g. fetch
+// messages)
 func (js *jetStream) UpdateConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (Consumer, error) {
 	if err := validateStreamName(stream); err != nil {
 		return nil, err
@@ -575,6 +707,10 @@ func (js *jetStream) UpdateConsumer(ctx context.Context, stream string, cfg Cons
 	return upsertConsumer(ctx, js, stream, cfg, consumerActionUpdate)
 }
 
+// OrderedConsumer returns an OrderedConsumer instance. OrderedConsumer allows
+// fetching messages from a stream (just like standard consumer), for in order
+// delivery of messages. Underlying consumer is re-created when necessary,
+// without additional client code.
 func (js *jetStream) OrderedConsumer(ctx context.Context, stream string, cfg OrderedConsumerConfig) (Consumer, error) {
 	if err := validateStreamName(stream); err != nil {
 		return nil, err
@@ -597,7 +733,9 @@ func (js *jetStream) OrderedConsumer(ctx context.Context, stream string, cfg Ord
 	return oc, nil
 }
 
-// Consumer returns a hook to an existing consumer, allowing processing of messages
+// Consumer returns a hook to an existing consumer, allowing processing
+// of messages. If consumer does not exist, ErrConsumerNotFound is
+// returned.
 func (js *jetStream) Consumer(ctx context.Context, stream string, name string) (Consumer, error) {
 	if err := validateStreamName(stream); err != nil {
 		return nil, err
@@ -605,7 +743,8 @@ func (js *jetStream) Consumer(ctx context.Context, stream string, name string) (
 	return getConsumer(ctx, js, stream, name)
 }
 
-// DeleteConsumer removes a consumer with given name from a stream
+// DeleteConsumer removes a consumer with given name from a stream.
+// If consumer does not exist, ErrConsumerNotFound is returned.
 func (js *jetStream) DeleteConsumer(ctx context.Context, stream string, name string) error {
 	if err := validateStreamName(stream); err != nil {
 		return err
@@ -633,6 +772,10 @@ func validateSubject(subject string) error {
 	return nil
 }
 
+// Returns *AccountInfo, containing details about the account associated
+// with this JetStream connection. If account is not enabled for JetStream,
+// ErrJetStreamNotEnabledForAccount is returned. If the server does not
+// have JetStream enabled, ErrJetStreamNotEnabled is returned.
 func (js *jetStream) AccountInfo(ctx context.Context) (*AccountInfo, error) {
 	ctx, cancel := wrapContextWithoutDeadline(ctx)
 	if cancel != nil {
@@ -660,10 +803,8 @@ func (js *jetStream) AccountInfo(ctx context.Context) (*AccountInfo, error) {
 	return &resp.AccountInfo, nil
 }
 
-// ListStreams returns StreamInfoLister enabling iterating over a channel of stream infos
-//
-// Available options:
-// [WithStreamListSubject] - allows filtering returned streams by provided subject
+// ListStreams returns StreamInfoLister, enabling iterating over a
+// channel of stream infos.
 func (js *jetStream) ListStreams(ctx context.Context, opts ...StreamListOpt) StreamInfoLister {
 	l := &streamLister{
 		js:      js,
@@ -716,10 +857,8 @@ func (s *streamLister) Err() error {
 	return s.err
 }
 
-// StreamNames returns a [StreamNameLister] enabling iterating over a channel of stream names
-//
-// Available options:
-// [WithStreamListSubject] - allows filtering returned streams by provided subject
+// StreamNames returns a  StreamNameLister, enabling iterating over a
+// channel of stream names.
 func (js *jetStream) StreamNames(ctx context.Context, opts ...StreamListOpt) StreamNameLister {
 	l := &streamLister{
 		js:    js,
@@ -762,6 +901,9 @@ func (js *jetStream) StreamNames(ctx context.Context, opts ...StreamListOpt) Str
 	return l
 }
 
+// StreamNameBySubject returns a stream name stream listening on given
+// subject. If no stream is bound to given subject, ErrStreamNotFound
+// is returned.
 func (js *jetStream) StreamNameBySubject(ctx context.Context, subject string) (string, error) {
 	ctx, cancel := wrapContextWithoutDeadline(ctx)
 	if cancel != nil {

--- a/jetstream/kv_options.go
+++ b/jetstream/kv_options.go
@@ -1,0 +1,89 @@
+package jetstream
+
+import (
+	"fmt"
+	"time"
+)
+
+type watchOptFn func(opts *watchOpts) error
+
+func (opt watchOptFn) configureWatcher(opts *watchOpts) error {
+	return opt(opts)
+}
+
+// IncludeHistory instructs the key watcher to include historical values as
+// well.
+func IncludeHistory() WatchOpt {
+	return watchOptFn(func(opts *watchOpts) error {
+		if opts.updatesOnly {
+			return fmt.Errorf("%w: include history can not be used with updates only", ErrInvalidOption)
+		}
+		opts.includeHistory = true
+		return nil
+	})
+}
+
+// UpdatesOnly instructs the key watcher to only include updates on values
+// (without latest values when started).
+func UpdatesOnly() WatchOpt {
+	return watchOptFn(func(opts *watchOpts) error {
+		if opts.includeHistory {
+			return fmt.Errorf("%w: updates only can not be used with include history", ErrInvalidOption)
+		}
+		opts.updatesOnly = true
+		return nil
+	})
+}
+
+// IgnoreDeletes will have the key watcher not pass any deleted keys.
+func IgnoreDeletes() WatchOpt {
+	return watchOptFn(func(opts *watchOpts) error {
+		opts.ignoreDeletes = true
+		return nil
+	})
+}
+
+// MetaOnly instructs the key watcher to retrieve only the entry meta data, not
+// the entry value.
+func MetaOnly() WatchOpt {
+	return watchOptFn(func(opts *watchOpts) error {
+		opts.metaOnly = true
+		return nil
+	})
+}
+
+// ResumeFromRevision instructs the key watcher to resume from a specific
+// revision number.
+func ResumeFromRevision(revision uint64) WatchOpt {
+	return watchOptFn(func(opts *watchOpts) error {
+		opts.resumeFromRevision = revision
+		return nil
+	})
+}
+
+// DeleteMarkersOlderThan indicates that delete or purge markers older than that
+// will be deleted as part of PurgeDeletes() operation, otherwise, only the data
+// will be removed but markers that are recent will be kept.
+// Note that if no option is specified, the default is 30 minutes. You can set
+// this option to a negative value to instruct to always remove the markers,
+// regardless of their age.
+type DeleteMarkersOlderThan time.Duration
+
+func (ttl DeleteMarkersOlderThan) configurePurge(opts *purgeOpts) error {
+	opts.dmthr = time.Duration(ttl)
+	return nil
+}
+
+type deleteOptFn func(opts *deleteOpts) error
+
+func (opt deleteOptFn) configureDelete(opts *deleteOpts) error {
+	return opt(opts)
+}
+
+// LastRevision deletes if the latest revision matches.
+func LastRevision(revision uint64) KVDeleteOpt {
+	return deleteOptFn(func(opts *deleteOpts) error {
+		opts.revision = revision
+		return nil
+	})
+}

--- a/jetstream/kv_options.go
+++ b/jetstream/kv_options.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package jetstream
 
 import (

--- a/jetstream/object_options.go
+++ b/jetstream/object_options.go
@@ -1,0 +1,26 @@
+package jetstream
+
+// GetObjectShowDeleted makes Get() return object if it was marked as deleted.
+func GetObjectShowDeleted() GetObjectOpt {
+	return func(opts *getObjectOpts) error {
+		opts.showDeleted = true
+		return nil
+	}
+}
+
+// GetObjectInfoShowDeleted makes GetInfo() return object if it was marked as
+// deleted.
+func GetObjectInfoShowDeleted() GetObjectInfoOpt {
+	return func(opts *getObjectInfoOpts) error {
+		opts.showDeleted = true
+		return nil
+	}
+}
+
+// ListObjectsShowDeleted makes ListObjects() return deleted objects.
+func ListObjectsShowDeleted() ListObjectsOpt {
+	return func(opts *listObjectOpts) error {
+		opts.showDeleted = true
+		return nil
+	}
+}

--- a/jetstream/object_options.go
+++ b/jetstream/object_options.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package jetstream
 
 // GetObjectShowDeleted makes Get() return object if it was marked as deleted.

--- a/jetstream/options.go
+++ b/jetstream/options.go
@@ -28,8 +28,7 @@ func (fn pullOptFunc) configureMessages(opts *consumeOpts) error {
 	return fn(opts)
 }
 
-// WithClientTrace enables request/response API calls tracing
-// ClientTrace is used to provide handlers for each event
+// WithClientTrace enables request/response API calls tracing.
 func WithClientTrace(ct *ClientTrace) JetStreamOpt {
 	return func(opts *jsOpts) error {
 		opts.clientTrace = ct
@@ -37,7 +36,7 @@ func WithClientTrace(ct *ClientTrace) JetStreamOpt {
 	}
 }
 
-// WithPublishAsyncErrHandler sets error handler for async message publish
+// WithPublishAsyncErrHandler sets error handler for async message publish.
 func WithPublishAsyncErrHandler(cb MsgErrHandler) JetStreamOpt {
 	return func(opts *jsOpts) error {
 		opts.publisherOpts.aecb = cb
@@ -45,7 +44,8 @@ func WithPublishAsyncErrHandler(cb MsgErrHandler) JetStreamOpt {
 	}
 }
 
-// WithPublishAsyncMaxPending sets the maximum outstanding async publishes that can be inflight at one time.
+// WithPublishAsyncMaxPending sets the maximum outstanding async publishes that
+// can be inflight at one time.
 func WithPublishAsyncMaxPending(max int) JetStreamOpt {
 	return func(opts *jsOpts) error {
 		if max < 1 {
@@ -56,7 +56,8 @@ func WithPublishAsyncMaxPending(max int) JetStreamOpt {
 	}
 }
 
-// WithPurgeSubject sets a specific subject for which messages on a stream will be purged
+// WithPurgeSubject sets a specific subject for which messages on a stream will
+// be purged
 func WithPurgeSubject(subject string) StreamPurgeOpt {
 	return func(req *StreamPurgeRequest) error {
 		req.Subject = subject
@@ -64,8 +65,9 @@ func WithPurgeSubject(subject string) StreamPurgeOpt {
 	}
 }
 
-// WithPurgeSequence is used to set a specific sequence number up to which (but not including) messages will be purged from a stream
-// Can be combined with [WithPurgeSubject] option, but not with [WithPurgeKeep]
+// WithPurgeSequence is used to set a specific sequence number up to which (but
+// not including) messages will be purged from a stream Can be combined with
+// [WithPurgeSubject] option, but not with [WithPurgeKeep]
 func WithPurgeSequence(sequence uint64) StreamPurgeOpt {
 	return func(req *StreamPurgeRequest) error {
 		if req.Keep != 0 {
@@ -76,8 +78,9 @@ func WithPurgeSequence(sequence uint64) StreamPurgeOpt {
 	}
 }
 
-// WithPurgeKeep sets the number of messages to be kept in the stream after purge.
-// Can be combined with [WithPurgeSubject] option, but not with [WithPurgeSequence]
+// WithPurgeKeep sets the number of messages to be kept in the stream after
+// purge. Can be combined with [WithPurgeSubject] option, but not with
+// [WithPurgeSequence]
 func WithPurgeKeep(keep uint64) StreamPurgeOpt {
 	return func(req *StreamPurgeRequest) error {
 		if req.Sequence != 0 {
@@ -88,8 +91,9 @@ func WithPurgeKeep(keep uint64) StreamPurgeOpt {
 	}
 }
 
-// WithGetMsgSubject sets the stream subject from which the message should be retrieved.
-// Server will return a first message with a seq >= to the input seq that has the specified subject.
+// WithGetMsgSubject sets the stream subject from which the message should be
+// retrieved. Server will return a first message with a seq >= to the input seq
+// that has the specified subject.
 func WithGetMsgSubject(subject string) GetMsgOpt {
 	return func(req *apiMsgGetRequest) error {
 		req.NextFor = subject
@@ -97,8 +101,9 @@ func WithGetMsgSubject(subject string) GetMsgOpt {
 	}
 }
 
-// PullMaxMessages limits the number of messages to be fetched from the stream in one request
-// If not provided, a default of 100 messages will be used
+// PullMaxMessages limits the number of messages to be buffered in the client.
+// If not provided, a default of 500 messages will be used.
+// This option is exclusive with PullMaxBytes.
 type PullMaxMessages int
 
 func (max PullMaxMessages) configureConsume(opts *consumeOpts) error {
@@ -117,7 +122,9 @@ func (max PullMaxMessages) configureMessages(opts *consumeOpts) error {
 	return nil
 }
 
-// PullExpiry sets timeout on a single batch request, waiting until at least one message is available
+// PullExpiry sets timeout on a single pull request, waiting until at least one
+// message is available.
+// If not provided, a default of 30 seconds will be used.
 type PullExpiry time.Duration
 
 func (exp PullExpiry) configureConsume(opts *consumeOpts) error {
@@ -138,7 +145,9 @@ func (exp PullExpiry) configureMessages(opts *consumeOpts) error {
 	return nil
 }
 
-// PullMaxBytes sets max_bytes limit on a fetch request
+// PullMaxBytes limits the number of bytes to be buffered in the client.
+// If not provided, the limit is not set (max messages will be used instead).
+// This option is exclusive with PullMaxMessages.
 type PullMaxBytes int
 
 func (max PullMaxBytes) configureConsume(opts *consumeOpts) error {
@@ -188,7 +197,8 @@ func (t PullThresholdBytes) configureMessages(opts *consumeOpts) error {
 // PullHeartbeat sets the idle heartbeat duration for a pull subscription
 // If a client does not receive a heartbeat message from a stream for more
 // than the idle heartbeat setting, the subscription will be removed
-// and error will be passed to the message handler
+// and error will be passed to the message handler.
+// If not provided, a default PullExpiry / 2 will be used (capped at 30 seconds)
 type PullHeartbeat time.Duration
 
 func (hb PullHeartbeat) configureConsume(opts *consumeOpts) error {
@@ -209,7 +219,8 @@ func (hb PullHeartbeat) configureMessages(opts *consumeOpts) error {
 	return nil
 }
 
-// StopAfter sets the number of messages after which the consumer is automatically stopped
+// StopAfter sets the number of messages after which the consumer is
+// automatically stopped and no more messages are pulled from the server.
 type StopAfter int
 
 func (nMsgs StopAfter) configureConsume(opts *consumeOpts) error {
@@ -228,8 +239,10 @@ func (nMsgs StopAfter) configureMessages(opts *consumeOpts) error {
 	return nil
 }
 
-// ConsumeErrHandler sets custom error handler invoked when an error was encountered while consuming messages
-// It will be invoked for both terminal (Consumer Deleted, invalid request body) and non-terminal (e.g. missing heartbeats) errors
+// ConsumeErrHandler sets custom error handler invoked when an error was
+// encountered while consuming messages It will be invoked for both terminal
+// (Consumer Deleted, invalid request body) and non-terminal (e.g. missing
+// heartbeats) errors.
 func ConsumeErrHandler(cb ConsumeErrHandlerFunc) PullConsumeOpt {
 	return pullOptFunc(func(cfg *consumeOpts) error {
 		cfg.ErrHandler = cb
@@ -237,7 +250,8 @@ func ConsumeErrHandler(cb ConsumeErrHandlerFunc) PullConsumeOpt {
 	})
 }
 
-// WithMessagesErrOnMissingHeartbeat sets whether a missing heartbeat error should be reported when calling Next (Default: true).
+// WithMessagesErrOnMissingHeartbeat sets whether a missing heartbeat error
+// should be reported when calling [MessagesContext.Next] (Default: true).
 func WithMessagesErrOnMissingHeartbeat(hbErr bool) PullMessagesOpt {
 	return pullOptFunc(func(cfg *consumeOpts) error {
 		cfg.ReportMissingHeartbeats = hbErr
@@ -245,7 +259,7 @@ func WithMessagesErrOnMissingHeartbeat(hbErr bool) PullMessagesOpt {
 	})
 }
 
-// FetchMaxWait sets custom timeout for fetching predefined batch of messages
+// FetchMaxWait sets custom timeout for fetching predefined batch of messages.
 func FetchMaxWait(timeout time.Duration) FetchOpt {
 	return func(req *pullRequest) error {
 		if timeout <= 0 {
@@ -256,7 +270,8 @@ func FetchMaxWait(timeout time.Duration) FetchOpt {
 	}
 }
 
-// WithDeletedDetails can be used to display the information about messages deleted from a stream on a stream info request
+// WithDeletedDetails can be used to display the information about messages
+// deleted from a stream on a stream info request
 func WithDeletedDetails(deletedDetails bool) StreamInfoOpt {
 	return func(req *streamInfoRequest) error {
 		req.DeletedDetails = deletedDetails
@@ -276,8 +291,9 @@ func WithSubjectFilter(subject string) StreamInfoOpt {
 	}
 }
 
-// WithStreamListSubject can be used to filter results of ListStreams and StreamNames requests
-// to only streams that have given subject in their configuration
+// WithStreamListSubject can be used to filter results of ListStreams and
+// StreamNames requests to only streams that have given subject in their
+// configuration.
 func WithStreamListSubject(subject string) StreamListOpt {
 	return func(req *streamsRequest) error {
 		req.Subject = subject
@@ -301,7 +317,8 @@ func WithExpectStream(stream string) PublishOpt {
 	}
 }
 
-// WithExpectLastSequence sets the expected sequence in the response from the publish.
+// WithExpectLastSequence sets the expected sequence in the response from the
+// publish.
 func WithExpectLastSequence(seq uint64) PublishOpt {
 	return func(opts *pubOpts) error {
 		opts.lastSeq = &seq
@@ -309,7 +326,8 @@ func WithExpectLastSequence(seq uint64) PublishOpt {
 	}
 }
 
-// WithExpectLastSequencePerSubject sets the expected sequence per subject in the response from the publish.
+// WithExpectLastSequencePerSubject sets the expected sequence per subject in
+// the response from the publish.
 func WithExpectLastSequencePerSubject(seq uint64) PublishOpt {
 	return func(opts *pubOpts) error {
 		opts.lastSubjectSeq = &seq
@@ -317,7 +335,8 @@ func WithExpectLastSequencePerSubject(seq uint64) PublishOpt {
 	}
 }
 
-// WithExpectLastMsgID sets the expected last msgId in the response from the publish.
+// WithExpectLastMsgID sets the expected last msgId in the response from the
+// publish.
 func WithExpectLastMsgID(id string) PublishOpt {
 	return func(opts *pubOpts) error {
 		opts.lastMsgID = id
@@ -326,7 +345,7 @@ func WithExpectLastMsgID(id string) PublishOpt {
 }
 
 // WithRetryWait sets the retry wait time when ErrNoResponders is encountered.
-// Defaults to 250ms
+// Defaults to 250ms.
 func WithRetryWait(dur time.Duration) PublishOpt {
 	return func(opts *pubOpts) error {
 		if dur <= 0 {
@@ -337,8 +356,8 @@ func WithRetryWait(dur time.Duration) PublishOpt {
 	}
 }
 
-// WithRetryAttempts sets the retry number of attempts when ErrNoResponders is encountered.
-// Defaults to 2
+// WithRetryAttempts sets the retry number of attempts when ErrNoResponders is
+// encountered. Defaults to 2
 func WithRetryAttempts(num int) PublishOpt {
 	return func(opts *pubOpts) error {
 		if num < 0 {
@@ -349,7 +368,9 @@ func WithRetryAttempts(num int) PublishOpt {
 	}
 }
 
-// WithStallWait sets the max wait when the producer becomes stall producing messages.
+// WithStallWait sets the max wait when the producer becomes stall producing
+// messages. If a publish call is blocked for this long, ErrTooManyStalledMsgs
+// is returned.
 func WithStallWait(ttl time.Duration) PublishOpt {
 	return func(opts *pubOpts) error {
 		if ttl <= 0 {
@@ -368,7 +389,8 @@ func (opt watchOptFn) configureWatcher(opts *watchOpts) error {
 	return opt(opts)
 }
 
-// IncludeHistory instructs the key watcher to include historical values as well.
+// IncludeHistory instructs the key watcher to include historical values as
+// well.
 func IncludeHistory() WatchOpt {
 	return watchOptFn(func(opts *watchOpts) error {
 		if opts.updatesOnly {
@@ -379,7 +401,8 @@ func IncludeHistory() WatchOpt {
 	})
 }
 
-// UpdatesOnly instructs the key watcher to only include updates on values (without latest values when started).
+// UpdatesOnly instructs the key watcher to only include updates on values
+// (without latest values when started).
 func UpdatesOnly() WatchOpt {
 	return watchOptFn(func(opts *watchOpts) error {
 		if opts.includeHistory {
@@ -398,7 +421,8 @@ func IgnoreDeletes() WatchOpt {
 	})
 }
 
-// MetaOnly instructs the key watcher to retrieve only the entry meta data, not the entry value.
+// MetaOnly instructs the key watcher to retrieve only the entry meta data, not
+// the entry value.
 func MetaOnly() WatchOpt {
 	return watchOptFn(func(opts *watchOpts) error {
 		opts.metaOnly = true
@@ -406,7 +430,8 @@ func MetaOnly() WatchOpt {
 	})
 }
 
-// ResumeFromRevision instructs the key watcher to resume from a specific revision number.
+// ResumeFromRevision instructs the key watcher to resume from a specific
+// revision number.
 func ResumeFromRevision(revision uint64) WatchOpt {
 	return watchOptFn(func(opts *watchOpts) error {
 		opts.resumeFromRevision = revision
@@ -451,7 +476,8 @@ func GetObjectShowDeleted() GetObjectOpt {
 	}
 }
 
-// GetObjectInfoShowDeleted makes GetInfo() return object if it was marked as deleted.
+// GetObjectInfoShowDeleted makes GetInfo() return object if it was marked as
+// deleted.
 func GetObjectInfoShowDeleted() GetObjectInfoOpt {
 	return func(opts *getObjectInfoOpts) error {
 		opts.showDeleted = true

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -746,8 +746,6 @@ func (p *pullConsumer) Fetch(batch int, opts ...FetchOpt) (MessageBatch, error) 
 }
 
 // FetchBytes is used to retrieve up to a provided bytes from the stream.
-// This method will always send a single request and wait until provided number of bytes is
-// exceeded or request times out.
 func (p *pullConsumer) FetchBytes(maxBytes int, opts ...FetchOpt) (MessageBatch, error) {
 	req := &pullRequest{
 		Batch:    1000000,

--- a/jetstream/stream.go
+++ b/jetstream/stream.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The NATS Authors
+// Copyright 2022-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -26,62 +26,80 @@ import (
 )
 
 type (
-	// Stream contains CRUD methods on a consumer, as well as operations on an existing stream
+	// Stream contains CRUD methods on a consumer, as well as operations on an existing stream.
+	// It allows fetching and removing messages from a stream, as well as purging a stream.
 	Stream interface {
 		streamConsumerManager
 
-		// Info returns stream details
+		// Info returns StreamInfo from the server.
 		Info(ctx context.Context, opts ...StreamInfoOpt) (*StreamInfo, error)
-		// CachedInfo returns *StreamInfo cached on a consumer struct
+
+		// CachedInfo returns ConsumerInfo currently cached on this stream.
+		// This method does not perform any network requests. The cached
+		// StreamInfo is updated on every call to Info and Update.
 		CachedInfo() *StreamInfo
 
-		// Purge removes messages from a stream
+		// Purge removes messages from a stream. It is a destructive operation.
+		// Use with caution. See StreamPurgeOpt for available options.
 		Purge(ctx context.Context, opts ...StreamPurgeOpt) error
 
-		// GetMsg retrieves a raw stream message stored in JetStream by sequence number
+		// GetMsg retrieves a raw stream message stored in JetStream by sequence number.
 		GetMsg(ctx context.Context, seq uint64, opts ...GetMsgOpt) (*RawStreamMsg, error)
-		// GetLastMsgForSubject retrieves the last raw stream message stored in JetStream by subject
+
+		// GetLastMsgForSubject retrieves the last raw stream message stored in
+		// JetStream on a given subject subject.
 		GetLastMsgForSubject(ctx context.Context, subject string) (*RawStreamMsg, error)
+
 		// DeleteMsg deletes a message from a stream.
-		// The message is marked as erased, but not overwritten
+		// On the server, the message is marked as erased, but not overwritten.
 		DeleteMsg(ctx context.Context, seq uint64) error
-		// SecureDeleteMsg deletes a message from a stream. The deleted message is overwritten with random data
-		// As a result, this operation is slower than DeleteMsg()
+
+		// SecureDeleteMsg deletes a message from a stream. The deleted message
+		// is overwritten with random data As a result, this operation is slower
+		// than DeleteMsg.
 		SecureDeleteMsg(ctx context.Context, seq uint64) error
 	}
 
 	streamConsumerManager interface {
-		// CreateOrUpdateConsumer creates a consumer on a given stream with given config.
-		// If consumer already exists, it will be updated (if possible).
-		// Consumer interface is returned, serving as a hook to operate on a consumer (e.g. fetch messages).
+		// CreateOrUpdateConsumer creates a consumer on a given stream with
+		// given config. If consumer already exists, it will be updated (if
+		// possible). Consumer interface is returned, serving as a hook to
+		// operate on a consumer (e.g. fetch messages)
 		CreateOrUpdateConsumer(ctx context.Context, cfg ConsumerConfig) (Consumer, error)
 
-		// CreateConsumer creates a consumer on a given stream with given config.
-		// If consumer already exists, an ErrConsumerExists is returned.
-		// Consumer interface is returned, serving as a hook to operate on a consumer (e.g. fetch messages).
+		// CreateConsumer creates a consumer on a given stream with given
+		// config. If consumer already exists, ErrConsumerExists is returned.
+		// Consumer interface is returned, serving as a hook to operate on a
+		// consumer (e.g. fetch messages)
 		CreateConsumer(ctx context.Context, cfg ConsumerConfig) (Consumer, error)
 
-		// UpdateConsumer updates an existing consumer with given config.
-		// If consumer does not exist, an ErrConsumerDoesNotExist is returned.
-		// Consumer interface is returned, serving as a hook to operate on a consumer (e.g. fetch messages).
+		// UpdateConsumer updates an existing consumer. If consumer does not
+		// exist, ErrConsumerDoesNotExist is returned. Consumer interface is
+		// returned, serving as a hook to operate on a consumer (e.g. fetch
+		// messages)
 		UpdateConsumer(ctx context.Context, cfg ConsumerConfig) (Consumer, error)
 
-		// OrderedConsumer returns an OrderedConsumer instance.
-		// OrderedConsumer allows fetching messages from a stream (just like standard consumer),
-		// for in order delivery of messages. Underlying consumer is re-created when necessary,
-		// without additional client code.
+		// OrderedConsumer returns an OrderedConsumer instance. OrderedConsumer
+		// allows fetching messages from a stream (just like standard consumer),
+		// for in order delivery of messages. Underlying consumer is re-created
+		// when necessary, without additional client code.
 		OrderedConsumer(ctx context.Context, cfg OrderedConsumerConfig) (Consumer, error)
 
-		// Consumer returns a Consumer interface for an existing consumer
+		// Consumer returns a hook to an existing consumer, allowing processing
+		// of messages. If consumer does not exist, ErrConsumerNotFound is
+		// returned.
 		Consumer(ctx context.Context, consumer string) (Consumer, error)
 
-		// DeleteConsumer removes a consumer
+		// DeleteConsumer removes a consumer with given name from a stream.
+		// If consumer does not exist, ErrConsumerNotFound is returned.
 		DeleteConsumer(ctx context.Context, consumer string) error
 
-		// ListConsumers returns ConsumerInfoLister enabling iterating over a channel of consumer infos
+		// ListConsumers returns ConsumerInfoLister enabling iterating over a
+		// channel of consumer infos.
 		ListConsumers(context.Context) ConsumerInfoLister
 
-		// ConsumerNames returns a ConsumerNameLister enabling iterating over a channel of consumer names
+		// ConsumerNames returns a ConsumerNameLister enabling iterating over a
+		// channel of consumer names.
 		ConsumerNames(context.Context) ConsumerNameLister
 	}
 
@@ -99,6 +117,7 @@ type (
 		jetStream *jetStream
 	}
 
+	// StreamInfoOpt is a function setting options for [Stream.Info]
 	StreamInfoOpt func(*streamInfoRequest) error
 
 	streamInfoRequest struct {
@@ -112,7 +131,10 @@ type (
 		*ConsumerInfo
 	}
 
+	// StreamPurgeOpt is a function setting options for [Stream.Purge]
 	StreamPurgeOpt func(*StreamPurgeRequest) error
+
+	// StreamPurgeRequest is an API request body to purge a stream.
 
 	StreamPurgeRequest struct {
 		// Purge up to but not including sequence.
@@ -134,6 +156,7 @@ type (
 		Success bool `json:"success,omitempty"`
 	}
 
+	// GetMsgOpt is a function setting options for [Stream.GetMsg]
 	GetMsgOpt func(*apiMsgGetRequest) error
 
 	apiMsgGetRequest struct {
@@ -167,11 +190,17 @@ type (
 		Success bool `json:"success,omitempty"`
 	}
 
+	// ConsumerInfoLister is used to iterate over a channel of consumer infos.
+	// Err method can be used to check for errors encountered during iteration.
+	// Info channel is always closed and therefore can be used in a range loop.
 	ConsumerInfoLister interface {
 		Info() <-chan *ConsumerInfo
 		Err() error
 	}
 
+	// ConsumerNameLister is used to iterate over a channel of consumer names.
+	// Err method can be used to check for errors encountered during iteration.
+	// Name channel is always closed and therefore can be used in a range loop.
 	ConsumerNameLister interface {
 		Name() <-chan string
 		Err() error
@@ -200,18 +229,34 @@ type (
 	}
 )
 
+// CreateOrUpdateConsumer creates a consumer on a given stream with
+// given config. If consumer already exists, it will be updated (if
+// possible). Consumer interface is returned, serving as a hook to
+// operate on a consumer (e.g. fetch messages)
 func (s *stream) CreateOrUpdateConsumer(ctx context.Context, cfg ConsumerConfig) (Consumer, error) {
 	return upsertConsumer(ctx, s.jetStream, s.name, cfg, consumerActionCreateOrUpdate)
 }
 
+// CreateConsumer creates a consumer on a given stream with given
+// config. If consumer already exists, ErrConsumerExists is returned.
+// Consumer interface is returned, serving as a hook to operate on a
+// consumer (e.g. fetch messages)
 func (s *stream) CreateConsumer(ctx context.Context, cfg ConsumerConfig) (Consumer, error) {
 	return upsertConsumer(ctx, s.jetStream, s.name, cfg, consumerActionCreate)
 }
 
+// UpdateConsumer updates an existing consumer. If consumer does not
+// exist, ErrConsumerDoesNotExist is returned. Consumer interface is
+// returned, serving as a hook to operate on a consumer (e.g. fetch
+// messages)
 func (s *stream) UpdateConsumer(ctx context.Context, cfg ConsumerConfig) (Consumer, error) {
 	return upsertConsumer(ctx, s.jetStream, s.name, cfg, consumerActionUpdate)
 }
 
+// OrderedConsumer returns an OrderedConsumer instance. OrderedConsumer
+// allows fetching messages from a stream (just like standard consumer),
+// for in order delivery of messages. Underlying consumer is re-created
+// when necessary, without additional client code.
 func (s *stream) OrderedConsumer(ctx context.Context, cfg OrderedConsumerConfig) (Consumer, error) {
 	oc := &orderedConsumer{
 		jetStream:  s.jetStream,
@@ -231,19 +276,20 @@ func (s *stream) OrderedConsumer(ctx context.Context, cfg OrderedConsumerConfig)
 	return oc, nil
 }
 
+// Consumer returns a hook to an existing consumer, allowing processing
+// of messages. If consumer does not exist, ErrConsumerNotFound is
+// returned.
 func (s *stream) Consumer(ctx context.Context, name string) (Consumer, error) {
 	return getConsumer(ctx, s.jetStream, s.name, name)
 }
 
+// DeleteConsumer removes a consumer with given name from a stream.
+// If consumer does not exist, ErrConsumerNotFound is returned.
 func (s *stream) DeleteConsumer(ctx context.Context, name string) error {
 	return deleteConsumer(ctx, s.jetStream, s.name, name)
 }
 
-// Info fetches *StreamInfo from server
-//
-// Available options:
-// [WithDeletedDetails] - use to display the information about messages deleted from a stream
-// [WithSubjectFilter] - use to display the information about messages stored on given subjects
+// Info returns StreamInfo from the server.
 func (s *stream) Info(ctx context.Context, opts ...StreamInfoOpt) (*StreamInfo, error) {
 	ctx, cancel := wrapContextWithoutDeadline(ctx)
 	if cancel != nil {
@@ -312,20 +358,15 @@ func (s *stream) Info(ctx context.Context, opts ...StreamInfoOpt) (*StreamInfo, 
 	return info, nil
 }
 
-// CachedInfo returns *StreamInfo cached on a stream struct
-//
-// NOTE: The returned object might not be up to date with the most recent updates on the server
-// For up-to-date information, use [Info]
+// CachedInfo returns ConsumerInfo currently cached on this stream.
+// This method does not perform any network requests. The cached
+// StreamInfo is updated on every call to Info and Update.
 func (s *stream) CachedInfo() *StreamInfo {
 	return s.info
 }
 
-// Purge removes messages from a stream
-//
-// Available options:
-// [WithPurgeSubject] - can be used set a specific subject for which messages on a stream will be purged
-// [WithPurgeSequence] - can be used to set a specific sequence number up to which (but not including) messages will be purged from a stream
-// [WithPurgeKeep] - can be used to set the number of messages to be kept in the stream after purge.
+// Purge removes messages from a stream. It is a destructive operation.
+// Use with caution. See StreamPurgeOpt for available options.
 func (s *stream) Purge(ctx context.Context, opts ...StreamPurgeOpt) error {
 	ctx, cancel := wrapContextWithoutDeadline(ctx)
 	if cancel != nil {
@@ -357,6 +398,7 @@ func (s *stream) Purge(ctx context.Context, opts ...StreamPurgeOpt) error {
 	return nil
 }
 
+// GetMsg retrieves a raw stream message stored in JetStream by sequence number.
 func (s *stream) GetMsg(ctx context.Context, seq uint64, opts ...GetMsgOpt) (*RawStreamMsg, error) {
 	req := &apiMsgGetRequest{Seq: seq}
 	for _, opt := range opts {
@@ -367,6 +409,8 @@ func (s *stream) GetMsg(ctx context.Context, seq uint64, opts ...GetMsgOpt) (*Ra
 	return s.getMsg(ctx, req)
 }
 
+// GetLastMsgForSubject retrieves the last raw stream message stored in
+// JetStream on a given subject subject.
 func (s *stream) GetLastMsgForSubject(ctx context.Context, subject string) (*RawStreamMsg, error) {
 	return s.getMsg(ctx, &apiMsgGetRequest{LastFor: subject})
 }
@@ -491,13 +535,14 @@ func convertDirectGetMsgResponseToMsg(name string, r *nats.Msg) (*RawStreamMsg, 
 }
 
 // DeleteMsg deletes a message from a stream.
-// The message is marked as erased, but not overwritten
+// On the server, the message is marked as erased, but not overwritten.
 func (s *stream) DeleteMsg(ctx context.Context, seq uint64) error {
 	return s.deleteMsg(ctx, &msgDeleteRequest{Seq: seq, NoErase: true})
 }
 
-// SecureDeleteMsg deletes a message from a stream. The deleted message is overwritten with random data
-// As a result, this operation is slower than DeleteMsg()
+// SecureDeleteMsg deletes a message from a stream. The deleted message
+// is overwritten with random data As a result, this operation is slower
+// than DeleteMsg.
 func (s *stream) SecureDeleteMsg(ctx context.Context, seq uint64) error {
 	return s.deleteMsg(ctx, &msgDeleteRequest{Seq: seq})
 }
@@ -522,7 +567,8 @@ func (s *stream) deleteMsg(ctx context.Context, req *msgDeleteRequest) error {
 	return nil
 }
 
-// ListConsumers returns ConsumerInfoLister enabling iterating over a channel of consumer infos.
+// ListConsumers returns ConsumerInfoLister enabling iterating over a
+// channel of consumer infos.
 func (s *stream) ListConsumers(ctx context.Context) ConsumerInfoLister {
 	l := &consumerLister{
 		js:        s.jetStream,
@@ -568,7 +614,8 @@ func (s *consumerLister) Err() error {
 	return s.err
 }
 
-// ConsumerNames returns a ConsumerNameLister enabling iterating over a channel of consumer names
+// ConsumerNames returns a ConsumerNameLister enabling iterating over a
+// channel of consumer names.
 func (s *stream) ConsumerNames(ctx context.Context) ConsumerNameLister {
 	l := &consumerLister{
 		js:    s.jetStream,

--- a/jetstream/stream_config.go
+++ b/jetstream/stream_config.go
@@ -130,7 +130,7 @@ type (
 		// Sources is a list of other streams this stream sources messages from.
 		Sources []*StreamSource `json:"sources,omitempty"`
 
-		// Sealed streams do not allow messages to be deleted via limits or API,
+		// Sealed streams do not allow messages to be published or deleted via limits or API,
 		// sealed streams can not be unsealed via configuration update. Can only
 		// be set on already created streams via the Update API.
 		Sealed bool `json:"sealed,omitempty"`


### PR DESCRIPTION
This is the first part of improving `jetstream` package documentation.
This PR updates documantation for core jetstream (no KV or Object Store), by expanding docs to struct fields, as well as having more detailed documentation on public methods and interfaces.

What will be added in subsequent PRs:
- KV/Object store documentation improvements, together with respective section in README
- Code examples

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>