### PR TITLE
[ADDED] PushConsumer implementation in jetstream package

### DIFF
--- a/jetstream/README.md
+++ b/jetstream/README.md
@@ -6,33 +6,30 @@ This doc covers the basic usage of the `jetstream` package in `nats.go` client.
 - [Overview](#overview)
 - [Basic usage](#basic-usage)
 - [Streams](#streams)
-- [Stream management (CRUD)](#stream-management-crud)
-- [Listing streams and stream names](#listing-streams-and-stream-names)
-- [Stream-specific operations](#stream-specific-operations)
+  - [Stream management (CRUD)](#stream-management-crud)
+  - [Listing streams and stream names](#listing-streams-and-stream-names)
+  - [Stream-specific operations](#stream-specific-operations)
 - [Consumers](#consumers)
-- [Consumers management](#consumers-management)
-- [Listing consumers and consumer
-    names](#listing-consumers-and-consumer-names)
-- [Ordered consumers](#ordered-consumers)
-- [Receiving messages from the
-    consumer](#receiving-messages-from-the-consumer)
-  - [Single fetch](#single-fetch)
-  - [Continuous polling](#continuous-polling)
-  - [Using `Consume()` receive messages in a
-        callback](#using-consume-receive-messages-in-a-callback)
-  - [Using `Messages()` to iterate over incoming
-        messages](#using-messages-to-iterate-over-incoming-messages)
+  - [Consumers management](#consumers-management)
+  - [Listing consumers and consumer names](#listing-consumers-and-consumer-names)
+  - [Ordered consumers](#ordered-consumers)
+  - [Receiving messages from pull consumers](#receiving-messages-from-pull-consumers)
+    - [Single fetch](#single-fetch)
+    - [Continuous polling](#continuous-polling)
+      - [Using `Consume()` receive messages in a callback](#using-consume-receive-messages-in-a-callback)
+      - [Using `Messages()` to iterate over incoming messages](#using-messages-to-iterate-over-incoming-messages)
+    - [Receiving messages from push consumers](#receiving-messages-from-push-consumers)
 - [Publishing on stream](#publishing-on-stream)
-- [Synchronous publish](#synchronous-publish)
-- [Async publish](#async-publish)
+  - [Synchronous publish](#synchronous-publish)
+  - [Async publish](#async-publish)
 - [KeyValue Store](#keyvalue-store)
-- [Basic usage of KV bucket](#basic-usage-of-kv-bucket)
-- [Watching for changes on a bucket](#watching-for-changes-on-a-bucket)
-- [Additional operations on a bucket](#additional-operations-on-a-bucket)
+  - [Basic usage of KV bucket](#basic-usage-of-kv-bucket)
+  - [Watching for changes on a bucket](#watching-for-changes-on-a-bucket)
+  - [Additional operations on a bucket](#additional-operations-on-a-bucket)
 - [Object Store](#object-store)
-- [Basic usage of Object Store](#basic-usage-of-object-store)
-- [Watching for changes on a store](#watching-for-changes-on-a-store)
-- [Additional operations on a store](#additional-operations-on-a-store)
+  - [Basic usage of Object Store](#basic-usage-of-object-store)
+  - [Watching for changes on a store](#watching-for-changes-on-a-store)
+  - [Additional operations on a store](#additional-operations-on-a-store)
 - [Examples](#examples)
 
 ## Overview
@@ -254,14 +251,34 @@ fmt.Println(cachedInfo.Config.Name)
 
 ## Consumers
 
-Only pull consumers are supported in `jetstream` package. However, unlike the
-JetStream API in `nats` package, pull consumers allow for continuous message
-retrieval (similarly to how `nats.Subscribe()` works). Because of that, push
-consumers can be easily replaced by pull consumers for most of the use cases.
+Both pull and push consumers are supported in `jetstream` package. For most use
+cases, we recommend using pull consumers as they allow for more fine-grained
+control over the message processing and can often prevent issues such as e.g.
+slow consumers. However, unlike the JetStream API in `nats` package, pull
+consumers allow for continuous message retrieval (similarly to how
+`nats.Subscribe()` works). Because of that, push consumers can be easily
+replaced by pull consumers for most of the use cases. Push consumers are
+supported mainly for the purpose of ease of migration from `nats` package. The
+interfaces for consuming messages via push and pull consumers are similar, with
+the main difference being that push consumers do not support fetching individual
+batches of messages.
 
 ### Consumers management
 
-CRUD operations on consumers can be achieved on 2 levels:
+Both pull and push consumers can be managed using `jetstream` package. The
+following example demonstrates how to create, update, fetch and delete a pull
+consumer. Push consumers can be managed in a similar way, with method names
+containing `Push` (e.g. `CreatePushConsumer`, `UpdatePushConsumer`,
+`DeletePushConsumer`).
+
+> __NOTE__: It is important to use `CreateConsumer` and `CreatePushConsumer`
+methods to create the respective consumer types as they return the correct
+interface (different for push and pull consumers). `DeliverSubject` is mandatory
+when creating a push consumer and cannot be provided when creating a pull
+consumer. Similarly, an attempt to get a push consumer using `Consumer` method
+will result in an error (and vice versa).
+
+CRUD operations on pull consumers can be achieved on 2 levels:
 
 - on `JetStream` interface
 
@@ -370,6 +387,8 @@ message ordering. It is also resilient to consumer deletion.
 Ordered consumers present the same set of message consumption methods as
 standard pull consumers.
 
+> __NOTE__: Ordered consumers are not supported for push consumers.
+
 ```go
 js, _ := jetstream.New(nc)
 
@@ -380,7 +399,7 @@ cons, _ := js.OrderedConsumer(ctx, "ORDERS", jetstream.OrderedConsumerConfig{
 })
 ```
 
-### Receiving messages from the consumer
+### Receiving messages from pull consumers
 
 The `Consumer` interface covers allows fetching messages on demand, with
 pre-defined batch size on bytes limit, or continuous push-like receiving of
@@ -469,10 +488,12 @@ cons, _ := js.CreateOrUpdateConsumer("ORDERS", jetstream.ConsumerConfig{
     AckPolicy: jetstream.AckExplicitPolicy,
     // receive messages from ORDERS.A subject only
     FilterSubject: "ORDERS.A"
-}))
+})
 
 consContext, _ := c.Consume(func(msg jetstream.Msg) {
     fmt.Printf("Received a JetStream message: %s\n", string(msg.Data()))
+    // messages are not acknowledged automatically
+    msg.Ack()
 })
 defer consContext.Stop()
 ```
@@ -497,7 +518,7 @@ type PullThresholdMessages int
   buffer
 - `PullHeartbeat(time.Duration)` - idle heartbeat duration for a single pull
 request. An error will be triggered if at least 2 heartbeats are missed
-- `WithConsumeErrHandler(func (ConsumeContext, error))` - when used, sets a
+- `ConsumeErrHandler(func (ConsumeContext, error))` - when used, sets a
   custom error handler on `Consume()`, allowing e.g. tracking missing
   heartbeats.
 - `PullMaxMessagesWithBytesLimit` - up to the provided number of messages will
@@ -590,6 +611,40 @@ for {
     }()
 }
 ```
+
+#### Receiving messages from push consumers
+
+The `PushConsumer` interface currently only allows message processing in a
+callback using `Consume()`.
+
+As heartbeat for push consumers is not managed when using `Consume()`, it is
+important to set `IdleHeartbeat` on the consumer level. Similarly, `FlowControl`
+can be set to prevent the consumer from receiving more messages than it can
+handle.
+
+```go
+cons, _ := js.CreateOrUpdatePushConsumer("ORDERS", jetstream.ConsumerConfig{
+    DeliverSubject: nats.NewInbox()
+    AckPolicy: jetstream.AckExplicitPolicy,
+    // receive messages from ORDERS.A subject only
+    FilterSubject: "ORDERS.A",
+    // unlike pull consumers, idle heartbeat is configured on the consumer level
+    IdleHeartbeat: 30 * time.Second
+})
+
+consContext, _ := c.Consume(func(msg jetstream.Msg) {
+    fmt.Printf("Received a JetStream message: %s\n", string(msg.Data()))
+    // messages are not acknowledged automatically
+    msg.Ack()
+})
+defer consContext.Stop()
+```
+
+`Consume()` on `PushConsumer` can be supplied with `ConsumeErrHandler` option
+to set a custom error handler allowing e.g. tracking missing heartbeats.
+
+> __NOTE__: `Stop()` should always be called on `ConsumeContext` to avoid
+> leaking goroutines.
 
 ## Publishing on stream
 

--- a/jetstream/consumer.go
+++ b/jetstream/consumer.go
@@ -147,6 +147,21 @@ type (
 		CachedInfo() *ConsumerInfo
 	}
 
+	PushConsumer interface {
+		// Consume will continuously receive messages and handle them
+		// with the provided callback function. Consume can be configured using
+		// PushConsumeOpt options:
+		//
+		// - Error handling and monitoring can be configured using ConsumeErrHandler.
+		Consume(handler MessageHandler, opts ...PushConsumeOpt) (ConsumeContext, error)
+
+		// Info fetches current ConsumerInfo from the server.
+		Info(context.Context) (*ConsumerInfo, error)
+
+		// CachedInfo returns ConsumerInfo currently cached on this consumer.
+		CachedInfo() *ConsumerInfo
+	}
+
 	createConsumerRequest struct {
 		Stream string          `json:"stream_name"`
 		Config *ConsumerConfig `json:"config"`
@@ -187,8 +202,75 @@ func (p *pullConsumer) CachedInfo() *ConsumerInfo {
 	return p.info
 }
 
-func upsertConsumer(ctx context.Context, js *jetStream, stream string, cfg ConsumerConfig, action string) (Consumer, error) {
+// Info fetches current ConsumerInfo from the server.
+func (p *pushConsumer) Info(ctx context.Context) (*ConsumerInfo, error) {
 	ctx, cancel := js.wrapContextWithoutDeadline(ctx)
+	if cancel != nil {
+		defer cancel()
+	}
+	infoSubject := apiSubj(p.jetStream.apiPrefix, fmt.Sprintf(apiConsumerInfoT, p.stream, p.name))
+	var resp consumerInfoResponse
+
+	if _, err := p.jetStream.apiRequestJSON(ctx, infoSubject, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Error != nil {
+		if resp.Error.ErrorCode == JSErrCodeConsumerNotFound {
+			return nil, ErrConsumerNotFound
+		}
+		return nil, resp.Error
+	}
+	if resp.Error == nil && resp.ConsumerInfo == nil {
+		return nil, ErrConsumerNotFound
+	}
+
+	p.info = resp.ConsumerInfo
+	return resp.ConsumerInfo, nil
+}
+
+// CachedInfo returns ConsumerInfo currently cached on this consumer.
+// This method does not perform any network requests. The cached
+// ConsumerInfo is updated on every call to Info and Update.
+func (p *pushConsumer) CachedInfo() *ConsumerInfo {
+	return p.info
+}
+
+func upsertPullConsumer(ctx context.Context, js *jetStream, stream string, cfg ConsumerConfig, action string) (Consumer, error) {
+	resp, err := upsertConsumer(ctx, js, stream, cfg, action)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pullConsumer{
+		jetStream: js,
+		stream:    stream,
+		name:      resp.Name,
+		durable:   cfg.Durable != "",
+		info:      resp.ConsumerInfo,
+		subs:      syncx.Map[string, *pullSubscription]{},
+	}, nil
+}
+
+func upsertPushConsumer(ctx context.Context, js *jetStream, stream string, cfg ConsumerConfig, action string) (PushConsumer, error) {
+	if cfg.DeliverSubject == "" {
+		return nil, ErrNotPushConsumer
+	}
+
+	resp, err := upsertConsumer(ctx, js, stream, cfg, action)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pushConsumer{
+		jetStream: js,
+		stream:    stream,
+		name:      resp.Name,
+		info:      resp.ConsumerInfo,
+	}, nil
+}
+
+func upsertConsumer(ctx context.Context, js *jetStream, stream string, cfg ConsumerConfig, action string) (*consumerInfoResponse, error) {
+	ctx, cancel := wrapContextWithoutDeadline(ctx)
 	if cancel != nil {
 		defer cancel()
 	}
@@ -240,14 +322,7 @@ func upsertConsumer(ctx context.Context, js *jetStream, stream string, cfg Consu
 		return nil, ErrConsumerMultipleFilterSubjectsNotSupported
 	}
 
-	return &pullConsumer{
-		js:      js,
-		stream:  stream,
-		name:    resp.Name,
-		durable: cfg.Durable != "",
-		info:    resp.ConsumerInfo,
-		subs:    syncx.Map[string, *pullSubscription]{},
-	}, nil
+	return &resp, nil
 }
 
 const (
@@ -268,7 +343,49 @@ func generateConsName() string {
 }
 
 func getConsumer(ctx context.Context, js *jetStream, stream, name string) (Consumer, error) {
-	ctx, cancel := js.wrapContextWithoutDeadline(ctx)
+	info, err := fetchConsumerInfo(ctx, js, stream, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if info.Config.DeliverSubject != "" {
+		return nil, ErrNotPullConsumer
+	}
+
+	cons := &pullConsumer{
+		jetStream: js,
+		stream:    stream,
+		name:      name,
+		durable:   info.Config.Durable != "",
+		info:      info,
+		subs:      syncx.Map[string, *pullSubscription]{},
+	}
+
+	return cons, nil
+}
+
+func getPushConsumer(ctx context.Context, js *jetStream, stream, name string) (PushConsumer, error) {
+	info, err := fetchConsumerInfo(ctx, js, stream, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if info.Config.DeliverSubject == "" {
+		return nil, ErrNotPushConsumer
+	}
+
+	cons := &pushConsumer{
+		jetStream: js,
+		stream:    stream,
+		name:      name,
+		info:      info,
+	}
+
+	return cons, nil
+}
+
+func fetchConsumerInfo(ctx context.Context, js *jetStream, stream, name string) (*ConsumerInfo, error) {
+	ctx, cancel := ctx, cancel := js.wrapContextWithoutDeadline(ctx)
 	if cancel != nil {
 		defer cancel()
 	}
@@ -292,16 +409,7 @@ func getConsumer(ctx context.Context, js *jetStream, stream, name string) (Consu
 		return nil, ErrConsumerNotFound
 	}
 
-	cons := &pullConsumer{
-		js:      js,
-		stream:  stream,
-		name:    name,
-		durable: resp.Config.Durable != "",
-		info:    resp.ConsumerInfo,
-		subs:    syncx.Map[string, *pullSubscription]{},
-	}
-
-	return cons, nil
+	return resp.ConsumerInfo, nil
 }
 
 func deleteConsumer(ctx context.Context, js *jetStream, stream, consumer string) error {

--- a/jetstream/consumer_config.go
+++ b/jetstream/consumer_config.go
@@ -98,7 +98,8 @@ type (
 		PinnedTS time.Time `json:"pinned_ts,omitempty"`
 	}
 
-	// ConsumerConfig is the configuration of a JetStream consumer.
+	// ConsumerConfig represents the configuration of a JetStream consumer,
+	// encompassing both push and pull consumer settings
 	ConsumerConfig struct {
 		// Name is an optional name for the consumer. If not set, one is
 		// generated automatically.
@@ -253,6 +254,26 @@ type (
 
 		// PriorityGroups is a list of priority groups this consumer supports.
 		PriorityGroups []string `json:"priority_groups,omitempty"`
+
+		// Fields specific for push consumers:
+
+		// DeliverSubject is the subject to deliver messages to for push consumers
+		DeliverSubject string `json:"deliver_subject,omitempty"`
+
+		// DeliverGroup is the group name for push consumers
+		DeliverGroup string `json:"deliver_group,omitempty"`
+
+		// FlowControl is a flag to enable flow control for the consumer.
+		// When set, server will regularly send an empty message with Status
+		// header 100 and a reply subject, consumers must reply to these
+		// messages to control the rate of message delivery
+		FlowControl bool `json:"flow_control,omitempty"`
+
+		// IdleHeartbeat enables push consumer idle heartbeat messages.
+		// If the Consumer is idle for more than the set value, an empty message
+		// with Status header 100 will be sent indicating the consumer is still
+		// alive.
+		IdleHeartbeat time.Duration `json:"idle_heartbeat,omitempty"`
 	}
 
 	// OrderedConsumerConfig is the configuration of an ordered JetStream

--- a/jetstream/errors.go
+++ b/jetstream/errors.go
@@ -161,6 +161,18 @@ var (
 	// does not exist.
 	ErrConsumerNameAlreadyInUse JetStreamError = &jsError{message: "consumer name already in use"}
 
+	// ErrNotPullConsumer is returned when attempting to fetch or create pull
+	// consumer and the returned consumer is a push consumer.
+	ErrNotPullConsumer JetStreamError = &jsError{message: "consumer is not a pull consumer"}
+
+	// ErrNotPushConsumer is returned when attempting to fetch or create push
+	// consumer and the returned consumer is a pull consumer.
+	ErrNotPushConsumer JetStreamError = &jsError{message: "consumer is not a push consumer"}
+
+	// ErrConsumerAlreadyConsuming is returned when attempting to consume from
+	// the same push consumer more than once.
+	ErrConsumerAlreadyConsuming JetStreamError = &jsError{message: "consumer is already consuming"}
+
 	// ErrInvalidJSAck is returned when JetStream ack from message publish is
 	// invalid.
 	ErrInvalidJSAck JetStreamError = &jsError{message: "invalid jetstream publish response"}

--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -206,6 +206,7 @@ type (
 		// If consumer does not exist, ErrConsumerNotFound is returned.
 		DeleteConsumer(ctx context.Context, stream string, consumer string) error
 
+		// CreateOrUpdatePushConsumer creates a push consumer on a given stream with
 		// PauseConsumer pauses a consumer until the given time.
 		PauseConsumer(ctx context.Context, stream string, consumer string, pauseUntil time.Time) (*ConsumerPauseResponse, error)
 
@@ -218,7 +219,7 @@ type (
 		// consumer (e.g. fetch messages).
 		CreateOrUpdatePushConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (PushConsumer, error)
 
-		// CreateConsumer creates a push consumer on a given stream with given
+		// CreatePushConsumer creates a push consumer on a given stream with given
 		// config. If consumer already exists and the provided configuration
 		// differs from its configuration, ErrConsumerExists is returned. If the
 		// provided configuration is the same as the existing consumer, the
@@ -226,7 +227,7 @@ type (
 		// allowing to consume messages.
 		CreatePushConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (PushConsumer, error)
 
-		// UpdateConsumer updates an existing push consumer. If consumer does not
+		// UpdatePushConsumer updates an existing push consumer. If consumer does not
 		// exist, ErrConsumerDoesNotExist is returned. Consumer interface is
 		// returned, allowing to consume messages.
 		UpdatePushConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (PushConsumer, error)
@@ -883,7 +884,7 @@ func (js *jetStream) DeleteConsumer(ctx context.Context, stream string, name str
 	return deleteConsumer(ctx, js, stream, name)
 }
 
-// CreateOrUpdateConsumer creates a push consumer on a given stream with
+// CreateOrUpdatePushConsumer creates a push consumer on a given stream with
 // given config. If consumer already exists, it will be updated (if
 // possible). Consumer interface is returned, allowing to consume messages.
 func (js *jetStream) CreateOrUpdatePushConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (PushConsumer, error) {
@@ -906,7 +907,7 @@ func (js *jetStream) CreatePushConsumer(ctx context.Context, stream string, cfg 
 	return upsertPushConsumer(ctx, js, stream, cfg, consumerActionCreate)
 }
 
-// UpdateConsumer updates an existing push consumer. If consumer does not
+// UpdatePushConsumer updates an existing push consumer. If consumer does not
 // exist, ErrConsumerDoesNotExist is returned. Consumer interface is
 // returned, allowing to consume messages.
 func (js *jetStream) UpdatePushConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (PushConsumer, error) {
@@ -916,7 +917,7 @@ func (js *jetStream) UpdatePushConsumer(ctx context.Context, stream string, cfg 
 	return upsertPushConsumer(ctx, js, stream, cfg, consumerActionUpdate)
 }
 
-// Consumer returns an interface to an existing consumer, allowing processing
+// PushConsumer returns an interface to an existing consumer, allowing processing
 // of messages. If consumer does not exist, ErrConsumerNotFound is
 // returned.
 func (js *jetStream) PushConsumer(ctx context.Context, stream string, name string) (PushConsumer, error) {

--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -211,6 +211,32 @@ type (
 
 		// ResumeConsumer resumes a paused consumer.
 		ResumeConsumer(ctx context.Context, stream string, consumer string) (*ConsumerPauseResponse, error)
+
+		// CreateOrUpdateConsumer creates a push consumer on a given stream with
+		// given config. If consumer already exists, it will be updated (if
+		// possible). Consumer interface is returned, allowing to operate on a
+		// consumer (e.g. fetch messages).
+		CreateOrUpdatePushConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (PushConsumer, error)
+
+		// CreateConsumer creates a push consumer on a given stream with given
+		// config. If consumer already exists and the provided configuration
+		// differs from its configuration, ErrConsumerExists is returned. If the
+		// provided configuration is the same as the existing consumer, the
+		// existing consumer is returned. Consumer interface is returned,
+		// allowing to consume messages.
+		CreatePushConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (PushConsumer, error)
+
+		// UpdateConsumer updates an existing push consumer. If consumer does not
+		// exist, ErrConsumerDoesNotExist is returned. Consumer interface is
+		// returned, allowing to consume messages.
+		UpdatePushConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (PushConsumer, error)
+
+		// PushConsumer returns an interface to an existing push consumer, allowing processing
+		// of messages. If consumer does not exist, ErrConsumerNotFound is
+		// returned.
+		//
+		// It returns ErrNotPushConsumer if the consumer is not a push consumer (deliver subject is not set).
+		PushConsumer(ctx context.Context, stream string, consumer string) (PushConsumer, error)
 	}
 
 	// StreamListOpt is a functional option for [StreamManager.ListStreams] and
@@ -787,7 +813,7 @@ func (js *jetStream) CreateOrUpdateConsumer(ctx context.Context, stream string, 
 	if err := validateStreamName(stream); err != nil {
 		return nil, err
 	}
-	return upsertConsumer(ctx, js, stream, cfg, consumerActionCreateOrUpdate)
+	return upsertPullConsumer(ctx, js, stream, cfg, consumerActionCreateOrUpdate)
 }
 
 // CreateConsumer creates a consumer on a given stream with given
@@ -800,7 +826,7 @@ func (js *jetStream) CreateConsumer(ctx context.Context, stream string, cfg Cons
 	if err := validateStreamName(stream); err != nil {
 		return nil, err
 	}
-	return upsertConsumer(ctx, js, stream, cfg, consumerActionCreate)
+	return upsertPullConsumer(ctx, js, stream, cfg, consumerActionCreate)
 }
 
 // UpdateConsumer updates an existing consumer. If consumer does not
@@ -810,7 +836,7 @@ func (js *jetStream) UpdateConsumer(ctx context.Context, stream string, cfg Cons
 	if err := validateStreamName(stream); err != nil {
 		return nil, err
 	}
-	return upsertConsumer(ctx, js, stream, cfg, consumerActionUpdate)
+	return upsertPullConsumer(ctx, js, stream, cfg, consumerActionUpdate)
 }
 
 // OrderedConsumer returns an OrderedConsumer instance. OrderedConsumer
@@ -855,6 +881,49 @@ func (js *jetStream) DeleteConsumer(ctx context.Context, stream string, name str
 		return err
 	}
 	return deleteConsumer(ctx, js, stream, name)
+}
+
+// CreateOrUpdateConsumer creates a push consumer on a given stream with
+// given config. If consumer already exists, it will be updated (if
+// possible). Consumer interface is returned, allowing to consume messages.
+func (js *jetStream) CreateOrUpdatePushConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (PushConsumer, error) {
+	if err := validateStreamName(stream); err != nil {
+		return nil, err
+	}
+	return upsertPushConsumer(ctx, js, stream, cfg, consumerActionCreateOrUpdate)
+}
+
+// CreatePushConsumer creates a push consumer on a given stream with given
+// config. If consumer already exists and the provided configuration
+// differs from its configuration, ErrConsumerExists is returned. If the
+// provided configuration is the same as the existing consumer, the
+// existing consumer is returned. Consumer interface is returned,
+// allowing to consume messages.
+func (js *jetStream) CreatePushConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (PushConsumer, error) {
+	if err := validateStreamName(stream); err != nil {
+		return nil, err
+	}
+	return upsertPushConsumer(ctx, js, stream, cfg, consumerActionCreate)
+}
+
+// UpdateConsumer updates an existing push consumer. If consumer does not
+// exist, ErrConsumerDoesNotExist is returned. Consumer interface is
+// returned, allowing to consume messages.
+func (js *jetStream) UpdatePushConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (PushConsumer, error) {
+	if err := validateStreamName(stream); err != nil {
+		return nil, err
+	}
+	return upsertPushConsumer(ctx, js, stream, cfg, consumerActionUpdate)
+}
+
+// Consumer returns an interface to an existing consumer, allowing processing
+// of messages. If consumer does not exist, ErrConsumerNotFound is
+// returned.
+func (js *jetStream) PushConsumer(ctx context.Context, stream string, name string) (PushConsumer, error) {
+	if err := validateStreamName(stream); err != nil {
+		return nil, err
+	}
+	return getPushConsumer(ctx, js, stream, name)
 }
 
 func (js *jetStream) PauseConsumer(ctx context.Context, stream string, consumer string, pauseUntil time.Time) (*ConsumerPauseResponse, error) {

--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -215,8 +215,7 @@ type (
 
 		// CreateOrUpdateConsumer creates a push consumer on a given stream with
 		// given config. If consumer already exists, it will be updated (if
-		// possible). Consumer interface is returned, allowing to operate on a
-		// consumer (e.g. fetch messages).
+		// possible). Consumer interface is returned, allowing to consume messages.
 		CreateOrUpdatePushConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (PushConsumer, error)
 
 		// CreatePushConsumer creates a push consumer on a given stream with given

--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -206,14 +206,13 @@ type (
 		// If consumer does not exist, ErrConsumerNotFound is returned.
 		DeleteConsumer(ctx context.Context, stream string, consumer string) error
 
-		// CreateOrUpdatePushConsumer creates a push consumer on a given stream with
 		// PauseConsumer pauses a consumer until the given time.
 		PauseConsumer(ctx context.Context, stream string, consumer string, pauseUntil time.Time) (*ConsumerPauseResponse, error)
 
 		// ResumeConsumer resumes a paused consumer.
 		ResumeConsumer(ctx context.Context, stream string, consumer string) (*ConsumerPauseResponse, error)
 
-		// CreateOrUpdateConsumer creates a push consumer on a given stream with
+		// CreateOrUpdatePushConsumer creates a push consumer on a given stream with
 		// given config. If consumer already exists, it will be updated (if
 		// possible). Consumer interface is returned, allowing to consume messages.
 		CreateOrUpdatePushConsumer(ctx context.Context, stream string, cfg ConsumerConfig) (PushConsumer, error)

--- a/jetstream/jetstream_options.go
+++ b/jetstream/jetstream_options.go
@@ -419,11 +419,16 @@ func (nMsgs StopAfter) configureMessages(opts *consumeOpts) error {
 // encountered while consuming messages It will be invoked for both terminal
 // (Consumer Deleted, invalid request body) and non-terminal (e.g. missing
 // heartbeats) errors.
-func ConsumeErrHandler(cb ConsumeErrHandlerFunc) PullConsumeOpt {
-	return pullOptFunc(func(cfg *consumeOpts) error {
-		cfg.ErrHandler = cb
-		return nil
-	})
+type ConsumeErrHandler ConsumeErrHandlerFunc
+
+func (c ConsumeErrHandler) configureConsume(opts *consumeOpts) error {
+	opts.ErrHandler = c
+	return nil
+}
+
+func (c ConsumeErrHandler) configurePushConsume(opts *pushConsumeOpts) error {
+	opts.ErrHandler = c
+	return nil
 }
 
 // WithMessagesErrOnMissingHeartbeat sets whether a missing heartbeat error

--- a/jetstream/message.go
+++ b/jetstream/message.go
@@ -141,7 +141,7 @@ type (
 )
 
 const (
-    statusControlMsg    = "100"
+	statusControlMsg    = "100"
 	statusBadRequest    = "400"
 	statusNoMsgs        = "404"
 	statusTimeout       = "408"

--- a/jetstream/message.go
+++ b/jetstream/message.go
@@ -141,13 +141,21 @@ type (
 )
 
 const (
-	controlMsg    = "100"
-	badRequest    = "400"
-	noMessages    = "404"
-	reqTimeout    = "408"
-	conflict      = "409"
-	noResponders  = "503"
-	pinIdMismatch = "423"
+    statusControlMsg    = "100"
+	statusBadRequest    = "400"
+	statusNoMsgs        = "404"
+	statusTimeout       = "408"
+	statusConflict      = "409"
+	statusNoResponders  = "503"
+	statusPinIdMismatch = "423"
+
+	fcRequestDescr     = "flowcontrol request"
+	idleHeartbeatDescr = "idle heartbeat"
+	consumerDeleted    = "consumer deleted"
+	leadershipChange   = "leadership change"
+	maxBytesExceeded   = "message size exceeds maxbytes"
+	batchCompleted     = "batch completed"
+	serverShutdown     = "server shutdown"
 )
 
 // Headers used when publishing messages.
@@ -411,33 +419,33 @@ func checkMsg(msg *nats.Msg) (bool, error) {
 	}
 
 	switch val {
-	case badRequest:
+	case statusBadRequest:
 		return false, ErrBadRequest
-	case noResponders:
+	case statusNoResponders:
 		return false, nats.ErrNoResponders
-	case noMessages:
+	case statusNoMsgs:
 		// 404 indicates that there are no messages.
 		return false, ErrNoMessages
-	case reqTimeout:
+	case statusTimeout:
 		return false, nats.ErrTimeout
-	case controlMsg:
+	case statusControlMsg:
 		return false, nil
-	case pinIdMismatch:
+	case statusPinIdMismatch:
 		return false, ErrPinIDMismatch
-	case conflict:
-		if strings.Contains(strings.ToLower(descr), "message size exceeds maxbytes") {
+	case statusConflict:
+		if strings.Contains(strings.ToLower(descr), maxBytesExceeded) {
 			return false, ErrMaxBytesExceeded
 		}
-		if strings.Contains(strings.ToLower(descr), "batch completed") {
+		if strings.Contains(strings.ToLower(descr), batchCompleted) {
 			return false, ErrBatchCompleted
 		}
-		if strings.Contains(strings.ToLower(descr), "consumer deleted") {
+		if strings.Contains(strings.ToLower(descr), consumerDeleted) {
 			return false, ErrConsumerDeleted
 		}
-		if strings.Contains(strings.ToLower(descr), "leadership change") {
+		if strings.Contains(strings.ToLower(descr), leadershipChange) {
 			return false, ErrConsumerLeadershipChanged
 		}
-		if strings.Contains(strings.ToLower(descr), "server shutdown") {
+		if strings.Contains(strings.ToLower(descr), serverShutdown) {
 			return false, ErrServerShutdown
 		}
 	}

--- a/jetstream/ordered.go
+++ b/jetstream/ordered.go
@@ -39,7 +39,7 @@ type (
 		consumerType      consumerType
 		doReset           chan struct{}
 		resetInProgress   atomic.Uint32
-		userErrHandler    ConsumeErrHandlerFunc
+		userErrHandler    ConsumeErrHandler
 		stopAfter         int
 		stopAfterMsgsLeft chan int
 		withStopAfter     bool

--- a/jetstream/publish.go
+++ b/jetstream/publish.go
@@ -478,7 +478,7 @@ func (js *jetStream) handleAsyncReply(m *nats.Msg) {
 	}
 
 	// Process no responders etc.
-	if len(m.Data) == 0 && m.Header.Get(statusHdr) == noResponders {
+	if len(m.Data) == 0 && m.Header.Get(statusHdr) == statusNoResponders {
 		if paf.retries < paf.maxRetries {
 			paf.retries++
 			time.AfterFunc(paf.retryWait, func() {

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -1123,7 +1123,7 @@ func (consumeOpts *consumeOpts) setDefaults(ordered bool) error {
 		}
 	}
 	if consumeOpts.Heartbeat > consumeOpts.Expires/2 {
-		return fmt.Errorf("%w: the value of Heartbeat must be less than 50% of expiry", ErrInvalidOption)
+		return fmt.Errorf("%w: the value of Heartbeat must be less than 50%% of expiry", ErrInvalidOption)
 	}
 	return nil
 }

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -1123,7 +1123,7 @@ func (consumeOpts *consumeOpts) setDefaults(ordered bool) error {
 		}
 	}
 	if consumeOpts.Heartbeat > consumeOpts.Expires/2 {
-		return errors.New("the value of Heartbeat must be less than 50%% of expiry")
+		return fmt.Errorf("%w: the value of Heartbeat must be less than 50%% of expiry", ErrInvalidOption)
 	}
 	return nil
 }

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -112,7 +112,7 @@ type (
 		MinAckPending           int64
 		Group                   string
 		Heartbeat               time.Duration
-		ErrHandler              ConsumeErrHandlerFunc
+		ErrHandler              ConsumeErrHandler
 		ReportMissingHeartbeats bool
 		ThresholdMessages       int
 		ThresholdBytes          int
@@ -701,15 +701,15 @@ func (s *pullSubscription) handleStatusMsg(msg *nats.Msg, msgErr error) error {
 }
 
 func (hb *hbMonitor) Stop() {
-	hb.Mutex.Lock()
+	hb.Lock()
 	hb.timer.Stop()
-	hb.Mutex.Unlock()
+	hb.Unlock()
 }
 
 func (hb *hbMonitor) Reset(dur time.Duration) {
-	hb.Mutex.Lock()
+	hb.Lock()
 	hb.timer.Reset(dur)
-	hb.Mutex.Unlock()
+	hb.Unlock()
 }
 
 // Stop unsubscribes from the stream and cancels subscription. Calling

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -1123,7 +1123,7 @@ func (consumeOpts *consumeOpts) setDefaults(ordered bool) error {
 		}
 	}
 	if consumeOpts.Heartbeat > consumeOpts.Expires/2 {
-		return fmt.Errorf("%w: the value of Heartbeat must be less than 50%% of expiry", ErrInvalidOption)
+		return fmt.Errorf("%w: the value of Heartbeat must be less than 50% of expiry", ErrInvalidOption)
 	}
 	return nil
 }

--- a/jetstream/push.go
+++ b/jetstream/push.go
@@ -1,0 +1,264 @@
+package jetstream
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nuid"
+)
+
+type (
+	pushConsumer struct {
+		sync.Mutex
+		jetStream *jetStream
+		stream    string
+		name      string
+		info      *ConsumerInfo
+		started   atomic.Bool
+	}
+
+	pushSubscription struct {
+		sync.Mutex
+		id                string
+		errs              chan error
+		subscription      *nats.Subscription
+		connStatusChanged chan nats.Status
+		closedCh          chan struct{}
+		done              chan struct{}
+		closed            atomic.Bool
+		consumeOpts       *pushConsumeOpts
+		hbMonitor         *hbMonitor
+		idleHeartbeat     time.Duration
+	}
+
+	pushConsumeOpts struct {
+		ErrHandler ConsumeErrHandler
+	}
+
+	PushConsumeOpt interface {
+		configurePushConsume(*pushConsumeOpts) error
+	}
+)
+
+func (p *pushConsumer) Consume(handler MessageHandler, opts ...PushConsumeOpt) (ConsumeContext, error) {
+	if handler == nil {
+		return nil, ErrHandlerRequired
+	}
+	consumeOpts := &pushConsumeOpts{}
+	for _, opt := range opts {
+		if err := opt.configurePushConsume(consumeOpts); err != nil {
+			return nil, err
+		}
+	}
+
+	p.Lock()
+	defer p.Unlock()
+
+	if p.info == nil {
+		return nil, ErrConsumerNotFound
+	}
+
+	if p.started.Load() {
+		return nil, ErrConsumerAlreadyConsuming
+	}
+
+	consumeID := nuid.Next()
+	sub := &pushSubscription{
+		id:                consumeID,
+		errs:              make(chan error, 1),
+		done:              make(chan struct{}, 1),
+		consumeOpts:       consumeOpts,
+		connStatusChanged: p.jetStream.conn.StatusChanged(nats.CONNECTED, nats.RECONNECTING),
+		idleHeartbeat:     p.info.Config.IdleHeartbeat,
+	}
+
+	sub.hbMonitor = sub.scheduleHeartbeatCheck(sub.idleHeartbeat)
+	internalHandler := func(msg *nats.Msg) {
+		if sub.hbMonitor != nil {
+			sub.hbMonitor.Stop()
+		}
+		defer func() {
+			if sub.hbMonitor != nil {
+				sub.hbMonitor.Reset(2 * sub.idleHeartbeat)
+			}
+		}()
+		status, descr := msg.Header.Get("Status"), msg.Header.Get("Description")
+		if status == "" {
+			jsMsg := p.jetStream.toJSMsg(msg)
+			handler(jsMsg)
+			return
+		}
+		sub.Lock()
+		if err, terminate := sub.handleStatusMsg(msg, status, descr); err != nil {
+			if sub.consumeOpts.ErrHandler != nil {
+				sub.consumeOpts.ErrHandler(sub, err)
+			}
+			if terminate {
+				sub.Stop()
+			}
+		}
+		sub.Unlock()
+	}
+
+	var err error
+	sub.subscription, err = p.jetStream.conn.Subscribe(p.info.Config.DeliverSubject, internalHandler)
+	if err != nil {
+		return nil, err
+	}
+
+	sub.subscription.SetClosedHandler(func(sid string) func(string) {
+		return func(subject string) {
+			p.started.Store(false)
+			sub.Lock()
+			defer sub.Unlock()
+			if sub.closedCh != nil {
+				close(sub.closedCh)
+				sub.closedCh = nil
+			}
+		}
+	}(sub.id))
+
+	go func() {
+		isConnected := true
+		for {
+			if sub.closed.Load() {
+				return
+			}
+			select {
+			case status, ok := <-sub.connStatusChanged:
+				if !ok {
+					continue
+				}
+				if status == nats.RECONNECTING {
+					if sub.hbMonitor != nil {
+						sub.hbMonitor.Stop()
+					}
+					isConnected = false
+				}
+				if status == nats.CONNECTED {
+					sub.Lock()
+					if !isConnected {
+						isConnected = true
+
+						if sub.hbMonitor != nil {
+							sub.hbMonitor.Reset(2 * sub.idleHeartbeat)
+						}
+					}
+					sub.Unlock()
+				}
+			case err := <-sub.errs:
+				sub.Lock()
+				if sub.consumeOpts.ErrHandler != nil {
+					sub.consumeOpts.ErrHandler(sub, err)
+				}
+				if errors.Is(err, ErrNoHeartbeat) {
+					if sub.hbMonitor != nil {
+						sub.hbMonitor.Reset(2 * sub.idleHeartbeat)
+					}
+				}
+				sub.Unlock()
+			case <-sub.done:
+				return
+			}
+		}
+	}()
+
+	p.started.Store(true)
+
+	return sub, nil
+
+}
+
+func (s *pushSubscription) handleStatusMsg(msg *nats.Msg, status, description string) (error, bool) {
+	switch status {
+	case statusControlMsg:
+		switch strings.ToLower(description) {
+		case idleHeartbeatDescr:
+			return nil, false
+		case fcRequestDescr:
+			if err := msg.Respond(nil); err != nil {
+				if s.consumeOpts.ErrHandler != nil {
+					s.consumeOpts.ErrHandler(s, err)
+				}
+			}
+			return nil, false
+		}
+	case statusConflict:
+		if description == consumerDeleted {
+			return ErrConsumerDeleted, true
+		}
+		if description == leadershipChange {
+			if s.consumeOpts.ErrHandler != nil {
+				s.consumeOpts.ErrHandler(s, ErrConsumerLeadershipChanged)
+				return ErrConsumerLeadershipChanged, false
+			}
+		}
+	}
+	return nil, false
+}
+
+// Stop unsubscribes from the stream and cancels subscription.
+// No more messages will be received after calling this method.
+// All messages that are already in the buffer are discarded.
+func (s *pushSubscription) Stop() {
+	if !s.closed.CompareAndSwap(false, true) {
+		return
+	}
+	s.Lock()
+	defer s.Unlock()
+	close(s.done)
+	s.subscription.Unsubscribe()
+	if s.hbMonitor != nil {
+		s.hbMonitor.Stop()
+	}
+}
+
+// Drain unsubscribes from the stream and cancels subscription.
+// All messages that are already in the buffer will be processed in callback function.
+func (s *pushSubscription) Drain() {
+	if !s.closed.CompareAndSwap(false, true) {
+		return
+	}
+	s.Lock()
+	defer s.Unlock()
+	close(s.done)
+	s.subscription.Drain()
+	if s.hbMonitor != nil {
+		s.hbMonitor.Stop()
+	}
+}
+
+// Closed returns a channel that is closed when consuming is
+// fully stopped/drained. When the channel is closed, no more messages
+// will be received and processing is complete.
+func (s *pushSubscription) Closed() <-chan struct{} {
+	s.Lock()
+	defer s.Unlock()
+	ch := s.closedCh
+	if ch == nil {
+		ch = make(chan struct{})
+		s.closedCh = ch
+	}
+	if !s.subscription.IsValid() {
+		close(s.closedCh)
+		s.closedCh = nil
+	}
+	return ch
+}
+
+func (s *pushSubscription) scheduleHeartbeatCheck(dur time.Duration) *hbMonitor {
+	if dur == 0 {
+		return nil
+	}
+	return &hbMonitor{
+		timer: time.AfterFunc(2*dur, func() {
+			s.Lock()
+			defer s.Unlock()
+			s.errs <- ErrNoHeartbeat
+		}),
+	}
+}

--- a/jetstream/stream.go
+++ b/jetstream/stream.go
@@ -374,7 +374,7 @@ func (s *stream) Consumer(ctx context.Context, name string) (Consumer, error) {
 }
 
 func (s *stream) PushConsumer(ctx context.Context, name string) (PushConsumer, error) {
-	return getPushConsumer(ctx, s.jetStream, s.name, name)
+	return getPushConsumer(ctx, s.js, s.name, name)
 }
 
 // DeleteConsumer removes a consumer with given name from a stream.

--- a/jetstream/stream.go
+++ b/jetstream/stream.go
@@ -123,8 +123,7 @@ type (
 
 		// CreateOrUpdatePushConsumer creates a push consumer on a given stream with
 		// given config. If consumer already exists, it will be updated (if
-		// possible). Consumer interface is returned, allowing to operate on a
-		// consumer (e.g. fetch messages).
+		// possible). Consumer interface is returned, allowing to consume messages.
 		CreateOrUpdatePushConsumer(ctx context.Context, cfg ConsumerConfig) (PushConsumer, error)
 
 		// CreatePushConsumer creates a push consumer on a given stream with given
@@ -323,8 +322,7 @@ func (s *stream) UpdateConsumer(ctx context.Context, cfg ConsumerConfig) (Consum
 
 // CreateOrUpdatePushConsumer creates a consumer on a given stream with
 // given config. If consumer already exists, it will be updated (if
-// possible). Consumer interface is returned, allowing to operate on a
-// consumer (e.g. fetch messages).
+// possible). Consumer interface is returned, allowing to consume messages.
 func (s *stream) CreateOrUpdatePushConsumer(ctx context.Context, cfg ConsumerConfig) (PushConsumer, error) {
 	return upsertPushConsumer(ctx, s.js, s.name, cfg, consumerActionCreateOrUpdate)
 }
@@ -334,14 +332,14 @@ func (s *stream) CreateOrUpdatePushConsumer(ctx context.Context, cfg ConsumerCon
 // differs from its configuration, ErrConsumerExists is returned. If the
 // provided configuration is the same as the existing consumer, the
 // existing consumer is returned. Consumer interface is returned,
-// allowing to operate on a consumer (e.g. fetch messages).
+// allowing to consume messages.
 func (s *stream) CreatePushConsumer(ctx context.Context, cfg ConsumerConfig) (PushConsumer, error) {
 	return upsertPushConsumer(ctx, s.js, s.name, cfg, consumerActionCreate)
 }
 
 // UpdatePushConsumer updates an existing consumer. If consumer does not
 // exist, ErrConsumerDoesNotExist is returned. Consumer interface is
-// returned, allowing to operate on a consumer (e.g. fetch messages).
+// returned, allowing to consume messages.
 func (s *stream) UpdatePushConsumer(ctx context.Context, cfg ConsumerConfig) (PushConsumer, error) {
 	return upsertPushConsumer(ctx, s.js, s.name, cfg, consumerActionUpdate)
 }

--- a/jetstream/stream.go
+++ b/jetstream/stream.go
@@ -127,7 +127,7 @@ type (
 		// consumer (e.g. fetch messages).
 		CreateOrUpdatePushConsumer(ctx context.Context, cfg ConsumerConfig) (PushConsumer, error)
 
-		// CreateConsumer creates a push consumer on a given stream with given
+		// CreatePushConsumer creates a push consumer on a given stream with given
 		// config. If consumer already exists and the provided configuration
 		// differs from its configuration, ErrConsumerExists is returned. If the
 		// provided configuration is the same as the existing consumer, the

--- a/jetstream/stream.go
+++ b/jetstream/stream.go
@@ -121,7 +121,7 @@ type (
 		// If consumer does not exist, ErrConsumerNotFound is returned.
 		UnpinConsumer(ctx context.Context, consumer string, group string) error
 
-		// CreateOrUpdateConsumer creates a push consumer on a given stream with
+		// CreateOrUpdatePushConsumer creates a push consumer on a given stream with
 		// given config. If consumer already exists, it will be updated (if
 		// possible). Consumer interface is returned, allowing to operate on a
 		// consumer (e.g. fetch messages).
@@ -135,7 +135,7 @@ type (
 		// allowing to consume messages.
 		CreatePushConsumer(ctx context.Context, cfg ConsumerConfig) (PushConsumer, error)
 
-		// UpdateConsumer updates an existing push consumer. If consumer does not
+		// UpdatePushConsumer updates an existing push consumer. If consumer does not
 		// exist, ErrConsumerDoesNotExist is returned. Consumer interface is
 		// returned, allowing to consume messages.
 		UpdatePushConsumer(ctx context.Context, cfg ConsumerConfig) (PushConsumer, error)
@@ -321,7 +321,7 @@ func (s *stream) UpdateConsumer(ctx context.Context, cfg ConsumerConfig) (Consum
 	return upsertPullConsumer(ctx, s.js, s.name, cfg, consumerActionUpdate)
 }
 
-// CreateOrUpdateConsumer creates a consumer on a given stream with
+// CreateOrUpdatePushConsumer creates a consumer on a given stream with
 // given config. If consumer already exists, it will be updated (if
 // possible). Consumer interface is returned, allowing to operate on a
 // consumer (e.g. fetch messages).
@@ -329,7 +329,7 @@ func (s *stream) CreateOrUpdatePushConsumer(ctx context.Context, cfg ConsumerCon
 	return upsertPushConsumer(ctx, s.js, s.name, cfg, consumerActionCreateOrUpdate)
 }
 
-// CreateConsumer creates a consumer on a given stream with given
+// CreatePushConsumer creates a consumer on a given stream with given
 // config. If consumer already exists and the provided configuration
 // differs from its configuration, ErrConsumerExists is returned. If the
 // provided configuration is the same as the existing consumer, the
@@ -339,7 +339,7 @@ func (s *stream) CreatePushConsumer(ctx context.Context, cfg ConsumerConfig) (Pu
 	return upsertPushConsumer(ctx, s.js, s.name, cfg, consumerActionCreate)
 }
 
-// UpdateConsumer updates an existing consumer. If consumer does not
+// UpdatePushConsumer updates an existing consumer. If consumer does not
 // exist, ErrConsumerDoesNotExist is returned. Consumer interface is
 // returned, allowing to operate on a consumer (e.g. fetch messages).
 func (s *stream) UpdatePushConsumer(ctx context.Context, cfg ConsumerConfig) (PushConsumer, error) {

--- a/jetstream/test/consumer_test.go
+++ b/jetstream/test/consumer_test.go
@@ -73,21 +73,21 @@ func TestConsumerInfo(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 
-		if info.Stream != "foo" {
-			t.Fatalf("Invalid stream name; expected: 'foo'; got: %s", info.Stream)
-		}
-		if info.Config.Description != "test consumer" {
-			t.Fatalf("Invalid consumer description; expected: 'test consumer'; got: %s", info.Config.Description)
-		}
-		if info.Config.PauseUntil != nil {
-			t.Fatalf("Consumer should not be paused")
-		}
-		if info.Paused != false {
-			t.Fatalf("Consumer should not be paused")
-		}
-		if info.PauseRemaining != 0 {
-			t.Fatalf("Consumer should not be paused")
-		}
+			if info.Stream != "foo" {
+				t.Fatalf("Invalid stream name; expected: 'foo'; got: %s", info.Stream)
+			}
+			if info.Config.Description != "test consumer" {
+				t.Fatalf("Invalid consumer description; expected: 'test consumer'; got: %s", info.Config.Description)
+			}
+			if info.Config.PauseUntil != nil {
+				t.Fatalf("Consumer should not be paused")
+			}
+			if info.Paused != false {
+				t.Fatalf("Consumer should not be paused")
+			}
+			if info.PauseRemaining != 0 {
+				t.Fatalf("Consumer should not be paused")
+			}
 
 			// update consumer and see if info is updated
 

--- a/jetstream/test/ordered_test.go
+++ b/jetstream/test/ordered_test.go
@@ -1151,7 +1151,7 @@ func TestOrderedConsumerMessages(t *testing.T) {
 		for i := 0; i < len(testMsgs); i++ {
 			msg, err := it.Next()
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("Unexpected error fetching next message: %s", err)
 			}
 			time.Sleep(50 * time.Millisecond)
 			msg.Ack()

--- a/jetstream/test/push_test.go
+++ b/jetstream/test/push_test.go
@@ -1,0 +1,434 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestPushConsumerConsume(t *testing.T) {
+	testSubject := "FOO.123"
+	testMsgs := []string{"m1", "m2", "m3", "m4", "m5"}
+	publishTestMsgs := func(t *testing.T, js jetstream.JetStream) {
+		for _, msg := range testMsgs {
+			if _, err := js.Publish(context.Background(), testSubject, []byte(msg)); err != nil {
+				t.Fatalf("Unexpected error during publish: %s", err)
+			}
+		}
+	}
+
+	t.Run("no options", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.CreatePushConsumer(ctx, jetstream.ConsumerConfig{
+			DeliverSubject: nats.NewInbox(),
+			AckPolicy:      jetstream.AckExplicitPolicy,
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		msgs := make([]jetstream.Msg, 0)
+		wg := &sync.WaitGroup{}
+		wg.Add(len(testMsgs))
+		l, err := c.Consume(func(msg jetstream.Msg) {
+			msg.Ack()
+			msgs = append(msgs, msg)
+			wg.Done()
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer l.Stop()
+
+		publishTestMsgs(t, js)
+		wg.Wait()
+		if len(msgs) != len(testMsgs) {
+			t.Fatalf("Unexpected received message count; want %d; got %d", len(testMsgs), len(msgs))
+		}
+		for i, msg := range msgs {
+			if string(msg.Data()) != testMsgs[i] {
+				t.Fatalf("Invalid msg on index %d; expected: %s; got: %s", i, testMsgs[i], string(msg.Data()))
+			}
+		}
+	})
+
+	t.Run("consumer already consuming", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.CreatePushConsumer(ctx, jetstream.ConsumerConfig{
+			DeliverSubject: nats.NewInbox(),
+			AckPolicy:      jetstream.AckExplicitPolicy,
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		l, err := c.Consume(func(msg jetstream.Msg) {
+			msg.Ack()
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer l.Stop()
+
+		_, err = c.Consume(func(msg jetstream.Msg) {})
+		if !errors.Is(err, jetstream.ErrConsumerAlreadyConsuming) {
+			t.Fatalf("Expected error; got none")
+		}
+	})
+
+	t.Run("missing heartbeats", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.CreatePushConsumer(ctx, jetstream.ConsumerConfig{
+			DeliverSubject: nats.NewInbox(),
+			AckPolicy:      jetstream.AckExplicitPolicy,
+			IdleHeartbeat:  100 * time.Millisecond,
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		// delete consumer to simulate missing heartbeats
+		if err := s.DeleteConsumer(context.Background(), c.CachedInfo().Name); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		errs := make(chan error, 1)
+		l, err := c.Consume(func(msg jetstream.Msg) {},
+			jetstream.ConsumeErrHandler(func(cc jetstream.ConsumeContext, err error) {
+				errs <- err
+			}))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer l.Stop()
+
+		select {
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Expected error; got none")
+		case err := <-errs:
+			if !errors.Is(err, jetstream.ErrNoHeartbeat) {
+				t.Fatalf("Expected error; got none")
+			}
+		}
+	})
+
+	t.Run("resubscribe", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.CreatePushConsumer(ctx, jetstream.ConsumerConfig{
+			DeliverSubject: nats.NewInbox(),
+			AckPolicy:      jetstream.AckExplicitPolicy,
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		msgs := make([]jetstream.Msg, 0)
+		wg := &sync.WaitGroup{}
+		publishTestMsgs(t, js)
+		wg.Add(len(testMsgs))
+		cc, err := c.Consume(func(msg jetstream.Msg) {
+			msgs = append(msgs, msg)
+			wg.Done()
+			msg.Ack()
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		wg.Wait()
+		if len(msgs) != len(testMsgs) {
+			t.Fatalf("Unexpected received message count; want %d; got %d", len(testMsgs), len(msgs))
+		}
+		cc.Stop()
+		publishTestMsgs(t, js)
+		wg.Add(len(testMsgs))
+		time.Sleep(100 * time.Millisecond)
+		if len(msgs) != len(testMsgs) {
+			t.Fatalf("Unexpected received message count; want %d; got %d", len(testMsgs), len(msgs))
+		}
+
+		cc, err = c.Consume(func(msg jetstream.Msg) {
+			msgs = append(msgs, msg)
+			wg.Done()
+			msg.Ack()
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer cc.Stop()
+		wg.Wait()
+		if len(msgs) != 2*len(testMsgs) {
+			t.Fatalf("Unexpected received message count; want %d; got %d", len(testMsgs), len(msgs))
+		}
+
+	})
+
+	t.Run("with server restart", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.CreatePushConsumer(ctx, jetstream.ConsumerConfig{
+			DeliverSubject: nats.NewInbox(),
+			AckPolicy:      jetstream.AckExplicitPolicy,
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		wg := &sync.WaitGroup{}
+		wg.Add(2 * len(testMsgs))
+		msgs := make([]jetstream.Msg, 0)
+		publishTestMsgs(t, js)
+		l, err := c.Consume(func(msg jetstream.Msg) {
+			msgs = append(msgs, msg)
+			wg.Done()
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer l.Stop()
+		time.Sleep(10 * time.Millisecond)
+		// restart the server
+		srv = restartBasicJSServer(t, srv)
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		time.Sleep(10 * time.Millisecond)
+		publishTestMsgs(t, js)
+		wg.Wait()
+	})
+
+	t.Run("drain", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.CreatePushConsumer(ctx, jetstream.ConsumerConfig{
+			AckPolicy:      jetstream.AckExplicitPolicy,
+			DeliverSubject: nats.NewInbox(),
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		wg := &sync.WaitGroup{}
+		wg.Add(5)
+		publishTestMsgs(t, js)
+		cc, err := c.Consume(func(msg jetstream.Msg) {
+			time.Sleep(50 * time.Millisecond)
+			msg.Ack()
+			wg.Done()
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		time.Sleep(100 * time.Millisecond)
+		cc.Drain()
+		wg.Wait()
+	})
+
+	t.Run("wait for closed after drain", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.CreatePushConsumer(ctx, jetstream.ConsumerConfig{
+			AckPolicy:      jetstream.AckExplicitPolicy,
+			DeliverSubject: nats.NewInbox(),
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		msgs := make([]jetstream.Msg, 0)
+		lock := sync.Mutex{}
+		publishTestMsgs(t, js)
+		cc, err := c.Consume(func(msg jetstream.Msg) {
+			time.Sleep(50 * time.Millisecond)
+			msg.Ack()
+			lock.Lock()
+			msgs = append(msgs, msg)
+			lock.Unlock()
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		closed := cc.Closed()
+		time.Sleep(100 * time.Millisecond)
+
+		cc.Drain()
+
+		select {
+		case <-closed:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Timeout waiting for consume to be closed")
+		}
+
+		if len(msgs) != len(testMsgs) {
+			t.Fatalf("Unexpected received message count after consume closed; want %d; got %d", len(testMsgs), len(msgs))
+		}
+	})
+
+	t.Run("wait for closed on already closed consume", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.CreatePushConsumer(ctx, jetstream.ConsumerConfig{
+			AckPolicy:      jetstream.AckExplicitPolicy,
+			DeliverSubject: nats.NewInbox(),
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		publishTestMsgs(t, js)
+		cc, err := c.Consume(func(msg jetstream.Msg) {
+			time.Sleep(50 * time.Millisecond)
+			msg.Ack()
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		time.Sleep(100 * time.Millisecond)
+
+		cc.Stop()
+
+		time.Sleep(100 * time.Millisecond)
+
+		select {
+		case <-cc.Closed():
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Timeout waiting for consume to be closed")
+		}
+	})
+}


### PR DESCRIPTION
This PR introduces a `PushConsumer` implementation in jetstream API. For now it only exposes callback-based `Consume()` implementation.
Due to interface differences and breaking change concerns, a completely new set of methods were added to enable operating on push consumers.

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)