### PR TITLE
[ADDED] PullMaxMessagesWithFetchSizeLimit option for Consume and Messages

### DIFF
--- a/jetstream/README.md
+++ b/jetstream/README.md
@@ -494,7 +494,7 @@ request. An error will be triggered if at least 2 heartbeats are missed
 - `WithConsumeErrHandler(func (ConsumeContext, error))` - when used, sets a
   custom error handler on `Consume()`, allowing e.g. tracking missing
   heartbeats.
-- `PullMaxMessagesWithFetchSizeLimit` - up to the provided number of messages
+- `PullMaxMessagesWithBytesLimit` - up to the provided number of messages
   will be buffered and a single fetch size will be limited to the provided
   value. This is an advanced option and should be used with caution. Most of the
   time, `PullMaxMessages` or `PullMaxBytes` should be used instead.
@@ -540,7 +540,7 @@ type PullThresholdMessages int
 - `PullHeartbeat(time.Duration)` - idle heartbeat duration for a single pull
 request. An error will be triggered if at least 2 heartbeats are missed (unless
 `WithMessagesErrOnMissingHeartbeat(false)` is used)
-- `PullMaxMessagesWithFetchSizeLimit` - up to the provided number of messages
+- `PullMaxMessagesWithBytesLimit` - up to the provided number of messages
   will be buffered and a single fetch size will be limited to the provided
   value. This is an advanced option and should be used with caution. Most of the
   time, `PullMaxMessages` or `PullMaxBytes` should be used instead.

--- a/jetstream/README.md
+++ b/jetstream/README.md
@@ -494,6 +494,10 @@ request. An error will be triggered if at least 2 heartbeats are missed
 - `WithConsumeErrHandler(func (ConsumeContext, error))` - when used, sets a
   custom error handler on `Consume()`, allowing e.g. tracking missing
   heartbeats.
+- `PullMaxMessagesWithFetchSizeLimit` - up to the provided number of messages
+  will be buffered and a single fetch size will be limited to the provided
+  value. This is an advanced option and should be used with caution. Most of the
+  time, `PullMaxMessages` or `PullMaxBytes` should be used instead.
 
 > __NOTE__: `Stop()` should always be called on `ConsumeContext` to avoid
 > leaking goroutines.
@@ -536,6 +540,10 @@ type PullThresholdMessages int
 - `PullHeartbeat(time.Duration)` - idle heartbeat duration for a single pull
 request. An error will be triggered if at least 2 heartbeats are missed (unless
 `WithMessagesErrOnMissingHeartbeat(false)` is used)
+- `PullMaxMessagesWithFetchSizeLimit` - up to the provided number of messages
+  will be buffered and a single fetch size will be limited to the provided
+  value. This is an advanced option and should be used with caution. Most of the
+  time, `PullMaxMessages` or `PullMaxBytes` should be used instead.
 
 ##### Using `Messages()` to fetch single messages one by one
 

