### PR TITLE
[FIXED] Publish async not closing done and stall channels after failed retries

### DIFF
--- a/jetstream/test/publish_test.go
+++ b/jetstream/test/publish_test.go
@@ -1453,6 +1453,7 @@ func TestPublishAsyncRetry(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
+			publishComplete := js.PublishAsyncComplete()
 			errs := make(chan error, 1)
 			go func() {
 				// create stream with delay so that publish will receive no responders
@@ -1475,6 +1476,12 @@ func TestPublishAsyncRetry(t *testing.T) {
 				t.Fatalf("Error creating stream: %v", err)
 			case <-time.After(5 * time.Second):
 				t.Fatalf("Timeout waiting for ack")
+			}
+
+			select {
+			case <-publishComplete:
+			case <-time.After(5 * time.Second):
+				t.Fatalf("Did not receive completion signal")
 			}
 		})
 	}


### PR DESCRIPTION
This fixes an issue in new JetStream API where if maximum number of retries
in `PublishMsgAsync` are reached and the publish failed, done and stall channels
are not closed.
Additionally, this fixes a potential race issue with modifying user msg when publishing.

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>