### PR TITLE
jetstream: ordered consumer: handle closed subscriptions gracefully

### DIFF
--- a/jetstream/ordered.go
+++ b/jetstream/ordered.go
@@ -539,6 +539,9 @@ func (c *orderedConsumer) reset() error {
 	if err != nil {
 		return err
 	}
+	if cons == nil {
+		return nats.ErrSubscriptionClosed
+	}
 	c.currentConsumer = cons.(*pullConsumer)
 	return nil
 }


### PR DESCRIPTION
In `orderedConsumer.reset()`, `retryWithBackoff()` is returned from with `false, nil` in case the subscription is closed. In this case, `var cons Consumer` is still `nil`, and the code crashes in the attempt to cast it to a `pullConsumer` later on.

Fix this by catching the `nil` case explicitly.

Signed-off-by: Daniel Mack <daniel.mack@holoplot.com>