### PR TITLE
Pause heartbeat detection during reconnection

### DIFF
--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -596,6 +596,12 @@ func (s *pullSubscription) Next() (Msg, error) {
 			if errors.Is(err, errConnected) {
 				if !isConnected {
 					isConnected = true
+
+					if hbMonitor != nil {
+						// we are not going to get a heartbeat while reconnecting
+						hbMonitor.Stop()
+					}
+
 					// try fetching consumer info several times to make sure consumer is available after reconnect
 					backoffOpts := backoffOpts{
 						attempts:                10,


### PR DESCRIPTION
Currently, reconnection may take many multiples of seconds to perform. However, heartbeat detection is still enabled during this period, making it extremely likely that the very first "message" after reconnection is a heartbeat failure.

This PR stops the heartbeat timer until a connection is successfully made.

Fixes #1622 