### PR TITLE
[UPDATED] Added json tags to KeyValueConfig struct to behave consistently with the StreamConfig one

### DIFF
--- a/jetstream/kv.go
+++ b/jetstream/kv.go
@@ -197,52 +197,52 @@ type (
 		// Bucket is the name of the KeyValue store. Bucket name has to be
 		// unique and can only contain alphanumeric characters, dashes, and
 		// underscores.
-		Bucket string
+		Bucket string `json:"bucket"`
 
 		// Description is an optional description for the KeyValue store.
-		Description string
+		Description string `json:"description,omitempty"`
 
 		// MaxValueSize is the maximum size of a value in bytes. If not
 		// specified, the default is -1 (unlimited).
-		MaxValueSize int32
+		MaxValueSize int32 `json:"max_value_size,omitempty"`
 
 		// History is the number of historical values to keep per key. If not
 		// specified, the default is 1. Max is 64.
-		History uint8
+		History uint8 `json:"history"`
 
 		// TTL is the expiry time for keys. By default, keys do not expire.
-		TTL time.Duration
+		TTL time.Duration `json:"ttl,omitempty"`
 
 		// MaxBytes is the maximum size in bytes of the KeyValue store. If not
 		// specified, the default is -1 (unlimited).
-		MaxBytes int64
+		MaxBytes int64 `json:"max_bytes"`
 
 		// Storage is the type of storage to use for the KeyValue store. If not
 		// specified, the default is FileStorage.
-		Storage StorageType
+		Storage StorageType `json:"storage"`
 
 		// Replicas is the number of replicas to keep for the KeyValue store in
 		// clustered jetstream. Defaults to 1, maximum is 5.
-		Replicas int
+		Replicas int `json:"replicas"`
 
 		// Placement is used to declare where the stream should be placed via
 		// tags and/or an explicit cluster name.
-		Placement *Placement
+		Placement *Placement `json:"placement,omitempty"`
 
 		// RePublish allows immediate republishing a message to the configured
 		// subject after it's stored.
-		RePublish *RePublish
+		RePublish *RePublish `json:"republish,omitempty"`
 
 		// Mirror defines the consiguration for mirroring another KeyValue
 		// store.
-		Mirror *StreamSource
+		Mirror *StreamSource `json:"mirror,omitempty"`
 
 		// Sources defines the configuration for sources of a KeyValue store.
-		Sources []*StreamSource
+		Sources []*StreamSource `json:"sources,omitempty"`
 
 		// Compression sets the underlying stream compression.
 		// NOTE: Compression is supported for nats-server 2.10.0+
-		Compression bool
+		Compression bool `json:"compression"`
 	}
 
 	// KeyLister is used to retrieve a list of key value store keys. It returns

