### PR TITLE
Release v1.39.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 go get github.com/nats-io/nats.go@latest
 
 # To get a specific version:
-go get github.com/nats-io/nats.go@v1.38.0
+go get github.com/nats-io/nats.go@v1.39.0
 
 # Note that the latest major version for NATS Server is v2:
 go get github.com/nats-io/nats-server/v2@latest

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.38.0"
+	Version                   = "1.39.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
### Overview

This release bumps the minimal go version in `go.mod` to `1.22`.

### Added
- JetStream:
  - Added `PullMaxMessagesWithFetchSizeLimit` option for Consume and Messages (#1789)
  - Added `Metadata` to `OrderedConsumerConfig` (#1737)
  - Added `JetStream.Options()` and `JetStream.Conn()` methods to `JetStream` interface (#1792)
- KeyValue:
  - Added `ListKeysFiltered` for listing keys with multiple filters (#1711)

### Fixed
- JetStream:
  - Fixed invalid heartbeat timer for `Consumer.Messages()` (#1786)
- ObjectStore:
  - Fixed invalid error being returned from `DeleteObjectStore` (#1762)
- WebSockets:
  - Fixed protocol parsing errors with websocket compression and PONGs (#1790)
- Core NATS:
  - Protect against possible nil pointer panic (#1771)

### Changed
- Bump go version to v1.22 (#1773)

### Improved
- Fixed typo in JetStream docs (#1758)
- Improved documentation of JetStream `Consume` and `Messages` options (#1770)
- Removed obsolete build tags (#1787)

### Complete Changes

https://github.com/nats-io/nats.go/compare/v1.38.0...v1.39.0