### PR TITLE
[FIXED] Initialize rqch channel for immediate reconnection on ForceReconnect

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -2844,6 +2844,16 @@ func (nc *Conn) doReconnect(err error, forceReconnect bool) {
 	var rt *time.Timer
 	// Channel used to kick routine out of sleep when conn is closed.
 	rqch := nc.rqch
+
+	// if rqch is nil, we need to set it up to signal
+	// the reconnect loop to reconnect immediately
+	// this means that `ForceReconnect` was called
+	// before entering doReconnect
+	if rqch == nil {
+		rqch = make(chan struct{})
+		close(rqch)
+	}
+
 	// Counter that is increased when the whole list of servers has been tried.
 	var wlf int
 


### PR DESCRIPTION
This is a follow-up to #1842 which introduced an issue where `nc.rqch`
could be cleared before reading it in `doReconnect`.
This happened e.g. when an auth error triggered reconnect close to
calling `ForceReconnect` (made apparent by `TestAuthExpiredForceReconnect`
starting to be flaky).

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>