### PR TITLE
[ADDED] ReconnectErrCB + handler function

### DIFF
--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -969,7 +969,6 @@ func TestCallbacksOrder(t *testing.T) {
 		nats.ReconnectWait(50*time.Millisecond),
 		nats.ReconnectJitter(0, 0),
 		nats.DontRandomize())
-
 	if err != nil {
 		t.Fatalf("Unable to connect: %v\n", err)
 	}
@@ -1093,6 +1092,35 @@ func TestCallbacksOrder(t *testing.T) {
 	t.Fatalf("The async callback dispatcher(s) should have stopped")
 }
 
+func TestReconnectErrHandler(t *testing.T) {
+	handler := func(ch chan bool) func(*nats.Conn, error) {
+		return func(*nats.Conn, error) {
+			ch <- true
+		}
+	}
+	t.Run("with RetryOnFailedConnect, MaxReconnects(-1), no connection", func(t *testing.T) {
+		opts := test.DefaultTestOptions
+		// Server should not be reachable to test this one
+		opts.Port = 4223
+		s := RunServerWithOptions(&opts)
+		defer s.Shutdown()
+
+		reconnectErr := make(chan bool)
+
+		nc, err := nats.Connect(nats.DefaultURL,
+			nats.ReconnectErrHandler(handler(reconnectErr)),
+			nats.RetryOnFailedConnect(true),
+			nats.MaxReconnects(-1))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+		if err = Wait(reconnectErr); err != nil {
+			t.Fatal("Timeout waiting for reconnect error handler")
+		}
+	})
+}
+
 func TestConnectHandler(t *testing.T) {
 	handler := func(ch chan bool) func(*nats.Conn) {
 		return func(*nats.Conn) {
@@ -1110,7 +1138,6 @@ func TestConnectHandler(t *testing.T) {
 			nats.ConnectHandler(handler(connected)),
 			nats.ReconnectHandler(handler(reconnected)),
 			nats.RetryOnFailedConnect(true))
-
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1130,7 +1157,6 @@ func TestConnectHandler(t *testing.T) {
 			nats.ConnectHandler(handler(connected)),
 			nats.ReconnectHandler(handler(reconnected)),
 			nats.RetryOnFailedConnect(true))
-
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1151,7 +1177,6 @@ func TestConnectHandler(t *testing.T) {
 		nc, err := nats.Connect(nats.DefaultURL,
 			nats.ConnectHandler(handler(connected)),
 			nats.ReconnectHandler(handler(reconnected)))
-
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1189,7 +1214,6 @@ func TestConnectHandler(t *testing.T) {
 			nats.ReconnectHandler(handler(reconnected)),
 			nats.RetryOnFailedConnect(true),
 			nats.ReconnectWait(100*time.Millisecond))
-
 		if err != nil {
 			t.Fatalf("Expected error on connect, got nil")
 		}
@@ -1221,7 +1245,6 @@ func TestConnectHandler(t *testing.T) {
 			nats.ReconnectHandler(handler(reconnected)),
 			nats.RetryOnFailedConnect(true),
 			nats.ReconnectWait(100*time.Millisecond))
-
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -2221,7 +2244,6 @@ func TestBarrier(t *testing.T) {
 		// invocation of this callback, but the Barrier should still be
 		// invoked.
 		nc.Barrier(func() { ch <- true })
-
 	})
 	if err != nil {
 		t.Fatalf("Error on subscribe: %v", err)


### PR DESCRIPTION
Hi,

I am often using those connect options due to an offline first approach:

```go
opts := []nats.Option{
    nats.RetryOnFailedConnect(true),
    nats.MaxReconnects(-1),
}
```
I noticed that **none** of the current handlers covers handling connection attempt errors when there never was an initial connection with those options.
This is probably a very narrow use case.

That is why I thought adding `ReconnectErrCB` and the corresponding `ReconnectErrHandler` makes sense.

Since this is my first contribution, please let me know whether I missed something or whether it should be solved
in a complete different manner. I am willing to put in more work if necessary of course.

Sorry for having a bit of additional diffs due to using `gopls` formatting. I did not find any formatting rules.
If there are any, I am happy to reformat accordingly.

Regards
