### PR TITLE
[IMPROVEMENT] added client retry for jetstream async publish old API

### DIFF
--- a/js.go
+++ b/js.go
@@ -870,7 +870,7 @@ func (js *js) handleAsyncReply(m *Msg) {
 		delete(js.pafs, id)
 		closeStc()
 		closeDch()
-		doErr(ErrNoStreamResponse)
+		doErr(ErrNoResponders)
 		return
 	}
 
@@ -984,7 +984,6 @@ func (js *js) PublishMsgAsync(m *Msg, opts ...PubOpt) (PubAckFuture, error) {
 	// register new paf if not retrying
 	if paf == nil {
 		m.Reply = js.newAsyncReply()
-		defer func() { m.Reply = _EMPTY_ }()
 
 		if m.Reply == _EMPTY_ {
 			return nil, errors.New("nats: error creating async reply handler")

--- a/js.go
+++ b/js.go
@@ -953,6 +953,10 @@ func (js *js) PublishMsgAsync(m *Msg, opts ...PubOpt) (PubAckFuture, error) {
 		}
 	}
 
+	if o.rnum < 0 {
+		return nil, fmt.Errorf("%w: retry attempts cannot be negative", ErrInvalidArg)
+	}
+
 	// Timeouts and contexts do not make sense for these.
 	if o.ttl != 0 || o.ctx != nil {
 		return nil, ErrContextAndTimeout

--- a/object.go
+++ b/object.go
@@ -398,7 +398,7 @@ func (obs *obs) Put(meta *ObjectMeta, r io.Reader, opts ...ObjectOpt) (*ObjectIn
 		return nil
 	}
 
-	h := sha256.New()
+	m, h := NewMsg(chunkSubj), sha256.New()
 	chunk, sent, total := make([]byte, meta.Opts.ChunkSize), 0, uint64(0)
 
 	// set up the info object. The chunk upload sets the size and digest
@@ -438,7 +438,6 @@ func (obs *obs) Put(meta *ObjectMeta, r io.Reader, opts ...ObjectOpt) (*ObjectIn
 		// Add chunk only if we received data
 		if n > 0 {
 			// Chunk processing.
-			m := NewMsg(chunkSubj)
 			m.Data = chunk[:n]
 			h.Write(m.Data)
 

--- a/object.go
+++ b/object.go
@@ -398,7 +398,7 @@ func (obs *obs) Put(meta *ObjectMeta, r io.Reader, opts ...ObjectOpt) (*ObjectIn
 		return nil
 	}
 
-	m, h := NewMsg(chunkSubj), sha256.New()
+	h := sha256.New()
 	chunk, sent, total := make([]byte, meta.Opts.ChunkSize), 0, uint64(0)
 
 	// set up the info object. The chunk upload sets the size and digest
@@ -438,6 +438,7 @@ func (obs *obs) Put(meta *ObjectMeta, r io.Reader, opts ...ObjectOpt) (*ObjectIn
 		// Add chunk only if we received data
 		if n > 0 {
 			// Chunk processing.
+			m := NewMsg(chunkSubj)
 			m.Data = chunk[:n]
 			h.Write(m.Data)
 

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -7964,7 +7964,7 @@ func TestJetStreamPublishAsync(t *testing.T) {
 	}
 
 	for i := 0; i < 100; i++ {
-		if _, err = js.PublishAsync("bar", []byte("Hello JS ASYNC PUB")); err != nil {
+		if _, err = js.PublishAsync("bar", []byte("Hello JS ASYNC PUB"), nats.RetryWait(5*time.Millisecond)); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		if np := js.PublishAsyncPending(); np > 10 {
@@ -7979,7 +7979,7 @@ func TestJetStreamPublishAsync(t *testing.T) {
 	}
 
 	for i := 0; i < 500; i++ {
-		if _, err = js.PublishAsync("bar", []byte("Hello JS ASYNC PUB")); err != nil {
+		if _, err = js.PublishAsync("bar", []byte("Hello JS ASYNC PUB"), nats.RetryWait(5*time.Millisecond)); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 	}
@@ -8047,7 +8047,7 @@ func TestPublishAsyncResetPendingOnReconnect(t *testing.T) {
 	acks := make(chan nats.PubAckFuture, 100)
 	go func() {
 		for i := 0; i < 100; i++ {
-			if ack, err := js.PublishAsync("FOO", []byte("hello")); err != nil {
+			if ack, err := js.PublishAsync("FOO", []byte("hello"), nats.RetryAttempts(0)); err != nil {
 				errs <- err
 				return
 			} else {


### PR DESCRIPTION
This PR contains following:
1. Added retry logic for jestream async publish using old API
2. retries are controlled by retry wait and retry attempts publish options
3. no responder error is retried
4. pub ack future object is re-used in retries

This PR fixes following issues:

- https://github.com/nats-io/nats.go/issues/1678