### PR TITLE
Remove `golang.org/x/text` dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/nats-io/nkeys v0.4.9
 	github.com/nats-io/nuid v1.0.1
-	golang.org/x/text v0.23.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,5 +8,3 @@ golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
 golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
-golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=

--- a/jetstream/stream_config.go
+++ b/jetstream/stream_config.go
@@ -19,9 +19,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 type (
@@ -528,12 +525,11 @@ const (
 )
 
 func (st StorageType) String() string {
-	caser := cases.Title(language.AmericanEnglish)
 	switch st {
 	case MemoryStorage:
-		return caser.String(memoryStorageString)
+		return "Memory"
 	case FileStorage:
-		return caser.String(fileStorageString)
+		return "File"
 	default:
 		return "Unknown Storage Type"
 	}


### PR DESCRIPTION
The only use of `x/text` is in one `String()` method. In the interests of not pulling more dependencies into the server than we need to, it'd be better if we didn't do that.

Signed-off-by: Neil Twigg <neil@nats.io>