### PR TITLE
Add Keys func to Header

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -3816,6 +3816,15 @@ func (h Header) Get(key string) string {
 	return _EMPTY_
 }
 
+// Keys returns a slice containing all the keys present in the Header.
+func (h Header) Keys() []string {
+	keys := make([]string, 0, len(h))
+	for k := range h {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 // Values returns all values associated with the given key.
 // It is case-sensitive.
 func (h Header) Values(key string) []string {


### PR DESCRIPTION
Resolves https://github.com/nats-io/nats.go/issues/1867

Adding `Keys` function to the `Header` satisfies the OpenTelemetry interface for [TextMapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#TextMapCarrier).
This allows tracing contexts to be inject and extracted from the Header using the OpenTelemetry library.