### PR TITLE
[FIXED] JetStream consumer hanging after connection closure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,7 @@ _testmain.go
 .idea
 
 # VS Code
-.vscode 
+.vscode
+
+# Claude Code instructions
+CLAUDE.md

--- a/jetstream/errors.go
+++ b/jetstream/errors.go
@@ -259,6 +259,10 @@ var (
 	// closed iterator.
 	ErrMsgIteratorClosed JetStreamError = &jsError{message: "messages iterator closed"}
 
+	// ErrConnectionClosed is returned when JetStream operations fail due to 
+	// underlying connection being closed.
+	ErrConnectionClosed JetStreamError = &jsError{message: "connection closed"}
+
 	// ErrOrderedConsumerReset is returned when resetting ordered consumer fails
 	// due to too many attempts.
 	ErrOrderedConsumerReset JetStreamError = &jsError{message: "recreating ordered consumer"}

--- a/jetstream/test/pull_test.go
+++ b/jetstream/test/pull_test.go
@@ -3483,3 +3483,263 @@ func TestPullConsumerNext(t *testing.T) {
 		}
 	})
 }
+
+func TestPullConsumerMessagesConnClose(t *testing.T) {
+	// This test checks whether Next() returns an error when the connection is closed
+	srv := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, srv)
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Create stream
+	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "test-stream",
+		Subjects: []string{"test.>"},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Create consumer
+	consumer, err := stream.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		Name: "test-consumer",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Get messages context
+	msgs, err := consumer.Messages()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Channel to receive the result from Next() call
+	errC := make(chan error, 1)
+
+	// Call Next() in a goroutine
+	go func() {
+		_, err := msgs.Next()
+		errC <- err
+	}()
+
+	// Give a moment for Next() to start waiting
+	time.Sleep(100 * time.Millisecond)
+
+	// Close the connection directly
+	nc.Close()
+
+	// Wait to see if Next() returns an error without calling Stop()
+	select {
+	case err := <-errC:
+		if err == nil {
+			t.Fatal("Expected Next() to return an error after connection closed")
+		}
+		// Should get ErrMsgIteratorClosed wrapped with ErrConnectionClosed
+		if !errors.Is(err, jetstream.ErrMsgIteratorClosed) {
+			t.Fatalf("Expected error to contain ErrMsgIteratorClosed, got: %v", err)
+		}
+		if !errors.Is(err, jetstream.ErrConnectionClosed) {
+			t.Fatalf("Expected error to contain ErrConnectionClosed, got: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Next() hung indefinitely after connection closed without calling Stop()")
+	}
+}
+
+func TestPullConsumerMessagesMaxReconnectsExceeded(t *testing.T) {
+	srv := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, srv)
+
+	nc, err := nats.Connect(srv.ClientURL(),
+		nats.MaxReconnects(3),
+		nats.ReconnectWait(10*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "test-stream",
+		Subjects: []string{"test.>"},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	consumer, err := stream.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		Name: "test-consumer",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	msgs, err := consumer.Messages()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	errC := make(chan error, 1)
+
+	go func() {
+		_, err := msgs.Next()
+		errC <- err
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Shutdown server to trigger reconnection attempts
+	shutdownJSServerAndRemoveStorage(t, srv)
+
+	select {
+	case err := <-errC:
+		if !errors.Is(err, jetstream.ErrMsgIteratorClosed) {
+			t.Fatalf("Expected error to contain ErrMsgIteratorClosed, got: %v", err)
+		}
+		if !errors.Is(err, jetstream.ErrConnectionClosed) {
+			t.Fatalf("Expected error to contain ErrConnectionClosed, got: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Timeout waiting for Next() to return an error after server shutdown")
+	}
+}
+
+func TestPullConsumerConsumeConnClose(t *testing.T) {
+	srv := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, srv)
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "test-stream",
+		Subjects: []string{"test.>"},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	consumer, err := stream.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		Name: "test-consumer",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	errC := make(chan error, 1)
+
+	consumeCtx, err := consumer.Consume(func(msg jetstream.Msg) {
+	}, jetstream.ConsumeErrHandler(func(cc jetstream.ConsumeContext, err error) {
+		errC <- err
+	}))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer consumeCtx.Stop()
+
+	time.Sleep(100 * time.Millisecond)
+
+	nc.Close()
+
+	select {
+	case err := <-errC:
+		if !errors.Is(err, jetstream.ErrConnectionClosed) {
+			t.Fatalf("Expected ErrConnectionClosed, got: %v", err)
+		}
+	case <-consumeCtx.Closed():
+		// Closed channel was triggered, but check if we also got an error
+		select {
+		case err := <-errC:
+			if !errors.Is(err, jetstream.ErrConnectionClosed) {
+				t.Fatalf("Expected ErrConnectionClosed, got: %v", err)
+			}
+		default:
+			t.Fatal("Consume was closed but no error was sent to error handler")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Consume did not return error after connection closed")
+	}
+}
+
+func TestPullConsumerConsumeMaxReconnectsExceeded(t *testing.T) {
+	srv := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, srv)
+
+	nc, err := nats.Connect(srv.ClientURL(),
+		nats.MaxReconnects(3),
+		nats.ReconnectWait(10*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "test-stream",
+		Subjects: []string{"test.>"},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	consumer, err := stream.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		Name: "test-consumer",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	errC := make(chan error, 1)
+
+	consumeCtx, err := consumer.Consume(func(msg jetstream.Msg) {
+	}, jetstream.ConsumeErrHandler(func(cc jetstream.ConsumeContext, err error) {
+		errC <- err
+	}))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer consumeCtx.Stop()
+
+	time.Sleep(100 * time.Millisecond)
+
+	shutdownJSServerAndRemoveStorage(t, srv)
+
+	select {
+	case err := <-errC:
+		if err == nil {
+			t.Fatal("Expected Consume to return an error after reconnection attempts exhausted")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Consume did not return error after reconnection attempts exhausted")
+	}
+}


### PR DESCRIPTION
Fixes #1875

JetStream consumer operations would hang indefinitely after server 
shutdown or connection closure.

Changes:
- Fixed core NATS closed handler bug for ChanSubscription and SyncSubscription  
- Added ErrConnectionClosed error for better error context
- Enhanced Consume() to report connection closure via ConsumeErrHandler
- Improved Next() to wrap ErrMsgIteratorClosed with ErrConnectionClosed

Both Messages().Next() and consumer.Consume() now properly handle connection 
closure and provide appropriate error reporting to applications.