### PR TITLE
[FIXED] Deadlock when fetching keys from KV while messages are deleted/purged

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -929,13 +929,14 @@ func (kv *kvs) History(key string, opts ...WatchOpt) ([]KeyValueEntry, error) {
 
 // Implementation for Watch
 type watcher struct {
-	mu          sync.Mutex
-	updates     chan KeyValueEntry
-	sub         *Subscription
-	initDone    bool
-	initPending uint64
-	received    uint64
-	ctx         context.Context
+	mu            sync.Mutex
+	updates       chan KeyValueEntry
+	sub           *Subscription
+	initDone      bool
+	initPending   uint64
+	received      uint64
+	ctx           context.Context
+	initDoneTimer *time.Timer
 }
 
 // Context returns the context for the watcher if set.
@@ -1044,8 +1045,11 @@ func (kv *kvs) WatchFiltered(keys []string, opts ...WatchOpt) (KeyWatcher, error
 				w.initPending = delta
 			}
 			if w.received > w.initPending || delta == 0 {
+				w.initDoneTimer.Stop()
 				w.initDone = true
 				w.updates <- nil
+			} else if w.initDoneTimer != nil {
+				w.initDoneTimer.Reset(kv.js.opts.wait)
 			}
 		}
 	}
@@ -1088,6 +1092,16 @@ func (kv *kvs) WatchFiltered(keys []string, opts ...WatchOpt) (KeyWatcher, error
 		if sub.jsi != nil && sub.jsi.pending == 0 {
 			w.initDone = true
 			w.updates <- nil
+		} else {
+			// Set a timer to send the marker if we do not get any messages.
+			w.initDoneTimer = time.AfterFunc(kv.js.opts.wait, func() {
+				w.mu.Lock()
+				defer w.mu.Unlock()
+				if !w.initDone {
+					w.initDone = true
+					w.updates <- nil
+				}
+			})
 		}
 	} else {
 		// if UpdatesOnly was used, mark initialization as complete
@@ -1097,6 +1111,7 @@ func (kv *kvs) WatchFiltered(keys []string, opts ...WatchOpt) (KeyWatcher, error
 	sub.pDone = func(_ string) {
 		close(w.updates)
 	}
+
 	sub.mu.Unlock()
 
 	w.sub = sub


### PR DESCRIPTION
KV watcher will now send a `nil` marker if we've not reached 0 pending msgs and have not received any new key for more than JS timeout. This avoids a deadlock when messages are purged/deleted from the stream while e.g. listing keys.

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)