### PR TITLE
[FIXED] KeyValue Keys() and ListKeys() returning duplicates

### DIFF
--- a/test/kv_test.go
+++ b/test/kv_test.go
@@ -1853,3 +1853,84 @@ func TestKeyValueWatcherStopTimer(t *testing.T) {
 	}
 	time.Sleep(500 * time.Millisecond)
 }
+
+func TestKeyValueListKeysDuplicates(t *testing.T) {
+	listKeysF := func(kv nats.KeyValue) ([]string, error) {
+		t.Helper()
+		lister, err := kv.ListKeys()
+		if err != nil {
+			return nil, fmt.Errorf("error listing keys: %v", err)
+		}
+		var keys []string
+		for key := range lister.Keys() {
+			keys = append(keys, key)
+		}
+		return keys, nil
+	}
+
+	keysF := func(kv nats.KeyValue) ([]string, error) {
+		t.Helper()
+		return kv.Keys()
+	}
+
+	for _, test := range []string{"ListKeys", "Keys"} {
+		t.Run(test, func(t *testing.T) {
+			s := RunBasicJetStreamServer()
+			defer shutdownJSServerAndRemoveStorage(t, s)
+
+			nc, js := jsClient(t, s)
+			defer nc.Close()
+
+			kv, err := js.CreateKeyValue(&nats.KeyValueConfig{Bucket: "TEST_KV", History: 5})
+			if err != nil {
+				t.Fatalf("Error creating KV: %v", err)
+			}
+
+			for i := range 10 {
+				key := fmt.Sprintf("key_%d", i)
+				if _, err := kv.PutString(key, "initial"); err != nil {
+					t.Fatalf("Error putting key %s: %v", key, err)
+				}
+			}
+
+			done := make(chan bool)
+			go func() {
+				// Continuously update existing keys
+				for {
+					select {
+					case <-done:
+						return
+					default:
+						for i := range 5 {
+							key := fmt.Sprintf("key_%d", i)
+							kv.PutString(key, "updated")
+						}
+					}
+				}
+			}()
+
+			// List keys multiple times while updates are happening
+			for range 20 {
+				var keys []string
+				if test == "Keys" {
+					keys, err = keysF(kv)
+				} else {
+					keys, err = listKeysF(kv)
+				}
+				if err != nil {
+					t.Fatalf("Error getting keys: %v", err)
+				}
+
+				seen := make(map[string]struct{})
+				for _, key := range keys {
+					if _, exists := seen[key]; exists {
+						t.Fatalf("Duplicate key found: %s", key)
+					}
+					seen[key] = struct{}{}
+				}
+			}
+
+			close(done)
+		})
+	}
+}


### PR DESCRIPTION
Use consumer pending count from creation time instead of first message
delta to fix race where concurrent updates could cause duplicate keys
during listing operations.

Fixed in both legacy and new JetStream APIs.