--- a/jetstream/kv.go
+++ b/jetstream/kv.go
@@ -208,22 +208,22 @@ type (
 
 		// History is the number of historical values to keep per key. If not
 		// specified, the default is 1. Max is 64.
-		History uint8 `json:"history"`
+		History uint8 `json:"history,omitempty"`
 
 		// TTL is the expiry time for keys. By default, keys do not expire.
 		TTL time.Duration `json:"ttl,omitempty"`
 
 		// MaxBytes is the maximum size in bytes of the KeyValue store. If not
 		// specified, the default is -1 (unlimited).
-		MaxBytes int64 `json:"max_bytes"`
+		MaxBytes int64 `json:"max_bytes,omitempty"`
 
 		// Storage is the type of storage to use for the KeyValue store. If not
 		// specified, the default is FileStorage.
-		Storage StorageType `json:"storage"`
+		Storage StorageType `json:"storage,omitempty"`
 
 		// Replicas is the number of replicas to keep for the KeyValue store in
 		// clustered jetstream. Defaults to 1, maximum is 5.
-		Replicas int `json:"replicas"`
+		Replicas int `json:"num_replicas,omitempty"`
 
 		// Placement is used to declare where the stream should be placed via
 		// tags and/or an explicit cluster name.
@@ -242,7 +242,7 @@ type (
 
 		// Compression sets the underlying stream compression.
 		// NOTE: Compression is supported for nats-server 2.10.0+
-		Compression bool `json:"compression"`
+		Compression bool `json:"compression,omitempty"`
 	}
 
 	// KeyLister is used to retrieve a list of key value store keys. It returns

--- a/kv.go
+++ b/kv.go
@@ -249,22 +249,22 @@ func purge() DeleteOpt {
 
 // KeyValueConfig is for configuring a KeyValue store.
 type KeyValueConfig struct {
-	Bucket       string
-	Description  string
-	MaxValueSize int32
-	History      uint8
-	TTL          time.Duration
-	MaxBytes     int64
-	Storage      StorageType
-	Replicas     int
-	Placement    *Placement
-	RePublish    *RePublish
-	Mirror       *StreamSource
-	Sources      []*StreamSource
+	Bucket       string          `json:"bucket"`
+	Description  string          `json:"description,omitempty"`
+	MaxValueSize int32           `json:"max_value_size,omitempty"`
+	History      uint8           `json:"history"`
+	TTL          time.Duration   `json:"ttl,omitempty"`
+	MaxBytes     int64           `json:"max_bytes"`
+	Storage      StorageType     `json:"storage"`
+	Replicas     int             `json:"replicas"`
+	Placement    *Placement      `json:"placement,omitempty"`
+	RePublish    *RePublish      `json:"republish,omitempty"`
+	Mirror       *StreamSource   `json:"mirror,omitempty"`
+	Sources      []*StreamSource `json:"sources,omitempty"`
 
 	// Enable underlying stream compression.
 	// NOTE: Compression is supported for nats-server 2.10.0+
-	Compression bool
+	Compression bool `json:"compression"`
 }
 
 // Used to watch all keys.

--- a/kv.go
+++ b/kv.go
@@ -253,7 +253,7 @@ type KeyValueConfig struct {
 	Description  string          `json:"description,omitempty"`
 	MaxValueSize int32           `json:"max_value_size,omitempty"`
 	History      uint8           `json:"history,omitempty"`
-	TTL          time.Duration   `json:"ttl,omitempty,omitempty"`
+	TTL          time.Duration   `json:"ttl,omitempty"`
 	MaxBytes     int64           `json:"max_bytes,omitempty"`
 	Storage      StorageType     `json:"storage,omitempty"`
 	Replicas     int             `json:"num_replicas,omitempty"`

--- a/kv.go
+++ b/kv.go
@@ -252,11 +252,11 @@ type KeyValueConfig struct {
 	Bucket       string          `json:"bucket"`
 	Description  string          `json:"description,omitempty"`
 	MaxValueSize int32           `json:"max_value_size,omitempty"`
-	History      uint8           `json:"history"`
-	TTL          time.Duration   `json:"ttl,omitempty"`
-	MaxBytes     int64           `json:"max_bytes"`
-	Storage      StorageType     `json:"storage"`
-	Replicas     int             `json:"replicas"`
+	History      uint8           `json:"history,omitempty"`
+	TTL          time.Duration   `json:"ttl,omitempty,omitempty"`
+	MaxBytes     int64           `json:"max_bytes,omitempty"`
+	Storage      StorageType     `json:"storage,omitempty"`
+	Replicas     int             `json:"num_replicas,omitempty"`
 	Placement    *Placement      `json:"placement,omitempty"`
 	RePublish    *RePublish      `json:"republish,omitempty"`
 	Mirror       *StreamSource   `json:"mirror,omitempty"`
@@ -264,7 +264,7 @@ type KeyValueConfig struct {
 
 	// Enable underlying stream compression.
 	// NOTE: Compression is supported for nats-server 2.10.0+
-	Compression bool `json:"compression"`
+	Compression bool `json:"compression,omitempty"`
 }
 
 // Used to watch all keys.


### PR DESCRIPTION
This PR add json tags to the `KeyValueConfig` struct like the ones already present in `StreamConfig`. 
This is useful when working with KV buckets because currently you need a map or support struct to marshal / unmarshal a  bucket config to / from JSON.

- I used the `StreamConfig` tags as reference.
- I replicated the `omitempty` option for the fields that have it in `StreamConfig`, but a check is needed for the other ones.