### PR TITLE
[ADDED] JetStream Publish Option ExpectLastSequencePerSubjectForSubject

### DIFF
--- a/jetstream/jetstream_options.go
+++ b/jetstream/jetstream_options.go
@@ -360,6 +360,17 @@ func WithExpectLastSequencePerSubject(seq uint64) PublishOpt {
 	}
 }
 
+// WithExpectLastSequencePerSubjectForSubject sets the subject to use when
+// ExpectLastSequencePerSubject is set. If the last message for the specified
+// subject has a different sequence number server will reject the message and
+// publish will fail.
+func WithExpectLastSequencePerSubjectForSubject(subj string) PublishOpt {
+	return func(opts *pubOpts) error {
+		opts.lastSubjectSeqSubject = subj
+		return nil
+	}
+}
+
 // WithExpectLastMsgID sets the expected message ID the last message on a stream
 // should have. If the last message has a different message ID server will
 // reject the message and publish will fail.

--- a/jetstream/message.go
+++ b/jetstream/message.go
@@ -181,6 +181,13 @@ const (
 	// [WithExpectLastSequencePerSubject] option.
 	ExpectedLastSubjSeqHeader = "Nats-Expected-Last-Subject-Sequence"
 
+	// ExpectedLastSubjSeqSubjHeader contains the subject to be used when
+	// the subject expected last sequence number is set in ExpectedLastSubjSeqHeader.
+	//
+	// This can be set when publishing messages using
+	// [WithExpectLastSequencePerSubjectForSubject] option.
+	ExpectedLastSubjSeqSubjHeader = "Nats-Expected-Last-Subject-Sequence-Subject"
+
 	// ExpectedLastMsgIDHeader contains the expected last message ID on the
 	// subject and can be used to apply optimistic concurrency control at
 	// stream level. Server will reject the message if it is not the case.

--- a/jetstream/publish.go
+++ b/jetstream/publish.go
@@ -41,11 +41,12 @@ type (
 	PublishOpt func(*pubOpts) error
 
 	pubOpts struct {
-		id             string
-		lastMsgID      string  // Expected last msgId
-		stream         string  // Expected stream name
-		lastSeq        *uint64 // Expected last sequence
-		lastSubjectSeq *uint64 // Expected last sequence per subject
+		id                    string
+		lastMsgID             string  // Expected last msgId
+		stream                string  // Expected stream name
+		lastSeq               *uint64 // Expected last sequence
+		lastSubjectSeq        *uint64 // Expected last sequence per subject
+		lastSubjectSeqSubject string  // Expected last sequence per subject for this subject
 
 		// Publish retries for NoResponders err.
 		retryWait     time.Duration // Retry wait between attempts
@@ -190,6 +191,9 @@ func (js *jetStream) PublishMsg(ctx context.Context, m *nats.Msg, opts ...Publis
 	if o.lastSubjectSeq != nil {
 		m.Header.Set(ExpectedLastSubjSeqHeader, strconv.FormatUint(*o.lastSubjectSeq, 10))
 	}
+	if o.lastSubjectSeqSubject != "" {
+		m.Header.Set(ExpectedLastSubjSeqSubjHeader, o.lastSubjectSeqSubject)
+	}
 
 	var resp *nats.Msg
 	var err error
@@ -272,6 +276,9 @@ func (js *jetStream) PublishMsgAsync(m *nats.Msg, opts ...PublishOpt) (PubAckFut
 	}
 	if o.lastSubjectSeq != nil {
 		m.Header.Set(ExpectedLastSubjSeqHeader, strconv.FormatUint(*o.lastSubjectSeq, 10))
+	}
+	if o.lastSubjectSeqSubject != "" {
+		m.Header.Set(ExpectedLastSubjSeqSubjHeader, o.lastSubjectSeqSubject)
 	}
 
 	paf := o.pafRetry

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -428,6 +428,23 @@ func TestJetStreamPublish(t *testing.T) {
 	if m.Header.Get(nats.ExpectedLastSubjSeqHdr) != "1" {
 		t.Fatalf("Header ExpectLastSequencePerSubject not set: %+v", m.Header)
 	}
+
+	// Test ExpectLastSequencePerSubjectForSubject. Just make sure that we set the header.
+	sub, err = nc.SubscribeSync("test")
+	if err != nil {
+		t.Fatalf("Error on subscribe: %v", err)
+	}
+	js.Publish("test",
+		[]byte("msg"),
+		nats.ExpectLastSequencePerSubject(1),
+		nats.ExpectLastSequencePerSubjectForSubject("test"))
+	m, err = sub.NextMsg(time.Second)
+	if err != nil {
+		t.Fatalf("Error on next msg: %v", err)
+	}
+	if m.Header.Get(nats.ExpectedLastSubjSeqSubjHdr) != "test" {
+		t.Fatalf("Header ExpectLastSequencePerSubjectForSubject not set: %+v", m.Header)
+	}
 }
 
 func TestJetStreamSubscribe(t *testing.T) {
@@ -8272,6 +8289,104 @@ func TestJetStreamPublishExpectZero(t *testing.T) {
 	}
 	got = hdr[0]
 	expected = "0"
+	if got != expected {
+		t.Fatalf("Expected %v, got: %v", expected, got)
+	}
+}
+
+func TestJetStreamPublishExpectZeroForSubject(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, s)
+
+	nc, js := jsClient(t, s)
+	defer nc.Close()
+
+	var err error
+
+	// Create the stream using our client API.
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"test", "foo", "bar"},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	sub, err := nc.SubscribeSync("foo")
+	if err != nil {
+		t.Errorf("Error: %s", err)
+	}
+
+	// Explicitly set the header to zero.
+	_, err = js.Publish("foo", []byte("bar"),
+		nats.ExpectLastSequence(0),
+		nats.ExpectLastSequencePerSubject(0),
+		nats.ExpectLastSequencePerSubjectForSubject("test"),
+	)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+
+	rawMsg, err := js.GetMsg("TEST", 1)
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+	hdr, ok := rawMsg.Header["Nats-Expected-Last-Sequence"]
+	if !ok {
+		t.Fatal("Missing header")
+	}
+	got := hdr[0]
+	expected := "0"
+	if got != expected {
+		t.Fatalf("Expected %v, got: %v", expected, got)
+	}
+	hdr, ok = rawMsg.Header["Nats-Expected-Last-Subject-Sequence"]
+	if !ok {
+		t.Fatal("Missing header")
+	}
+	got = hdr[0]
+	expected = "0"
+	if got != expected {
+		t.Fatalf("Expected %v, got: %v", expected, got)
+	}
+	hdr, ok = rawMsg.Header["Nats-Expected-Last-Subject-Sequence-Subject"]
+	if !ok {
+		t.Fatal("Missing header")
+	}
+	got = hdr[0]
+	expected = "test"
+	if got != expected {
+		t.Fatalf("Expected %v, got: %v", expected, got)
+	}
+
+	msg, err := sub.NextMsg(1 * time.Second)
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+	hdr, ok = msg.Header["Nats-Expected-Last-Sequence"]
+	if !ok {
+		t.Fatal("Missing header")
+	}
+	got = hdr[0]
+	expected = "0"
+	if got != expected {
+		t.Fatalf("Expected %v, got: %v", expected, got)
+	}
+	hdr, ok = msg.Header["Nats-Expected-Last-Subject-Sequence"]
+	if !ok {
+		t.Fatal("Missing header")
+	}
+	got = hdr[0]
+	expected = "0"
+	if got != expected {
+		t.Fatalf("Expected %v, got: %v", expected, got)
+	}
+	hdr, ok = msg.Header["Nats-Expected-Last-Subject-Sequence-Subject"]
+	if !ok {
+		t.Fatal("Missing header")
+	}
+	got = hdr[0]
+	expected = "test"
 	if got != expected {
 		t.Fatalf("Expected %v, got: %v", expected, got)
 	}


### PR DESCRIPTION
Adds publish option ExpectLastSequencePerSubjectForSubject to create the publish header "Nats-Expected-Last-Subject-Sequence-Subject" with the supplied value. This enables the server use an alternate subject when enforcing "Nats-Expected-Last-Subject-Sequence"

Relates to https://github.com/nats-io/nats-server/issues/5280
Relates to https://github.com/nats-io/nats-server/pull/5281

Signed-off-by: Caleb Champlin <caleb.champlin@gmail.com>