### PR TITLE
[ADDED] Channel-based Error() method to KeyLister and KeyWatcher interfaces

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -115,12 +115,22 @@ type KeyWatcher interface {
 	Updates() <-chan KeyValueEntry
 	// Stop will stop this watcher.
 	Stop() error
+	// Error returns a channel that will receive any error that occurs during
+	// watching. In particular, this will receive an error if the watcher times
+	// out while expecting more initial keys. The channel is closed when the
+	// watch operation completes or when Stop() is called.
+	Error() <-chan error
 }
 
 // KeyLister is used to retrieve a list of key value store keys
 type KeyLister interface {
 	Keys() <-chan string
 	Stop() error
+	// Error returns a channel that will receive any error that occurs during
+	// key listing. In particular, this will receive an error if the underlying
+	// watcher times out while expecting more keys. The channel is closed when
+	// the listing operation completes or when Stop() is called.
+	Error() <-chan error
 }
 
 type WatchOpt interface {
@@ -331,6 +341,7 @@ var (
 	ErrKeyDeleted             = errors.New("nats: key was deleted")
 	ErrHistoryToLarge         = errors.New("nats: history limited to a max of 64")
 	ErrNoKeysFound            = errors.New("nats: no keys found")
+	ErrKeyWatcherTimeout      = errors.New("nats: key watcher timed out waiting for initial keys")
 )
 
 var (
@@ -911,6 +922,10 @@ func (kl *keyLister) Stop() error {
 	return kl.watcher.Stop()
 }
 
+func (kl *keyLister) Error() <-chan error {
+	return kl.watcher.Error()
+}
+
 // History will return all values for the key.
 func (kv *kvs) History(key string, opts ...WatchOpt) ([]KeyValueEntry, error) {
 	opts = append(opts, IncludeHistory())
@@ -943,6 +958,7 @@ type watcher struct {
 	received      uint64
 	ctx           context.Context
 	initDoneTimer *time.Timer
+	errCh         chan error
 }
 
 // Context returns the context for the watcher if set.
@@ -967,6 +983,14 @@ func (w *watcher) Stop() error {
 		return nil
 	}
 	return w.sub.Unsubscribe()
+}
+
+// Error returns a channel that will receive any error that occurs during watching.
+func (w *watcher) Error() <-chan error {
+	if w == nil {
+		return nil
+	}
+	return w.errCh
 }
 
 // WatchAll watches all keys.
@@ -1006,7 +1030,11 @@ func (kv *kvs) WatchFiltered(keys []string, opts ...WatchOpt) (KeyWatcher, error
 	}
 
 	// We will block below on placing items on the chan. That is by design.
-	w := &watcher{updates: make(chan KeyValueEntry, 256), ctx: o.ctx}
+	w := &watcher{
+		updates: make(chan KeyValueEntry, 256),
+		ctx:     o.ctx,
+		errCh:   make(chan error, 1),
+	}
 
 	update := func(m *Msg) {
 		tokens, err := parser.GetMetadataFields(m.Reply)
@@ -1108,6 +1136,10 @@ func (kv *kvs) WatchFiltered(keys []string, opts ...WatchOpt) (KeyWatcher, error
 				defer w.mu.Unlock()
 				if !w.initDone {
 					w.initDone = true
+					select {
+					case w.errCh <- ErrKeyWatcherTimeout:
+					default:
+					}
 					w.updates <- nil
 				}
 			})
@@ -1124,6 +1156,7 @@ func (kv *kvs) WatchFiltered(keys []string, opts ...WatchOpt) (KeyWatcher, error
 			w.initDoneTimer.Stop()
 		}
 		close(w.updates)
+		close(w.errCh)
 	}
 
 	sub.mu.Unlock()


### PR DESCRIPTION
The new Error() method returns <-chan error, enabling concurrent error
handling with select statements. This allows immediate detection of
timeout errors during key listing/watching operations.

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>