### PR TITLE
BugFix: Make the header if it is empty

### DIFF
--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -205,6 +205,9 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 	p.Unlock()
 
 	internalHandler := func(msg *nats.Msg) {
+		if msg.Header == nil {
+			msg.Header = make(nats.Header)
+		}
 		if sub.hbMonitor != nil {
 			sub.hbMonitor.Stop()
 		}
@@ -781,6 +784,9 @@ func (p *pullConsumer) fetch(req *pullRequest) (MessageBatch, error) {
 			select {
 			case msg := <-msgs:
 				p.Lock()
+				if msg.Header == nil {
+					msg.Header = make(nats.Header)
+				}
 				if hbTimer != nil {
 					hbTimer.Reset(2 * req.Heartbeat)
 				}


### PR DESCRIPTION
## Summary
This pull request fixes a bug in the NATS Go client related to handling message headers in consumers. The issue occurs when setting headers on messages that initially lack them, which causes a panic and crashes the application.

## Problem Description
Consumers can successfully set or add headers to received messages if those messages already have headers. However, if a message arrives without headers and the consumer attempts to set a header, it results in a panic.

## Solution
The fix ensures that consumers safely check for the presence of headers in a message. If none exist, the header map is initialized to prevent panics, thus enhancing application stability.

## Impact
This improvement prevents unexpected crashes, ensuring the NATS Go client handles messages consistently, even those without initial headers.

```markdown
  Scenario 1: Message with Initial Headers  
  +-----------------+                       +--------------------+  
  |  Producer       |    Send Message       |  Consumer          |  
  |  (with headers) |---------------------->|  Reads Headers     |  
  +-----------------+                       |  Set/Add Header    |  
                                            |  (success)         |  
                                            +--------------------+  

  Scenario 2: Message without Initial Headers  
  +-----------------+                       +--------------------+  
  |  Producer       |    Send Message       |  Consumer          |  
  | (no headers)    |---------------------->|  Attempt Set/Add   |  
  +-----------------+                       |  Header (panic!)   |  
                                            +--------------------+
```

Example repository I've created to reproduce this scenario: [https://github.com/canack/nats-header-problem](https://github.com/canack/nats-header-problem)