### PR TITLE
[ADDED] Added support for cross-domain Object Store

### DIFF
--- a/jetstream/test/object_test.go
+++ b/jetstream/test/object_test.go
@@ -1268,3 +1268,100 @@ func TestObjectStoreMirror(t *testing.T) {
 		}
 	}
 }
+
+func TestObjectStoreCrossDomains(t *testing.T) {
+	expectSameContent := func(t *testing.T, a []byte, b []byte) {
+		t.Helper()
+		if !bytes.Equal(a, b) {
+			t.Fatalf("content mismatch")
+		}
+	}
+
+	hubFileContent := []byte("hub_file content")
+	leafFileContent := []byte("leaf_file content")
+
+	hconf := createConfFile(t, []byte(`
+		server_name: HUB
+		listen: 127.0.0.1:-1
+		jetstream: { domain: HUB, store_dir: 'hub_js' }
+		leafnodes { listen: 127.0.0.1:7422}
+		mappings {
+    	'$JS.HUB.API.$O.>': '$O.>'
+		}
+	}`))
+	defer os.Remove(hconf)
+	hs, _ := RunServerWithConfig(hconf)
+	defer shutdownJSServerAndRemoveStorage(t, hs)
+
+	lconf := createConfFile(t, []byte(`
+		server_name: LEAF
+		listen: 127.0.0.1:-1
+ 		jetstream: { domain:LEAF, store_dir: 'leaf_js' }
+ 		leafnodes {
+ 		 	remotes = [	{	url: "leaf://127.0.0.1"	}	]
+ 		}
+		mappings {
+    	'$JS.LEAF.API.$O.>': '$O.>'
+		}
+	}`))
+	defer os.Remove(lconf)
+	ls, _ := RunServerWithConfig(lconf)
+	defer shutdownJSServerAndRemoveStorage(t, ls)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Create OjectStore on HUB
+	hnc, hjs := jsClient(t, hs)
+	defer hnc.Close()
+
+	_, err := hjs.CreateObjectStore(ctx, jetstream.ObjectStoreConfig{Bucket: "HUB_BUCKET"})
+	expectOk(t, err)
+
+	// Create ObjectStore on Leafnode
+	lnc, ljs := jsClient(t, ls)
+	defer lnc.Close()
+
+	_, err = ljs.CreateObjectStore(ctx, jetstream.ObjectStoreConfig{Bucket: "LEAF_BUCKET"})
+	expectOk(t, err)
+
+	// Put an object cross-domain (HUB -> LEAF)
+	hljs, err := jetstream.NewWithDomain(hnc, "LEAF")
+	expectOk(t, err)
+	hlos, err := hljs.ObjectStore(ctx, "LEAF_BUCKET")
+	expectOk(t, err)
+	_, err = hlos.PutBytes(ctx, "leaf_file", leafFileContent)
+	expectOk(t, err)
+
+	// Put an object cross-domain (LEAF -> HUB)
+	lhjs, err := jetstream.NewWithDomain(lnc, "HUB")
+	expectOk(t, err)
+	lhos, err := lhjs.ObjectStore(ctx, "HUB_BUCKET")
+	expectOk(t, err)
+	_, err = lhos.PutBytes(ctx, "hub_file", hubFileContent)
+	expectOk(t, err)
+
+	// Read an object cross-domain (HUB <- LEAF)
+	hlb, err := hlos.GetBytes(ctx, "leaf_file")
+	expectOk(t, err)
+	expectSameContent(t, leafFileContent, hlb)
+
+	// Read an object cross-domain (LEAF <- HUB)
+	lhb, err := lhos.GetBytes(ctx, "hub_file")
+	expectOk(t, err)
+	expectSameContent(t, hubFileContent, lhb)
+
+	// Open local bucket using domainified JetStream (expected to fail)
+	_, err = hljs.ObjectStore(ctx, "HUB_BUCKET")
+	expectErr(t, err)
+	_, err = lhjs.ObjectStore(ctx, "LEAF_BUCKET")
+	expectErr(t, err)
+
+	// Delete an object cross-domain (HUB -> LEAF)
+	err = hlos.Delete(ctx, "leaf_file")
+	expectOk(t, err)
+
+	// Delete an object cross-domain (LEAF -> HUB)
+	err = lhos.Delete(ctx, "hub_file")
+	expectOk(t, err)
+}


### PR DESCRIPTION
Hi!

I have been recently trying to build a simple hub-spoke leaf node setup with a single account and different jetstream domains. Each spoke has its own object store with a limited TTL that i want to use as a staging area and the hub should have complete control over them.

These object stores must reside on the spokes because they must be available even if the connection to the hub is severed. There should also be no cross-talk between spokes, as well as as limited access from the spoke to the hub, and I managed to achieve that with different users and a scoped signing key.

However when i tried to operate the object stores form the hub, i noticed that the requests where timing out. A quick search got me to #1648 which correctly identifies the issue: chunk subjects do not use domains (and by extension any jetstream api prefix) and therefore cannot cross jetstream boundaries.

This pull request solves the issue by adding the jetstream API prefix to the **$O.>** subjects. I took inspiration from the nats.java fixes in nats-io/nats.java#1160 and nats-io/nats.java#1172

There still one thing missing though: a new mapping must be manually esablished on the spokes. For example:

```
mappings {
    '$JS.LEAF.API.$O.>': '$O.>'
}
```

Usually the nats server does behind the scene mappings when setting up jetstream domains (see [server/jetstream_api.go#331](https://github.com/nats-io/nats-server/blob/e50fb3198aec727b20580293216dfd3dad2ace1f/server/jetstream_api.go#L331) ). IMO a change should be made to add a default mapping for the **$O.>** subjects too to provide this functionality out of the box.

I fixed both the new and old jetstream API and added tests for both.

Since this is my first contribution, please let me know if I did everything correctly!

Thanks!