### PR TITLE
Release v1.44.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 go get github.com/nats-io/nats.go@latest
 
 # To get a specific version:
-go get github.com/nats-io/nats.go@v1.43.0
+go get github.com/nats-io/nats.go@v1.44.0
 
 # Note that the latest major version for NATS Server is v2:
 go get github.com/nats-io/nats-server/v2@latest

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.43.0"
+	Version                   = "1.44.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
## Changelog

## Overview

This PR adds a `PushConsumer` implementation to `jetstream`, allowing easier migration to new API while maintaining usage of push consumers. For now it only supports the callback-based `Consume()`, more consuming options will be added in future releases.

### ADDED
- Core NATS:
  - `UserCredentialBytes()` `Conn` option (#1877)
- JetStream:
  - `PushConsumer` implementation in `jetstream` package 
  - Expose `ClientTrace` in `JetStreamOptions` (#1886) 
- Service API:
  - Expose `WithEndpointPendingLimits` option (#1899)
- Legacy KeyValue:
  - `Error()` method to `KeyLister` and `KeyWatcher` interfaces (#1889)

### FIXED
- Core NATS:
  -  Fix timeoutWriter not recovering after first error (#1896)
- JetStream:
  - `Consumer.Next()` hangs after connection is closed (#1883)
  - Fixed stream info request for strict mode (#1887)
  - Ordered consumer not closing on connection close (#1885)
  - Return a more appropriate error when Subject Transform is not supported (#1416)
  - Fix subject transform comparison (#1907)
- Legacy JetStream:
  - Use timeout from `JetStreamContext` if no deadline is set on ctx (#1909)
- KeyValue:
  - `Keys()` and `ListKeys()` returning duplicates (#1884)
  - Fix subject prefix for the Create/Update operation in KV store (#1903)

### CHANGED
-  Change `DefaultSubPendingMsgsLimit` (#998) 

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)