### PR TITLE
[ADDED] DefaultTimeout option for JetStream API requests

### DIFF
--- a/jetstream/jetstream_options.go
+++ b/jetstream/jetstream_options.go
@@ -65,6 +65,19 @@ func WithPublishAsyncTimeout(dur time.Duration) JetStreamOpt {
 	}
 }
 
+// WithDefaultTimeout sets the default timeout for JetStream API requests.
+// It is used when context used for the request does not have a deadline set.
+// If not provided, a default of 5 seconds will be used.
+func WithDefaultTimeout(timeout time.Duration) JetStreamOpt {
+	return func(opts *JetStreamOptions) error {
+		if timeout <= 0 {
+			return fmt.Errorf("%w: timeout value must be greater than 0", ErrInvalidOption)
+		}
+		opts.DefaultTimeout = timeout
+		return nil
+	}
+}
+
 // WithPurgeSubject sets a specific subject for which messages on a stream will
 // be purged
 func WithPurgeSubject(subject string) StreamPurgeOpt {

--- a/jetstream/test/publish_test.go
+++ b/jetstream/test/publish_test.go
@@ -774,6 +774,41 @@ func TestPublish(t *testing.T) {
 	}
 }
 
+func TestPublishTimeout(t *testing.T) {
+	srv := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, srv)
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	js, err := jetstream.New(nc, jetstream.WithDefaultTimeout(200*time.Millisecond))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer nc.Close()
+
+	// create stream with no ack to force timeout
+	_, err = js.CreateStream(context.Background(), jetstream.StreamConfig{
+		Name:     "foo",
+		Subjects: []string{"FOO.*"},
+		NoAck:    true,
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	now := time.Now()
+	_, err = js.Publish(context.Background(), "FOO.1", []byte("msg"))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Expected deadline exceeded error; got: %v", err)
+	}
+	since := time.Since(now)
+	if since < 200*time.Millisecond || since > 500*time.Millisecond {
+		t.Fatalf("Expected timeout to be around 200ms; got: %v", since)
+	}
+}
+
 func TestPublishMsgAsync(t *testing.T) {
 	type publishConfig struct {
 		msg              *nats.Msg


### PR DESCRIPTION
This adds a `WithDefaultTimeout` option when creating `JetStream`. This timeout is used when a context without deadline is passed to JetStream requests.

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>