### PR TITLE
[FIXED] Race in MessageBatch

### DIFF
--- a/jetstream/test/ordered_test.go
+++ b/jetstream/test/ordered_test.go
@@ -580,131 +580,123 @@ func TestOrderedConsumerConsume(t *testing.T) {
 	})
 
 	t.Run("wait for closed after drain", func(t *testing.T) {
-		for i := 0; i < 10; i++ {
-			t.Run(fmt.Sprintf("run %d", i), func(t *testing.T) {
-				srv := RunBasicJetStreamServer()
-				defer shutdownJSServerAndRemoveStorage(t, srv)
-				nc, err := nats.Connect(srv.ClientURL())
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
 
-				js, err := jetstream.New(nc)
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				defer nc.Close()
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				c, err := s.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{})
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				msgs := make([]jetstream.Msg, 0)
-				lock := sync.Mutex{}
-				publishTestMsgs(t, js)
-				cc, err := c.Consume(func(msg jetstream.Msg) {
-					time.Sleep(50 * time.Millisecond)
-					msg.Ack()
-					lock.Lock()
-					msgs = append(msgs, msg)
-					lock.Unlock()
-				})
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				closed := cc.Closed()
-				time.Sleep(100 * time.Millisecond)
-				if err := s.DeleteConsumer(context.Background(), c.CachedInfo().Name); err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				publishTestMsgs(t, js)
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		msgs := make([]jetstream.Msg, 0)
+		lock := sync.Mutex{}
+		publishTestMsgs(t, js)
+		cc, err := c.Consume(func(msg jetstream.Msg) {
+			time.Sleep(50 * time.Millisecond)
+			msg.Ack()
+			lock.Lock()
+			msgs = append(msgs, msg)
+			lock.Unlock()
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		closed := cc.Closed()
+		time.Sleep(100 * time.Millisecond)
+		if err := s.DeleteConsumer(context.Background(), c.CachedInfo().Name); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		publishTestMsgs(t, js)
 
-				// wait for the consumer to be recreated before calling drain
-				for i := 0; i < 5; i++ {
-					_, err = c.Info(ctx)
-					if err != nil {
-						if errors.Is(err, jetstream.ErrConsumerNotFound) {
-							time.Sleep(100 * time.Millisecond)
-							continue
-						}
-						t.Fatalf("Unexpected error: %v", err)
-					}
-					break
+		// wait for the consumer to be recreated before calling drain
+		for i := 0; i < 5; i++ {
+			_, err = c.Info(ctx)
+			if err != nil {
+				if errors.Is(err, jetstream.ErrConsumerNotFound) {
+					time.Sleep(100 * time.Millisecond)
+					continue
 				}
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			break
+		}
 
-				cc.Drain()
+		cc.Drain()
 
-				select {
-				case <-closed:
-				case <-time.After(5 * time.Second):
-					t.Fatalf("Timeout waiting for consume to be closed")
-				}
+		select {
+		case <-closed:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Timeout waiting for consume to be closed")
+		}
 
-				if len(msgs) != 2*len(testMsgs) {
-					t.Fatalf("Unexpected received message count after consume closed; want %d; got %d", 2*len(testMsgs), len(msgs))
-				}
-			})
+		if len(msgs) != 2*len(testMsgs) {
+			t.Fatalf("Unexpected received message count after consume closed; want %d; got %d", 2*len(testMsgs), len(msgs))
 		}
 	})
 
 	t.Run("wait for closed on already closed consume", func(t *testing.T) {
-		for i := 0; i < 10; i++ {
-			t.Run(fmt.Sprintf("run %d", i), func(t *testing.T) {
-				srv := RunBasicJetStreamServer()
-				defer shutdownJSServerAndRemoveStorage(t, srv)
-				nc, err := nats.Connect(srv.ClientURL())
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
 
-				js, err := jetstream.New(nc)
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				defer nc.Close()
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				c, err := s.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{})
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				msgs := make([]jetstream.Msg, 0)
-				lock := sync.Mutex{}
-				publishTestMsgs(t, js)
-				cc, err := c.Consume(func(msg jetstream.Msg) {
-					time.Sleep(50 * time.Millisecond)
-					msg.Ack()
-					lock.Lock()
-					msgs = append(msgs, msg)
-					lock.Unlock()
-				})
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				time.Sleep(100 * time.Millisecond)
-				if err := s.DeleteConsumer(context.Background(), c.CachedInfo().Name); err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		msgs := make([]jetstream.Msg, 0)
+		lock := sync.Mutex{}
+		publishTestMsgs(t, js)
+		cc, err := c.Consume(func(msg jetstream.Msg) {
+			time.Sleep(50 * time.Millisecond)
+			msg.Ack()
+			lock.Lock()
+			msgs = append(msgs, msg)
+			lock.Unlock()
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		time.Sleep(100 * time.Millisecond)
+		if err := s.DeleteConsumer(context.Background(), c.CachedInfo().Name); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
 
-				cc.Stop()
+		cc.Stop()
 
-				time.Sleep(100 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 
-				select {
-				case <-cc.Closed():
-				case <-time.After(5 * time.Second):
-					t.Fatalf("Timeout waiting for consume to be closed")
-				}
-			})
+		select {
+		case <-cc.Closed():
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Timeout waiting for consume to be closed")
 		}
 	})
 }


### PR DESCRIPTION
This fixes a race in both new and legacy JetStream API, where for Fetch APIs returning `MessageBatch` there was a race condition when accessing the error.

Fixes #1733

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>