### PR TITLE
Release v1.37.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ When using or transitioning to Go modules support:
 ```bash
 # Go client latest or explicit version
 go get github.com/nats-io/nats.go/@latest
-go get github.com/nats-io/nats.go/@v1.36.0
+go get github.com/nats-io/nats.go/@v1.37.0
 
 # For latest NATS Server, add /v2 at the end
 go get github.com/nats-io/nats-server/v2

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.36.0"
+	Version                   = "1.37.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
### Added
- JetStream:
  - `CleanupPublisher` method for removing internal JetStream subscription (#1690)
  - `ConsumeContext.Closed()` method for waiting for consume to be closed/drained (#1691)

### Fixed
- JetStream:
  - Fix deadlock when accessing subscriptions map on a consumer (#1671)
  - Fix panic in `OrderedConsumer` (#1686)
  - Fix setting deliver policy in `Fetch()` for `OrderedConsumer` (#1693)
- Legacy JetStream:
  - Change `Fetch` and `FetchBatch` client timeout to a higher value (#1689)

### Improved
- Trim trailing slash if set on server address which can cause errors during lookup (#1654)
- Fixed README.md formatting (#1692)
 
### Deprecated
- Deprecate encoded connections (#1674)

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>