### PR TITLE
[FIXED] Reset channel after closing in ForceReconnect

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -2224,6 +2224,7 @@ func (nc *Conn) ForceReconnect() error {
 		// even if we're in the middle of a backoff
 		if nc.rqch != nil {
 			close(nc.rqch)
+			nc.rqch = nil
 		}
 		return nil
 	}


### PR DESCRIPTION
Set the `rqch` channel to `nil` after closing to avoid `close of closed channel` panic.
This channel is recreated in `doReconnect()` allowing to bypass wait time between reconnects.

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>