--- a/jetstream/errors.go
+++ b/jetstream/errors.go
@@ -199,6 +199,11 @@ var (
 	// on a pull request.
 	ErrMaxBytesExceeded JetStreamError = &jsError{message: "message size exceeds max bytes"}
 
+	// ErrBatchCompleted is returned when a fetch request sent the whole batch,
+	// but there are still bytes left. This is applicable only when MaxBytes is
+	// set on a pull request.
+	ErrBatchCompleted JetStreamError = &jsError{message: "batch completed"}
+
 	// ErrConsumerDeleted is returned when attempting to send pull request to a
 	// consumer which does not exist.
 	ErrConsumerDeleted JetStreamError = &jsError{message: "consumer deleted"}

--- a/jetstream/jetstream_options.go
+++ b/jetstream/jetstream_options.go
@@ -125,12 +125,12 @@ func (max PullMaxMessages) configureMessages(opts *consumeOpts) error {
 	return nil
 }
 
-type pullMaxMessagesWithFetchSizeLimit struct {
+type pullMaxMessagesWithBytesLimit struct {
 	maxMessages int
 	maxBytes    int
 }
 
-// PullMaxMessagesWithFetchSizeLimit limits the number of messages to be buffered
+// PullMaxMessagesWithBytesLimit limits the number of messages to be buffered
 // in the client. Additionally, it sets the maximum size a single fetch request
 // can have. Note that this will not limit the total size of messages buffered
 // in the client, but rather can serve as a way to limit what nats server will
@@ -139,13 +139,13 @@ type pullMaxMessagesWithFetchSizeLimit struct {
 // This is an advanced option and should be used with caution. Most users should
 // use [PullMaxMessages] or [PullMaxBytes] instead.
 //
-// PullMaxMessagesWithFetchSizeLimit implements both PullConsumeOpt and
+// PullMaxMessagesWithBytesLimit implements both PullConsumeOpt and
 // PullMessagesOpt, allowing it to configure Consumer.Consume and Consumer.Messages.
-func PullMaxMessagesWithFetchSizeLimit(maxMessages, byteLimit int) pullMaxMessagesWithFetchSizeLimit {
-	return pullMaxMessagesWithFetchSizeLimit{maxMessages, byteLimit}
+func PullMaxMessagesWithBytesLimit(maxMessages, byteLimit int) pullMaxMessagesWithBytesLimit {
+	return pullMaxMessagesWithBytesLimit{maxMessages, byteLimit}
 }
 
-func (m pullMaxMessagesWithFetchSizeLimit) configureConsume(opts *consumeOpts) error {
+func (m pullMaxMessagesWithBytesLimit) configureConsume(opts *consumeOpts) error {
 	if m.maxMessages <= 0 {
 		return fmt.Errorf("%w: maxMessages size must be at least 1", ErrInvalidOption)
 	}
@@ -162,7 +162,7 @@ func (m pullMaxMessagesWithFetchSizeLimit) configureConsume(opts *consumeOpts) e
 	return nil
 }
 
-func (m pullMaxMessagesWithFetchSizeLimit) configureMessages(opts *consumeOpts) error {
+func (m pullMaxMessagesWithBytesLimit) configureMessages(opts *consumeOpts) error {
 	if m.maxMessages <= 0 {
 		return fmt.Errorf("%w: maxMessages size must be at least 1", ErrInvalidOption)
 	}

--- a/jetstream/message.go
+++ b/jetstream/message.go
@@ -418,6 +418,9 @@ func checkMsg(msg *nats.Msg) (bool, error) {
 		if strings.Contains(strings.ToLower(descr), "message size exceeds maxbytes") {
 			return false, ErrMaxBytesExceeded
 		}
+		if strings.Contains(strings.ToLower(descr), "batch completed") {
+			return false, ErrBatchCompleted
+		}
 		if strings.Contains(strings.ToLower(descr), "consumer deleted") {
 			return false, ErrConsumerDeleted
 		}

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -195,7 +195,7 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 	sub := &pullSubscription{
 		id:          consumeID,
 		consumer:    p,
-		errs:        make(chan error, 1),
+		errs:        make(chan error, 10),
 		done:        make(chan struct{}, 1),
 		fetchNext:   make(chan *pullRequest, 1),
 		consumeOpts: consumeOpts,
@@ -392,7 +392,7 @@ func (s *pullSubscription) incrementDeliveredMsgs() {
 func (s *pullSubscription) checkPending() {
 	// check if we went below any threshold
 	// we don't want to track bytes threshold if either it's not set or we used
-	// PullMaxMessagesWithFetchSizeLimit
+	// PullMaxMessagesWithBytesLimit
 	if (s.pending.msgCount < s.consumeOpts.ThresholdMessages ||
 		(s.pending.byteCount < s.consumeOpts.ThresholdBytes && s.consumeOpts.MaxBytes != 0 && !s.consumeOpts.LimitSize)) &&
 		s.fetchInProgress.Load() == 0 {
@@ -447,7 +447,7 @@ func (p *pullConsumer) Messages(opts ...PullMessagesOpt) (MessagesContext, error
 		consumer:    p,
 		done:        make(chan struct{}, 1),
 		msgs:        msgs,
-		errs:        make(chan error, 1),
+		errs:        make(chan error, 10),
 		fetchNext:   make(chan *pullRequest, 1),
 		consumeOpts: consumeOpts,
 	}
@@ -768,7 +768,7 @@ func (p *pullConsumer) fetch(req *pullRequest) (MessageBatch, error) {
 		consumer: p,
 		done:     make(chan struct{}, 1),
 		msgs:     msgs,
-		errs:     make(chan error, 1),
+		errs:     make(chan error, 10),
 	}
 	inbox := p.js.conn.NewInbox()
 	var err error

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -101,6 +101,7 @@ type (
 		Expires                 time.Duration
 		MaxMessages             int
 		MaxBytes                int
+		LimitSize               bool
 		Heartbeat               time.Duration
 		ErrHandler              ConsumeErrHandlerFunc
 		ReportMissingHeartbeats bool
@@ -160,9 +161,10 @@ type (
 )
 
 const (
-	DefaultMaxMessages = 500
-	DefaultExpires     = 30 * time.Second
-	unset              = -1
+	DefaultMaxMessages       = 500
+	DefaultExpires           = 30 * time.Second
+	defaultBatchMaxBytesOnly = 1_000_000
+	unset                    = -1
 )
 
 func min(x, y int) int {
@@ -373,7 +375,7 @@ func (s *pullSubscription) resetPendingMsgs() {
 // lock should be held before calling this method
 func (s *pullSubscription) decrementPendingMsgs(msg *nats.Msg) {
 	s.pending.msgCount--
-	if s.consumeOpts.MaxBytes != 0 {
+	if s.consumeOpts.MaxBytes != 0 && !s.consumeOpts.LimitSize {
 		s.pending.byteCount -= msg.Size()
 	}
 }
@@ -389,17 +391,19 @@ func (s *pullSubscription) incrementDeliveredMsgs() {
 // lock should be held before calling this method
 func (s *pullSubscription) checkPending() {
 	if (s.pending.msgCount < s.consumeOpts.ThresholdMessages ||
-		(s.pending.byteCount < s.consumeOpts.ThresholdBytes && s.consumeOpts.MaxBytes != 0)) &&
+		(s.pending.byteCount < s.consumeOpts.ThresholdBytes && s.consumeOpts.MaxBytes != 0 && !s.consumeOpts.LimitSize)) &&
 		s.fetchInProgress.Load() == 0 {
 
 		var batchSize, maxBytes int
-		if s.consumeOpts.MaxBytes == 0 {
-			// if using messages, calculate appropriate batch size
-			batchSize = s.consumeOpts.MaxMessages - s.pending.msgCount
-		} else {
-			// if using bytes, use the max value
-			batchSize = s.consumeOpts.MaxMessages
-			maxBytes = s.consumeOpts.MaxBytes - s.pending.byteCount
+		batchSize = s.consumeOpts.MaxMessages - s.pending.msgCount
+		if s.consumeOpts.MaxBytes != 0 {
+			if s.consumeOpts.LimitSize {
+				maxBytes = s.consumeOpts.MaxBytes
+			} else {
+				maxBytes = s.consumeOpts.MaxBytes - s.pending.byteCount
+				// when working with max bytes only, always ask for full batch
+				batchSize = s.consumeOpts.MaxMessages
+			}
 		}
 		if s.consumeOpts.StopAfter > 0 {
 			batchSize = min(batchSize, s.consumeOpts.StopAfter-s.delivered-s.pending.msgCount)
@@ -584,7 +588,7 @@ func (s *pullSubscription) Next() (Msg, error) {
 }
 
 func (s *pullSubscription) handleStatusMsg(msg *nats.Msg, msgErr error) error {
-	if !errors.Is(msgErr, nats.ErrTimeout) && !errors.Is(msgErr, ErrMaxBytesExceeded) {
+	if !errors.Is(msgErr, nats.ErrTimeout) && !errors.Is(msgErr, ErrMaxBytesExceeded) && !errors.Is(msgErr, ErrBatchCompleted) {
 		if errors.Is(msgErr, ErrConsumerDeleted) || errors.Is(msgErr, ErrBadRequest) {
 			return msgErr
 		}
@@ -605,7 +609,7 @@ func (s *pullSubscription) handleStatusMsg(msg *nats.Msg, msgErr error) error {
 	if s.pending.msgCount < 0 {
 		s.pending.msgCount = 0
 	}
-	if s.consumeOpts.MaxBytes > 0 {
+	if s.consumeOpts.MaxBytes > 0 && !s.consumeOpts.LimitSize {
 		s.pending.byteCount -= bytesLeft
 		if s.pending.byteCount < 0 {
 			s.pending.byteCount = 0
@@ -712,7 +716,7 @@ func (p *pullConsumer) Fetch(batch int, opts ...FetchOpt) (MessageBatch, error) 
 // FetchBytes is used to retrieve up to a provided bytes from the stream.
 func (p *pullConsumer) FetchBytes(maxBytes int, opts ...FetchOpt) (MessageBatch, error) {
 	req := &pullRequest{
-		Batch:     1000000,
+		Batch:     defaultBatchMaxBytesOnly,
 		MaxBytes:  maxBytes,
 		Expires:   DefaultExpires,
 		Heartbeat: unset,
@@ -985,40 +989,37 @@ func parseMessagesOpts(ordered bool, opts ...PullMessagesOpt) (*consumeOpts, err
 }
 
 func (consumeOpts *consumeOpts) setDefaults(ordered bool) error {
-	if consumeOpts.MaxBytes != unset && consumeOpts.MaxMessages != unset {
+	// we cannot use both max messages and max bytes unless we're using max bytes as fetch size limiter
+	if consumeOpts.MaxBytes != unset && consumeOpts.MaxMessages != unset && !consumeOpts.LimitSize {
 		return errors.New("only one of MaxMessages and MaxBytes can be specified")
 	}
-	if consumeOpts.MaxBytes != unset {
-		// when max_bytes is used, set batch size to a very large number
-		consumeOpts.MaxMessages = 1000000
-	} else if consumeOpts.MaxMessages != unset {
+	if consumeOpts.MaxBytes != unset && !consumeOpts.LimitSize {
+		consumeOpts.MaxMessages = defaultBatchMaxBytesOnly
+	} else if consumeOpts.MaxMessages == unset {
+		consumeOpts.MaxMessages = DefaultMaxMessages
+	}
+	if consumeOpts.MaxBytes == unset {
 		consumeOpts.MaxBytes = 0
-	} else {
-		if consumeOpts.MaxBytes == unset {
-			consumeOpts.MaxBytes = 0
-		}
-		if consumeOpts.MaxMessages == unset {
-			consumeOpts.MaxMessages = DefaultMaxMessages
-		}
 	}
 
 	if consumeOpts.ThresholdMessages == 0 {
+		// half of the max messages, rounded up
 		consumeOpts.ThresholdMessages = int(math.Ceil(float64(consumeOpts.MaxMessages) / 2))
 	}
 	if consumeOpts.ThresholdBytes == 0 {
+		// half of the max bytes, rounded up
 		consumeOpts.ThresholdBytes = int(math.Ceil(float64(consumeOpts.MaxBytes) / 2))
 	}
 	if consumeOpts.Heartbeat == unset {
+		consumeOpts.Heartbeat = consumeOpts.Expires / 2
 		if ordered {
-			consumeOpts.Heartbeat = 5 * time.Second
 			if consumeOpts.Expires < 10*time.Second {
 				consumeOpts.Heartbeat = consumeOpts.Expires / 2
+			} else {
+				consumeOpts.Heartbeat = 5 * time.Second
 			}
-		} else {
-			consumeOpts.Heartbeat = consumeOpts.Expires / 2
-			if consumeOpts.Heartbeat > 30*time.Second {
-				consumeOpts.Heartbeat = 30 * time.Second
-			}
+		} else if consumeOpts.Heartbeat > 30*time.Second {
+			consumeOpts.Heartbeat = 30 * time.Second
 		}
 	}
 	if consumeOpts.Heartbeat > consumeOpts.Expires/2 {

--- a/jetstream/test/pull_test.go
+++ b/jetstream/test/pull_test.go
@@ -1979,7 +1979,7 @@ func TestPullConsumerMessages(t *testing.T) {
 		}
 		defer sub.Unsubscribe()
 
-		it, err := c.Messages(jetstream.PullMaxMessagesWithFetchSizeLimit(10, 1024))
+		it, err := c.Messages(jetstream.PullMaxMessagesWithBytesLimit(10, 1024))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -3020,7 +3020,7 @@ func TestPullConsumerConsume(t *testing.T) {
 			msg.Ack()
 			msgs = append(msgs, msg)
 			wg.Done()
-		}, jetstream.PullMaxMessagesWithFetchSizeLimit(10, 1024))
+		}, jetstream.PullMaxMessagesWithBytesLimit(10, 1024))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -3118,7 +3118,7 @@ func TestPullConsumerConsume(t *testing.T) {
 			msg.Ack()
 			msgs = append(msgs, msg)
 			wg.Done()
-		}, jetstream.PullMaxMessagesWithFetchSizeLimit(2, 1024))
+		}, jetstream.PullMaxMessagesWithBytesLimit(2, 1024))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}


### PR DESCRIPTION
This PR adds a new option to be used with `Consumer.Consume` and `Consumer.Messages` - `PullMaxMessagesWithFetchSizeLimit`. This option sets both max messages and max bytes in each fetch request, but does not track pending bytes and always sends constant `max_bytes` in each pull request.

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>