### PR TITLE
[FIXED] Add RemoveStatusListener method and fixFetch memory leak

### DIFF
--- a/js.go
+++ b/js.go
@@ -3145,12 +3145,11 @@ func (sub *Subscription) Fetch(batch int, opts ...PullOpt) ([]*Msg, error) {
 		go func() {
 			select {
 			case <-ctx.Done():
-				return
 			case <-connStatusChanged:
 				disconnected.Store(true)
 				cancel()
-				return
 			}
+			nc.RemoveStatusListener(connStatusChanged)
 		}()
 		err = sendReq()
 		for err == nil && len(msgs) < batch {
@@ -3404,12 +3403,11 @@ func (sub *Subscription) FetchBatch(batch int, opts ...PullOpt) (MessageBatch, e
 	go func() {
 		select {
 		case <-ctx.Done():
-			return
 		case <-connStatusChanged:
 			disconnected.Store(true)
 			cancel()
-			return
 		}
+		nc.RemoveStatusListener(connStatusChanged)
 	}()
 	requestBatch := batch - len(result.msgs)
 	req := nextRequest{


### PR DESCRIPTION
This adds a new method, `Conn.RemoveStatusListener`, which allows to manually remove an unwanted status changed listener. Internally listeners were converted to map for more efficient lookup.

Fixes a memory leak in `Fetch` and `FetchBatch` which caused status listeners to never be cleaned up (they would only disappear after status is changed).

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)