### PR TITLE
Fix wrong initial settings of js ordered consumer

### DIFF
--- a/jetstream/ordered.go
+++ b/jetstream/ordered.go
@@ -559,7 +559,6 @@ func (c *orderedConsumer) getConsumerConfigForSeq(seq uint64) *ConsumerConfig {
 		cfg.DeliverPolicy = DeliverByStartTimePolicy
 		cfg.OptStartTime = c.cfg.OptStartTime
 	}
-
 	if c.cfg.InactiveThreshold != 0 {
 		cfg.InactiveThreshold = c.cfg.InactiveThreshold
 	}

--- a/jetstream/ordered.go
+++ b/jetstream/ordered.go
@@ -537,7 +537,7 @@ func (c *orderedConsumer) getConsumerConfigForSeq(seq uint64) *ConsumerConfig {
 		cfg.FilterSubjects = c.cfg.FilterSubjects
 	}
 
-	if seq != c.cfg.OptStartSeq+1 {
+	if seq > c.cfg.OptStartSeq {
 		return cfg
 	}
 
@@ -559,6 +559,7 @@ func (c *orderedConsumer) getConsumerConfigForSeq(seq uint64) *ConsumerConfig {
 		cfg.DeliverPolicy = DeliverByStartTimePolicy
 		cfg.OptStartTime = c.cfg.OptStartTime
 	}
+
 	if c.cfg.InactiveThreshold != 0 {
 		cfg.InactiveThreshold = c.cfg.InactiveThreshold
 	}

--- a/jetstream/ordered.go
+++ b/jetstream/ordered.go
@@ -537,7 +537,7 @@ func (c *orderedConsumer) getConsumerConfigForSeq(seq uint64) *ConsumerConfig {
 		cfg.FilterSubjects = c.cfg.FilterSubjects
 	}
 
-	if seq > c.cfg.OptStartSeq {
+	if seq > c.cfg.OptStartSeq && seq != 1 {
 		return cfg
 	}
 


### PR DESCRIPTION
Currently we lost initial settings of ordered consumer if there is OptStartSeq is present.
Just fixed wrong check initial request condition

Also it looks like we will lost initial settings on every consumer reset. The main problem as I see is that policy can be changed from DeliverLastPerSubjectPolicy to DeliverByStartSequencePolicy just by consumer reset. This is very unexpected behavior. 
Also lost InactiveThreshold is a bit unpleasant too.