### PR TITLE
Release v1.41.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 go get github.com/nats-io/nats.go@latest
 
 # To get a specific version:
-go get github.com/nats-io/nats.go@v1.40.1
+go get github.com/nats-io/nats.go@v1.41.0
 
 # Note that the latest major version for NATS Server is v2:
 go get github.com/nats-io/nats-server/v2@latest

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.40.1"
+	Version                   = "1.41.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
### Overview

This release adds consumer priority groups to JetStream, exposing overflow and pinning policies. For more information on consumer priority groups, see [ADR-42](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-42.md).

### Added
- JetStream:
  - Consumer priority groups with pinned and overflow policies (#1826)
  -  `WithDefaultTimeout` option for JetStream API requests (#1843

### Fixed

- KeyValue:
  - Ensure timer is stopped when watcher is stopped (#1838)
- ObjectStore:
  - Ensure object watcher stop closes the updates channel (#1844)
- Core NATS:
  - Data race when reading current status in `sub.StatusChanged` and `nc.StatusChanged` (#1841)
  - Reset channel after closing in `ForceReconnect` to avoid panic on subsequent `ForceReconnect` calls (#1842, #1846)

### Changed

### Improved

- Legacy JetStream:
  - Cancel `Fetch` and `FetchBatch` on reconnect (#1840)
- JetStream:
  - Invalid default in documentation for `OrderedConsumerConfig.InactiveThreshold` (#1845)
- KeyValue:
  - Stop the watcher before performing the purge operations for `PurgeDeletes` (#1839) 

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)