### PR TITLE
[FIXED] Invalid subscription on ordered consumer in leaderless cluster

### DIFF
--- a/js.go
+++ b/js.go
@@ -2206,6 +2206,9 @@ func (sub *Subscription) resetOrderedConsumer(sseq uint64) {
 				// retry for insufficient resources, as it may mean that client is connected to a running
 				// server in cluster while the server hosting R1 JetStream resources is restarting
 				return
+			} else if errors.As(err, &apiErr) && apiErr.ErrorCode == JSErrCodeJetStreamNotAvailable {
+				// retry if JetStream meta leader is temporarily unavailable
+				return
 			}
 			pushErr(err)
 			return

--- a/jserrors.go
+++ b/jserrors.go
@@ -166,6 +166,7 @@ const (
 	JSErrCodeJetStreamNotEnabledForAccount ErrorCode = 10039
 	JSErrCodeJetStreamNotEnabled           ErrorCode = 10076
 	JSErrCodeInsufficientResourcesErr      ErrorCode = 10023
+	JSErrCodeJetStreamNotAvailable         ErrorCode = 10008
 
 	JSErrCodeStreamNotFound  ErrorCode = 10059
 	JSErrCodeStreamNameInUse ErrorCode = 10058


### PR DESCRIPTION
An ordered consumer would not be recreated if there's temporarily no meta leader, which returns the following error:
```
nats: JetStream system temporarily unavailable: recreating ordered consumer on connection [70] for subscription on ""
```
After the first error, it will continuously fail with a `nats: invalid subscription` error.

That error matches with this server error:
```
JSClusterNotAvailErr: {Code: 503, ErrCode: 10008, Description: "JetStream system temporarily unavailable"},
```