### PR TITLE
[IMPROVED] Ordered consumer creation and initial config settings

### DIFF
--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -739,13 +739,12 @@ func (js *jetStream) OrderedConsumer(ctx context.Context, stream string, cfg Ord
 		namePrefix: nuid.Next(),
 		doReset:    make(chan struct{}, 1),
 	}
-	if cfg.OptStartSeq != 0 {
-		oc.cursor.streamSeq = cfg.OptStartSeq
-	}
-	err := oc.reset()
+	consCfg := oc.getConsumerConfig()
+	cons, err := js.CreateOrUpdateConsumer(ctx, stream, *consCfg)
 	if err != nil {
 		return nil, err
 	}
+	oc.currentConsumer = cons.(*pullConsumer)
 
 	return oc, nil
 }

--- a/jetstream/stream.go
+++ b/jetstream/stream.go
@@ -273,13 +273,12 @@ func (s *stream) OrderedConsumer(ctx context.Context, cfg OrderedConsumerConfig)
 		namePrefix: nuid.Next(),
 		doReset:    make(chan struct{}, 1),
 	}
-	if cfg.OptStartSeq != 0 {
-		oc.cursor.streamSeq = cfg.OptStartSeq
-	}
-	err := oc.reset()
+	consCfg := oc.getConsumerConfig()
+	cons, err := s.CreateOrUpdateConsumer(ctx, *consCfg)
 	if err != nil {
 		return nil, err
 	}
+	oc.currentConsumer = cons.(*pullConsumer)
 
 	return oc, nil
 }


### PR DESCRIPTION
This changes a few things around creating ordered consumers:
- initial ordered consumer creation is now done without retries
- fixed an issue where start seq could be invalid when resetting a consumer which did not receive any messages
- simplified getConsumerConfig()

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)