### PR TITLE
Release v1.33.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ When using or transitioning to Go modules support:
 ```bash
 # Go client latest or explicit version
 go get github.com/nats-io/nats.go/@latest
-go get github.com/nats-io/nats.go/@v1.33.0
+go get github.com/nats-io/nats.go/@v1.33.1
 
 # For latest NATS Server, add /v2 at the end
 go get github.com/nats-io/nats-server/v2

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.33.0"
+	Version                   = "1.33.1"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
### Overview

This release fixes `v1.33.0` release which was re-released with different tag, causing checksum mismatch when running `go get github.com/nats-io/nats.go@v1.33.0`.