### PR TITLE
Fixed stream info request for strict mode

### DIFF
--- a/jetstream/stream.go
+++ b/jetstream/stream.go
@@ -138,7 +138,7 @@ type (
 	StreamInfoOpt func(*streamInfoRequest) error
 
 	streamInfoRequest struct {
-		apiPaged
+		apiPagedRequest
 		DeletedDetails bool   `json:"deleted_details,omitempty"`
 		SubjectFilter  string `json:"subjects_filter,omitempty"`
 	}


### PR DESCRIPTION
The (new) JS stream info API would log the following in the server:
```
Invalid JetStream request '$G > $JS.API.STREAM.INFO.<KV_bucket_name>': json: unknown field "total"
```

This was due to the inclusion of the `total` field. Should use the `apiPagedRequest` instead. Current 2.11 servers log this warning, and requests will be fully rejected if strict mode is turned on (which might become the default for 2.12).