### PR TITLE
Adds a keys method to the NATS message header

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -3640,6 +3640,17 @@ func (h Header) Get(key string) string {
 	return _EMPTY_
 }
 
+// Returns the list of keys in the message header
+func (h Header) Keys() []string {
+	keys := make([]string, len(h))
+	i := 0
+	for k := range h {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
 // Values returns all values associated with the given key.
 // It is case-sensitive.
 func (h Header) Values(key string) []string {

--- a/nats_test.go
+++ b/nats_test.go
@@ -29,6 +29,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1591,6 +1592,25 @@ func TestHeaderParser(t *testing.T) {
 	checkStatus("NATS/1.0 503", 503, "")
 	checkStatus("NATS/1.0 503 No Responders", 503, "No Responders")
 	checkStatus("NATS/1.0  404   No Messages", 404, "No Messages")
+}
+
+func TestHeaderKeys(t *testing.T) {
+	m := NewMsg("testing")
+	m.Header = Header{
+		"field1": []string{"a"},
+		"field2": []string{"b"},
+	}
+	actualKeys := m.Header.Keys()
+	if !slices.Contains(actualKeys, "field1") ||
+		!slices.Contains(actualKeys, "field2") {
+		t.Fatalf("Keys did not return expected list: %+v", actualKeys)
+	}
+
+	m.Header = Header{}
+	emptyKeys := m.Header.Keys()
+	if len(emptyKeys) > 0 {
+		t.Fatal("Empty header should've returned empty keys list")
+	}
 }
 
 func TestHeaderMultiLine(t *testing.T) {


### PR DESCRIPTION
On the surface this is just a convenience function, however, by adding the `Keys` method with this signature, we make the `msg.Header` field a suitable target for injection of open telemetry span context. In other words, after this change, the `Header` field will satisfy the [TextMapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel@v1.24.0/propagation#TextMapCarrier) interface:

```
type TextMapCarrier interface {

	// Get returns the value associated with the passed key.
	Get(key) string
	// Set stores the key-value pair.
	Set(key string, value string)
	// Keys lists the keys stored in this carrier.
	Keys() []string
}
```

This means we'll be able to use NATS message headers to automatically convey OpenTelemetry span context via the `TraceContext`'s `Inject` and `Extract` functions:

```
tctx.Inject(ctx, msg.Header)
...
rehydratedContext := tctx.Extract(ctx, msg.Header)
```