### PR TITLE
Add exception to `compress` license

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -4,8 +4,10 @@ on:
   push:
     paths:
       - 'go.mod'
+      - 'dependencies.tpl'
     branches:
       - main
+      - add-license-exception
 
 jobs:
   license-check:

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -4,10 +4,8 @@ on:
   push:
     paths:
       - 'go.mod'
-      - 'dependencies.tpl'
     branches:
       - main
-      - add-license-exception
 
 jobs:
   license-check:

--- a/dependencies.tpl
+++ b/dependencies.tpl
@@ -5,5 +5,5 @@ This file lists the dependencies used in this repository.
 {{/* compress has actually a BSD 3-Clause license, but the License file in the repo confuses go-license tooling, hence the manual exception */}}
 | Dependency                                       | License                                 |
 |--------------------------------------------------|-----------------------------------------|
-{{ range . }}| {{ .Name }} | {{ if eq .Name "github.com/klauspost/compress" }}BSD 3-Clause{{ else }}{{ .LicenseName }}{{ end }} |
+{{ range . }}| {{ .Name }} | {{ if eq .Name "github.com/klauspost/compress/flate" }}BSD 3-Clause{{ else }}{{ .LicenseName }}{{ end }} |
 {{ end }}

--- a/dependencies.tpl
+++ b/dependencies.tpl
@@ -2,7 +2,8 @@
 
 This file lists the dependencies used in this repository.
 
+{{/* compress has actually a BSD 3-Clause license, but the License file in the repo confuses go-license tooling, hence the manual exception */}}
 | Dependency                                       | License                                 |
 |--------------------------------------------------|-----------------------------------------|
-{{ range . }}| {{.Name}}                           | {{.LicenseName}}                        |
+{{ range . }}| {{ .Name }} | {{ if eq .Name "github.com/klauspost/compress" }}BSD 3-Clause{{ else }}{{ .LicenseName }}{{ end }} |
 {{ end }}


### PR DESCRIPTION
The `compress` license for the code we use is actually BSD-3, however it's License.md file is confusing the `go-license` tooling.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>