### PR TITLE
[Added] option WithProtocolTrace to enable protocol tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,22 +83,23 @@ nc.Close()
 
 ## Connection Tracing
 
-For debugging NATS protocol interactions, you can enable connection tracing to see all data sent and received:
+For debugging NATS protocol interactions, you can enable tracing to see all data sent and received:
 
 ```go
-// Enable tracing to stdout
-nc, err := nats.Connect(nats.DefaultURL, nats.WithConnTrace(nats.NewStdoutTrace()))
+// Enable tracing to stderr
+nc, err := nats.Connect(nats.DefaultURL, nats.WithProtocolTrace(nats.NewStderrTrace()))
 
 // Custom tracing with your own handlers
-trace := &nats.ConnTrace{
+logger := log.New(os.Stderr, "", 0)
+trace := &nats.ProtocolTrace{
     DataSent: func(data []byte) {
-        fmt.Printf("NATS >>> %s", data)
+        logger.Printf("NATS >>> %s", data)
     },
     DataReceived: func(data []byte) {
-        fmt.Printf("NATS <<< %s", data)
+        logger.Printf("NATS <<< %s", data)
     },
 }
-nc, err := nats.Connect(nats.DefaultURL, nats.WithConnTrace(trace))
+nc, err := nats.Connect(nats.DefaultURL, nats.WithProtocolTrace(trace))
 ```
 
 ## JetStream


### PR DESCRIPTION
This was claude code generated/human verified,
based on https://github.com/nats-io/nats.go/pull/911
and https://github.com/nats-io/nats.go/pull/334#issuecomment-352613677
And similar to [debug option in nats.js](https://nats-io.github.io/nats.js/core/index.html#connection-options)

We can copy-paste the tracing snippet that @kozlovic shows in the second link(I found it extremely useful), but why don't we make it part of the client, so it is easy to do just:

```
nc, err := nats.Connect(nats.DefaultURL, nats.WithProtocolTrace(nats.NewStderrTrace()))
```
and easily see all the nitty-gritty details from the wire
![image](https://github.com/user-attachments/assets/a4d4ee87-817c-4d64-94c9-fc8b5fc578cc)
in any program or test

