### PR TITLE
perf: use reflect to test equity of message headers

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -31,6 +31,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -726,21 +727,7 @@ func (m *Msg) Equal(msg *Msg) bool {
 	if !bytes.Equal(m.Data, msg.Data) {
 		return false
 	}
-	if len(m.Header) != len(msg.Header) {
-		return false
-	}
-	for k, v := range m.Header {
-		val, ok := msg.Header[k]
-		if !ok || len(v) != len(val) {
-			return false
-		}
-		for i, hdr := range v {
-			if hdr != val[i] {
-				return false
-			}
-		}
-	}
-	return true
+	return reflect.DeepEqual(m.Header, msg.Header)
 }
 
 // Size returns a message size in bytes.


### PR DESCRIPTION
This patch uses reflection to test equality of message headers. This apporach is more efficient in the case when:
+ Both `m.Header` and `msg.Header` are non-nil
+ `m.Header` and `msg.Header` share the same underlying object, so the equality can be caught before testing the content of the map, compared to the original approach. For reference, [map reflect implementation](https://github.com/golang/go/blob/5817e650946aaa0ac28956de96b3f9aa1de4b299/src/reflect/deepequal.go#L142-L144) in go source code: 

```go
	case Map:
		if v1.IsNil() != v2.IsNil() {
			return false
		}
		if v1.Len() != v2.Len() {
			return false
		}
		if v1.UnsafePointer() == v2.UnsafePointer() {
			return true
		}
		iter := v1.MapRange()
		for iter.Next() {
			val1 := iter.Value()
			val2 := v2.MapIndex(iter.Key())
			if !val1.IsValid() || !val2.IsValid() || !deepValueEqual(val1, val2, visited) {
				return false
			}
		}
		return true
```