### PR TITLE
Fix typo: TimeStampHeaer -> TimeStampHeader

### DIFF
--- a/jetstream/message.go
+++ b/jetstream/message.go
@@ -211,7 +211,7 @@ const (
 	SequenceHeader = "Nats-Sequence"
 
 	// TimeStampHeader contains the original timestamp of the message.
-	TimeStampHeaer = "Nats-Time-Stamp"
+	TimeStampHeader = "Nats-Time-Stamp"
 
 	// SubjectHeader contains the original subject the message was published to.
 	SubjectHeader = "Nats-Subject"

--- a/jetstream/stream.go
+++ b/jetstream/stream.go
@@ -561,7 +561,7 @@ func convertDirectGetMsgResponseToMsg(r *nats.Msg) (*RawStreamMsg, error) {
 	if err != nil {
 		return nil, fmt.Errorf("nats: invalid sequence header '%s': %v", seqStr, err)
 	}
-	timeStr := r.Header.Get(TimeStampHeaer)
+	timeStr := r.Header.Get(TimeStampHeader)
 	if timeStr == "" {
 		return nil, errors.New("nats: missing timestamp header")
 	}


### PR DESCRIPTION
This pull request fixes a typo in the constant name:
TimeStampHeaer -> TimeStampHeader

Correcting this typo improves code readability and prevents potential issues when using this constant.
