### PR TITLE
[FIXED] Stopping micro service should fully unsubscribe (#1871)

### DIFF
--- a/micro/service.go
+++ b/micro/service.go
@@ -692,7 +692,10 @@ func (s *service) Stop() error {
 	if s.stopped {
 		return nil
 	}
-	for _, e := range s.endpoints {
+	// make a copy of s.endpoints to range over in order to stop
+	// since *Endpoint.stop manipulates s.endpoints!
+	endpointsToStop := append(make([]*Endpoint, 0, len(s.endpoints)), s.endpoints...)
+	for _, e := range endpointsToStop {
 		if err := e.stop(); err != nil {
 			fmt.Println("Error stopping endpoint: ", err)
 			return err


### PR DESCRIPTION
Fixes the issue describe in #1871  by ensuring the ranging of endpoints is not impacted by the action to perform the stop on the endpoint (which manipulates the endpoints slice). This is achieved by making a copy of the slice beforehand.