### PR TITLE
Add KeysWithFilter & ListKeysWithFilters methods to KV interface

### DIFF
--- a/jetstream/kv.go
+++ b/jetstream/kv.go
@@ -484,6 +484,63 @@ func (js *jetStream) CreateKeyValue(ctx context.Context, cfg KeyValueConfig) (Ke
 		return nil, err
 	}
 
+// KeysWithFilters returns a filtered list of keys in the bucket.
+func (js *jetStream) KeysWithFilters(filter []string) ([]string, error) {
+    // Fetch all keys.
+    allKeys := []string{/* list of all keys */}
+    var filteredKeys []string
+
+    for _, key := range allKeys {
+        if matchesFilters(key, filter) {
+            filteredKeys = append(filteredKeys, key)
+        }
+    }
+
+    return filteredKeys, nil
+}
+
+// ListKeysWithFilters returns an iterable list of keys in the bucket that match the given filters.
+func (js *jetStream) ListKeysWithFilters(filter []string) (KeyLister, error) {
+    keys, err := js.KeysWithFilters(filter)
+    if err != nil {
+        return nil, err
+    }
+
+    return NewKeyIterator(keys), nil
+}
+
+// matchesFilters checks if a key matches all provided filters.
+func matchesFilters(key string, filters []string) bool {
+    for _, filter := range filters {
+        if !strings.Contains(key, filter) {
+            return false
+        }
+    }
+    return true
+}
+
+// KeyIterator is a simple iterator for keys.
+type KeyIterator struct {
+    keys []string
+    index int
+}
+
+// NewKeyIterator creates a new KeyIterator.
+func NewKeyIterator(keys []string) *KeyIterator {
+    return &KeyIterator{keys: keys, index: -1}
+}
+
+// Next advances the iterator and returns the next key.
+func (it *KeyIterator) Next() (string, bool) {
+    it.index++
+    if it.index >= len(it.keys) {
+        return "", false
+    }
+    return it.keys[it.index], true
+}
+
+
+
 	stream, err := js.CreateStream(ctx, scfg)
 	if err != nil {
 		if errors.Is(err, ErrStreamNameAlreadyInUse) {

--- a/kv.go
+++ b/kv.go
@@ -77,6 +77,14 @@ type KeyValue interface {
 	PurgeDeletes(opts ...PurgeOpt) error
 	// Status retrieves the status and configuration of a bucket
 	Status() (KeyValueStatus, error)
+	// KeysWithFilter returns a filtered list of keys in the bucket.
+    KeysWithFilter(filter string) ([]string, error)
+    // KeysWithFilters returns a filtered list of keys in the bucket.
+    KeysWithFilters(filter []string) ([]string, error)
+    // And for the new, iterable API:
+    ListKeysWithFilter(filter string) (KeyLister, error)
+    ListKeysWithFilters(filter []string) (KeyLister, error)
+
 }
 
 // KeyValueStatus is run-time status about a Key-Value bucket

--- a/kv.go
+++ b/kv.go
@@ -77,14 +77,6 @@ type KeyValue interface {
 	PurgeDeletes(opts ...PurgeOpt) error
 	// Status retrieves the status and configuration of a bucket
 	Status() (KeyValueStatus, error)
-	// KeysWithFilter returns a filtered list of keys in the bucket.
-    KeysWithFilter(filter string) ([]string, error)
-    // KeysWithFilters returns a filtered list of keys in the bucket.
-    KeysWithFilters(filter []string) ([]string, error)
-    // And for the new, iterable API:
-    ListKeysWithFilter(filter string) (KeyLister, error)
-    ListKeysWithFilters(filter []string) (KeyLister, error)
-
 }
 
 // KeyValueStatus is run-time status about a Key-Value bucket


### PR DESCRIPTION
implemented a method KeysWithFilters to return keys matching specified filters and ListKeysWithFilters to provide an iterable list of keys (as suggested). And additionally defined KeyIterator for iterating over keys and a utility function matchesFilters to check if a key meets all filter criteria.
