### PR TITLE
fix: use resp.Error to show NATS error in deleteMsg

### DIFF
--- a/jetstream/stream.go
+++ b/jetstream/stream.go
@@ -569,7 +569,7 @@ func (s *stream) deleteMsg(ctx context.Context, req *msgDeleteRequest) error {
 		return err
 	}
 	if !resp.Success {
-		return fmt.Errorf("%w: %s", ErrMsgDeleteUnsuccessful, err)
+		return fmt.Errorf("%w: %s", ErrMsgDeleteUnsuccessful, resp.Error.Error())
 	}
 	return nil
 }


### PR DESCRIPTION
The error message in deleteMsg was printing nil when resp.Success was false. Changed to use resp.Error, displaying the actual NATS error.