### PR TITLE
[FIXED] typos in comments

### DIFF
--- a/bench/bench.go
+++ b/bench/bench.go
@@ -36,7 +36,7 @@ type Sample struct {
 	End       time.Time
 }
 
-// SampleGroup for a number of samples, the group is a Sample itself agregating the values the Samples
+// SampleGroup for a number of samples, the group is a Sample itself aggregating the values the Samples
 type SampleGroup struct {
 	Sample
 	Samples []*Sample
@@ -156,7 +156,7 @@ func (s *Sample) Throughput() float64 {
 	return float64(s.MsgBytes) / s.Duration().Seconds()
 }
 
-// Rate of meessages in the job per second
+// Rate of messages in the job per second
 func (s *Sample) Rate() int64 {
 	return int64(float64(s.JobMsgCnt) / s.Duration().Seconds())
 }

--- a/bench/benchlib_test.go
+++ b/bench/benchlib_test.go
@@ -116,7 +116,7 @@ func TestGroupThoughput(t *testing.T) {
 	sg.AddSample(millionMessagesSecondSample(2))
 	sg.AddSample(millionMessagesSecondSample(3))
 	if sg.Throughput() != 2*Million*MsgSize {
-		t.Fatalf("Expected througput at %d million bytes/sec", 2*MsgSize)
+		t.Fatalf("Expected throughput at %d million bytes/sec", 2*MsgSize)
 	}
 }
 


### PR DESCRIPTION
Fixed following typos:

.\bench\bench.go:39: agregating ==> aggregating
.\bench\bench.go:159: meessages ==> messages
.\bench\benchlib_test.go:119: througput ==> throughput