### PR TITLE
fix: protocol parsing errors with ws compression and pongs

### DIFF
--- a/ws.go
+++ b/ws.go
@@ -76,14 +76,15 @@ var wsGUID = []byte("258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
 var compressFinalBlock = []byte{0x00, 0x00, 0xff, 0xff, 0x01, 0x00, 0x00, 0xff, 0xff}
 
 type websocketReader struct {
-	r       io.Reader
-	pending [][]byte
-	ib      []byte
-	ff      bool
-	fc      bool
-	nl      bool
-	dc      *wsDecompressor
-	nc      *Conn
+	r        io.Reader
+	pending  [][]byte
+	compress bool
+	ib       []byte
+	ff       bool
+	fc       bool
+	nl       bool
+	dc       *wsDecompressor
+	nc       *Conn
 }
 
 type wsDecompressor struct {
@@ -312,11 +313,13 @@ func (r *websocketReader) Read(p []byte) (int, error) {
 				}
 				r.fc = false
 			}
+		} else if r.compress {
+			b = bytes.Clone(b)
 		}
 		// Add to the pending list if dealing with uncompressed frames or
 		// after we have received the full compressed message and decompressed it.
 		if addToPending {
-			r.pending = append(r.pending, bytes.Clone(b))
+			r.pending = append(r.pending, b)
 		}
 	}
 	// In case of compression, there may be nothing to drain
@@ -647,6 +650,7 @@ func (nc *Conn) wsInitHandshake(u *url.URL) error {
 
 	wsr := wsNewReader(nc.br.r)
 	wsr.nc = nc
+	wsr.compress = compress
 	// We have to slurp whatever is in the bufio reader and copy to br.r
 	if n := br.Buffered(); n != 0 {
 		wsr.ib, _ = br.Peek(n)

--- a/ws.go
+++ b/ws.go
@@ -316,7 +316,7 @@ func (r *websocketReader) Read(p []byte) (int, error) {
 		// Add to the pending list if dealing with uncompressed frames or
 		// after we have received the full compressed message and decompressed it.
 		if addToPending {
-			r.pending = append(r.pending, b)
+			r.pending = append(r.pending, bytes.Clone(b))
 		}
 	}
 	// In case of compression, there may be nothing to drain


### PR DESCRIPTION
Fixes: https://github.com/nats-io/nats.go/issues/1783

This PR addresses a problem that happens when using WS compression and receiving PONGs from the server along with other compressed messages.

The byte slices added to websocketReader.pending are memory references to the original buffer, so when the buffer is re-written in websocketReader.drainPending([]byte) the value for the pending PONG message takes a value that is part of the re-written bytes in the buffer.

This only happens with compression, because the size of the messages in the buffer changes, and only happens when receiving PONG messages, because the value for the regular messages is a new []byte generated after decompression, and not a memory reference to a sub-slice of the original buffer