### PR TITLE
Add web socket custom headers support in nats go client

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -146,6 +146,7 @@ var (
 	ErrMaxConnectionsExceeded      = errors.New("nats: server maximum connections exceeded")
 	ErrConnectionNotTLS            = errors.New("nats: connection is not tls")
 	ErrMaxSubscriptionsExceeded    = errors.New("nats: server maximum subscriptions exceeded")
+	ErrWebSocketHeadersAlreadySet  = errors.New("nats: websocket connection headers already set")
 )
 
 // GetDefaultOptions returns default configuration options for the client.
@@ -244,6 +245,9 @@ type UserInfoCB func() (string, string)
 // again. Note that this is invoked after the library tried the
 // whole list of URLs and failed to reconnect.
 type ReconnectDelayHandler func(attempts int) time.Duration
+
+// WebSocketHeadersHandler is an optional callback handler for generating token used for WebSocket connections.
+type WebSocketHeadersHandler func() (http.Header, error)
 
 // asyncCB is used to preserve order for async callbacks.
 type asyncCB struct {
@@ -519,6 +523,12 @@ type Options struct {
 	// from SubscribeSync if the server returns a permissions error for a subscription.
 	// Defaults to false.
 	PermissionErrOnSubscribe bool
+
+	// WebSocketConnectionHeaders is an optional http request headers to be sent with the WebSocket request.
+	WebSocketConnectionHeaders http.Header
+
+	// WebSocketConnectionHeadersHandler is an optional callback handler for generating token  used for WebSocket connections.
+	WebSocketConnectionHeadersHandler WebSocketHeadersHandler
 }
 
 const (
@@ -1463,6 +1473,26 @@ func TLSHandshakeFirst() Option {
 	return func(o *Options) error {
 		o.TLSHandshakeFirst = true
 		o.Secure = true
+		return nil
+	}
+}
+
+func WebSocketConnectionHeaders(headers http.Header) Option {
+	return func(o *Options) error {
+		if o.WebSocketConnectionHeadersHandler != nil {
+			return ErrWebSocketHeadersAlreadySet
+		}
+		o.WebSocketConnectionHeaders = headers
+		return nil
+	}
+}
+
+func WebSocketConnectionHeadersHandler(cb WebSocketHeadersHandler) Option {
+	return func(o *Options) error {
+		if o.WebSocketConnectionHeaders != nil && len(o.WebSocketConnectionHeaders) != 0 {
+			return ErrWebSocketHeadersAlreadySet
+		}
+		o.WebSocketConnectionHeadersHandler = cb
 		return nil
 	}
 }

--- a/test/ws_test.go
+++ b/test/ws_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"net/http"
 	"runtime"
 	"strings"
 	"sync"
@@ -610,4 +611,90 @@ func TestWSNoDeadlockOnAuthFailure(t *testing.T) {
 	}
 
 	tm.Stop()
+}
+
+func TestWsWithCustomHeaders(t *testing.T) {
+	sopts := testWSGetDefaultOptions(t, false)
+	s := RunServerWithOptions(sopts)
+	defer s.Shutdown()
+
+	staticHeader := make(http.Header, 0)
+	staticHeader.Set("Authorization", "Bearer Random Token")
+
+	headerProvider := func() (http.Header, error) {
+		return staticHeader, nil
+	}
+
+	for _, test := range []struct {
+		name              string
+		connectionOptions []nats.Option
+		wantErr           bool
+	}{
+		{
+			name: "Failure 1: Both headers and handler present",
+			connectionOptions: []nats.Option{
+				nats.WebSocketConnectionHeadersHandler(headerProvider),
+				nats.WebSocketConnectionHeaders(staticHeader),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Success 1: Headers present as static headers",
+			connectionOptions: []nats.Option{
+				nats.WebSocketConnectionHeaders(staticHeader),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Success 2: Header supplied through handler",
+			connectionOptions: []nats.Option{
+				nats.WebSocketConnectionHeadersHandler(headerProvider),
+			},
+			wantErr: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			url := fmt.Sprintf("ws://127.0.0.1:%d", sopts.Websocket.Port)
+			nc, err := nats.Connect(url, test.connectionOptions...)
+			if err != nil && test.wantErr {
+				return
+			}
+			if err != nil && !test.wantErr {
+				t.Fatalf("Error connecting to nats server: %v", err)
+			}
+			defer nc.Close()
+			sub, err := nc.SubscribeSync("foo")
+			if err != nil {
+				t.Fatalf("Error on subscribe: %v", err)
+			}
+
+			msgs := make([][]byte, 100)
+			for i := 0; i < len(msgs); i++ {
+				msg := make([]byte, 100)
+				for j := 0; j < len(msg); j++ {
+					msg[j] = 'A'
+				}
+				msgs[i] = msg
+			}
+			for i, msg := range msgs {
+				if err := nc.Publish("foo", msg); err != nil {
+					t.Fatalf("Error on publish: %v", err)
+				}
+				// Make sure that compression/masking does not touch user data
+				if !bytes.Equal(msgs[i], msg) {
+					t.Fatalf("User content has been changed: %v, got %v", msgs[i], msg)
+				}
+			}
+
+			for i := 0; i < len(msgs); i++ {
+				msg, err := sub.NextMsg(time.Second)
+				if err != nil {
+					t.Fatalf("Error getting next message (%d): %v", i+1, err)
+				}
+				if !bytes.Equal(msgs[i], msg.Data) {
+					t.Fatalf("Expected message (%d): %v, got %v", i+1, msgs[i], msg)
+				}
+			}
+		})
+	}
 }

--- a/test/ws_test.go
+++ b/test/ws_test.go
@@ -620,7 +620,6 @@ func TestWsWithCustomHeaders(t *testing.T) {
 
 	staticHeader := make(http.Header, 0)
 	staticHeader.Set("Authorization", "Bearer Random Token")
-
 	headerProvider := func() (http.Header, error) {
 		return staticHeader, nil
 	}
@@ -660,7 +659,7 @@ func TestWsWithCustomHeaders(t *testing.T) {
 				return
 			}
 			if err != nil && !test.wantErr {
-				t.Fatalf("Error connecting to nats server: %v", err)
+				t.Fatalf("Did not expect error, found error: %v", err)
 			}
 			defer nc.Close()
 			sub, err := nc.SubscribeSync("foo")


### PR DESCRIPTION
This pull request introduces support for custom headers in WebSocket connections to the NATS server. The key changes include:

Provision for supplying custom WebSocket request headers — developers can now attach additional HTTP headers (e.g., authorization tokens or tracing metadata) when establishing a WebSocket connection via NATS Go.

A reference to a related issue in the .NET client repository (https://github.com/nats-io/nats.net/issues/305) highlights the broader context and motivation for this enhancement

Usage:
You can provide static headers using nats connection option WebSocketConnectionHeaders
```go
staticHeader := make(http.Header, 0)
staticHeader.Set("Authorization", "Bearer ${TOKEN}")
nc, err := nats.Connect(url, nats.WebSocketConnectionHeaders(staticHeader))
````

You can also provide a handler that supplies headers using WebSocketConnectionHeadersHandler connection option.

```go
headerProvider := func() (http.Header, error) {
		var headers http.Header
		// your logic to get headers
		return headers, nil
	}
nc, err := nats.Connect(url, nats.WebSocketConnectionHeadersHandler(headerProvider))
```