### PR TITLE
[ADDED] JetStream: Expose ClientTrace in JetStreamOptions

### DIFF
--- a/jetstream/api.go
+++ b/jetstream/api.go
@@ -127,8 +127,8 @@ func (js *jetStream) apiRequest(ctx context.Context, subj string, data ...[]byte
 	if len(data) > 0 {
 		req = data[0]
 	}
-	if js.opts.clientTrace != nil {
-		ctrace := js.opts.clientTrace
+	if js.opts.ClientTrace != nil {
+		ctrace := js.opts.ClientTrace
 		if ctrace.RequestSent != nil {
 			ctrace.RequestSent(subj, req)
 		}
@@ -137,8 +137,8 @@ func (js *jetStream) apiRequest(ctx context.Context, subj string, data ...[]byte
 	if err != nil {
 		return nil, err
 	}
-	if js.opts.clientTrace != nil {
-		ctrace := js.opts.clientTrace
+	if js.opts.ClientTrace != nil {
+		ctrace := js.opts.ClientTrace
 		if ctrace.ResponseReceived != nil {
 			ctrace.ResponseReceived(subj, resp.Data, resp.Header)
 		}

--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -315,6 +315,9 @@ type (
 		// a deadline set.
 		DefaultTimeout time.Duration
 
+		// ClientTrace enables request/response API calls tracing.
+		ClientTrace *ClientTrace
+
 		publisherOpts asyncPublisherOpts
 
 		// this is the actual prefix used in the API requests
@@ -322,7 +325,6 @@ type (
 		apiPrefix      string
 		replyPrefix    string
 		replyPrefixLen int
-		clientTrace    *ClientTrace
 	}
 
 	// ClientTrace can be used to trace API interactions for [JetStream].
@@ -528,7 +530,13 @@ func (js *jetStream) Conn() *nats.Conn {
 }
 
 func (js *jetStream) Options() JetStreamOptions {
-	return js.opts
+	opts := js.opts
+	// Return a copy of ClientTrace to prevent modification
+	if opts.ClientTrace != nil {
+		clientTraceCopy := *opts.ClientTrace
+		opts.ClientTrace = &clientTraceCopy
+	}
+	return opts
 }
 
 // CreateStream creates a new stream with given config and returns an

--- a/jetstream/jetstream_options.go
+++ b/jetstream/jetstream_options.go
@@ -31,7 +31,7 @@ func (fn pullOptFunc) configureMessages(opts *consumeOpts) error {
 // WithClientTrace enables request/response API calls tracing.
 func WithClientTrace(ct *ClientTrace) JetStreamOpt {
 	return func(opts *JetStreamOptions) error {
-		opts.clientTrace = ct
+		opts.ClientTrace = ct
 		return nil
 	}
 }

--- a/jetstream/kv.go
+++ b/jetstream/kv.go
@@ -834,10 +834,10 @@ func (js *jetStream) legacyJetStream() (nats.JetStreamContext, error) {
 	if js.opts.apiPrefix != "" {
 		opts = append(opts, nats.APIPrefix(js.opts.apiPrefix))
 	}
-	if js.opts.clientTrace != nil {
+	if js.opts.ClientTrace != nil {
 		opts = append(opts, nats.ClientTrace{
-			RequestSent:      js.opts.clientTrace.RequestSent,
-			ResponseReceived: js.opts.clientTrace.ResponseReceived,
+			RequestSent:      js.opts.ClientTrace.RequestSent,
+			ResponseReceived: js.opts.ClientTrace.ResponseReceived,
 		})
 	}
 	return js.conn.JetStream(opts...)


### PR DESCRIPTION
Make ClientTrace field publicly accessible through Options() method.
Returns a copy to maintain read-only contract.