### PR TITLE
[IMPROVED] Stop the watcher before performing the purge operations for PurgeDeletes.

### DIFF
--- a/jetstream/kv.go
+++ b/jetstream/kv.go
@@ -1377,6 +1377,8 @@ func (kv *kvs) PurgeDeletes(ctx context.Context, opts ...KVPurgeOpt) error {
 			deleteMarkers = append(deleteMarkers, entry)
 		}
 	}
+	// Stop watcher here so as we purge we do not have the system continually updating numPending.
+	watcher.Stop()
 
 	var b strings.Builder
 	// Do actual purges here.

--- a/kv.go
+++ b/kv.go
@@ -826,6 +826,8 @@ func (kv *kvs) PurgeDeletes(opts ...PurgeOpt) error {
 			deleteMarkers = append(deleteMarkers, entry)
 		}
 	}
+	// Stop watcher here so as we purge we do not have the system continually updating numPending.
+	watcher.Stop()
 
 	var (
 		pr StreamPurgeRequest


### PR DESCRIPTION
This is to avoid the server having to keep calculating numPending for the watcher itself. This can be especially penal if we purge more than one message and the stream / KV has a lot of keys. The server will also be improved in handling this situation, those changes are in flight.

Signed-off-by: Derek Collison <derek@nats.io>
