### PR TITLE
Release v1.40.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 go get github.com/nats-io/nats.go@latest
 
 # To get a specific version:
-go get github.com/nats-io/nats.go@v1.39.1
+go get github.com/nats-io/nats.go@v1.40.0
 
 # Note that the latest major version for NATS Server is v2:
 go get github.com/nats-io/nats-server/v2@latest

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.39.1"
+	Version                   = "1.40.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
### Overview

This release focuses on adding support for new features from [NATS Server v2.11.0](https://github.com/nats-io/nats-server/releases/tag/v2.11.0). This includes:

- Per message TTLs
- Consumer pause and resume

Batch direct get will be released in [orbit](https://github.com/synadia-io/orbit.go). Support for consumer priority groups will be added in the next minor release.

### Added
- JetStream:
  - Pause and resume JetStream consumer (#1571)
  - Per message TTL option for JetStream publish (#1825)
  - Timeout option for async publish (#1819)
- Service API
  - Support for disabling queue groups at service, group, and endpoint levels (#1797)
- Core NATS:
  - `ReconnectErrCB` for handling failed reconnect attempts in a callback (#1804)

### Fixed
- JetStream
  - Invalid subscription on ordered consumer in leaderless cluster (#1808)
  - Ordered consumer not restarting on no responders (#1827)
  - Avoid ack id collision in PublishAsync (#1812)
  - Possible panic in `Consumer.Fetch` (#1828)
  - Use `resp.Error` to show NATS error in `deleteMsg` (#1822)
- KeyValue
  - Deadlock when fetching keys from KV while messages are deleted/purged (#1824)

### Changed
- Bump go version to 1.23 and update dependencies (#1821)

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)