### PR TITLE
Release v1.38.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 go get github.com/nats-io/nats.go@latest
 
 # To get a specific version:
-go get github.com/nats-io/nats.go@v1.37.0
+go get github.com/nats-io/nats.go@v1.38.0
 
 # Note that the latest major version for NATS Server is v2:
 go get github.com/nats-io/nats-server/v2@latest

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.37.0"
+	Version                   = "1.38.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
### Added
- Core NATS:
  - Added `UserInfoHandler` for dynamically setting user/password (#1713)
  - Added `PermissionErrOnSubscribe` option, causing `SubscribeSync` to return `nats.ErrPermissionViolation` on `NextMsg()` if there was a permission error ((#1728)
  - Added `Msgs()` method on `Subscription`, returning an iterator (`iter.Seq2[*nats.Msg, error]`) for the subscription. This method is only available for go version >=1.23 (#1728)
-  KeyValue:
  - Added `WatchFiltered` method to watch for updates with multiple filters (#1739)

### Fixed
- Core NATS:
  - Fixed closing connections on max subscriptions exceeded (#1709)
  - Removed redundant nil checks (#1751)
  - Add missing nats prefix to error (#1753)
- JetStream:
  - Fixed `PublishAsync` not closing done and stall channels after failed retries (#1719)
  - Set valid fetch sequence in ordered consumer's `Fetch()` and `Next()` after timeout (#1705)
  - Do not overwrite ordered consumer deliver policy if start time is set (#1742)
  - Fixed race condition in `MessageBatch` (#1743)
 - Legacy JetStream:
   - Fixed race condition in `MessageBatch` (#1743)

### Changed
- Legacy Jetstream:
  - Added client retry for jetstream async publish old API (#1695)

### Improved
- Moved CI to github actions (#1623, #1716)
- Use errors.New instead of fmt.Errorf to improve efficiency (#1707)
- Fixed invalid schemas in Service API documentation (#1720)
- Added mention of TTL reset in `kv.Update` method (#1727)
- Updated installation commands in `README.md` (#1745)
- Bump `nkeys` to v0.4.9 (#1750)