### PR TITLE
[FIXED] Invalid heartbeat timer for Consumer.Messages

### DIFF
--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -507,7 +507,7 @@ func (s *pullSubscription) Next() (Msg, error) {
 	if closed && !drainMode {
 		return nil, ErrMsgIteratorClosed
 	}
-	hbMonitor := s.scheduleHeartbeatCheck(2 * s.consumeOpts.Heartbeat)
+	hbMonitor := s.scheduleHeartbeatCheck(s.consumeOpts.Heartbeat)
 	defer func() {
 		if hbMonitor != nil {
 			hbMonitor.Stop()


### PR DESCRIPTION
This fixes an issue where for `Consumer.Messages` the heartbeat error would be returned after 4*idle heartbeat (instead of 2*)

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>