### PR TITLE
[FIXED] Use timeout from JetStreamContext if no deadline is set on ctx

### DIFF
--- a/jsm.go
+++ b/jsm.go
@@ -1778,6 +1778,11 @@ func getJSContextOpts(defs *jsOpts, opts ...JSOpt) (*jsOpts, context.CancelFunc,
 	if o.pre == _EMPTY_ {
 		o.pre = defs.pre
 	}
-
+	if o.ctx != nil {
+		// if context does not have a deadline, use timeout from js context
+		if _, hasDeadline := o.ctx.Deadline(); !hasDeadline {
+			o.ctx, cancel = context.WithTimeout(o.ctx, defs.wait)
+		}
+	}
 	return &o, cancel, nil
 }


### PR DESCRIPTION
Legacy JetStream API calls could block indefinitely if `nats.Context` was used without deadline. This PR changes this so that a timeout from JetStreamContext will be used instead.

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)