### PR TITLE
Adding support for top level middleware and setting headers

### DIFF
--- a/micro/request.go
+++ b/micro/request.go
@@ -56,6 +56,9 @@ type (
 		// Headers returns request headers.
 		Headers() Headers
 
+		// SetHeader sets a specific header
+		SetHeader(key, value string)
+
 		// Subject returns underlying NATS message subject.
 		Subject() string
 	}
@@ -179,6 +182,17 @@ func (r *request) Data() []byte {
 // Headers returns request headers.
 func (r *request) Headers() Headers {
 	return Headers(r.msg.Header)
+}
+
+func (r *request) SetHeader(key string, value string) {
+	if len(r.msg.Header) != 0 {
+		r.msg.Header.Set(key, value)
+		return
+	}
+	headers := nats.Header{
+		key: []string{value},
+	}
+	r.msg.Header = headers
 }
 
 // Subject returns underlying NATS message subject.

--- a/micro/service.go
+++ b/micro/service.go
@@ -101,6 +101,8 @@ type (
 		Metadata map[string]string `json:"metadata"`
 	}
 
+	Middleware func(Handler) Handler
+
 	// Stats is the type returned by STATS monitoring endpoint.
 	// It contains stats of all registered endpoints.
 	Stats struct {
@@ -195,6 +197,9 @@ type (
 
 		// ErrorHandler is invoked on any nats-related service error.
 		ErrorHandler ErrHandler
+
+		// Middleware is a slice of handlers that should be run on every request
+		Middleware []Middleware
 	}
 
 	EndpointConfig struct {
@@ -400,6 +405,9 @@ func (s *service) AddEndpoint(name string, handler Handler, opts ...EndpointOpt)
 		subject = options.subject
 	}
 	queueGroup := queueGroupName(options.queueGroup, s.Config.QueueGroup)
+	for _, v := range s.Middleware {
+		handler = v(handler)
+	}
 	return addEndpoint(s, name, subject, handler, options.metadata, queueGroup)
 }
 


### PR DESCRIPTION
We are embarking on some new internal tooling and would like to use this micro package since it simplifies a lot of work. One thing we are missing is top level middleware we can use. We could technically do this without middleware in the service, but we would have to wrap every function in it separately.

This also allows for setting a header value so that in the middleware a header value can be set on the request and then passed through. 

Hopefully this doesn't stray too far from the idea of this package.