### PR TITLE
Release v1.41.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 go get github.com/nats-io/nats.go@latest
 
 # To get a specific version:
-go get github.com/nats-io/nats.go@v1.41.0
+go get github.com/nats-io/nats.go@v1.41.1
 
 # Note that the latest major version for NATS Server is v2:
 go get github.com/nats-io/nats-server/v2@latest

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.41.0"
+	Version                   = "1.41.1"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
## Changelog

### FIXED
- ObjectStore:
  - Use default timeout for `ObjectStore.Get` when no deadline is set on ctx (#1850)

### IMPROVED
- Remove `golang.org/x/text` dependency (#1849)

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)