### PR TITLE
Add WithExpectLastSequenceForSubject publish option

### DIFF
--- a/jetstream/jetstream_options.go
+++ b/jetstream/jetstream_options.go
@@ -587,6 +587,21 @@ func WithExpectLastSequencePerSubject(seq uint64) PublishOpt {
 	}
 }
 
+// WithExpectLastSequenceForSubject sets the sequence and subject for which the
+// last sequence number should be checked. If the last message on a subject
+// has a different sequence number server will reject the message and publish
+// will fail.
+func WithExpectLastSequenceForSubject(seq uint64, subject string) PublishOpt {
+	return func(opts *pubOpts) error {
+		if subject == "" {
+			return fmt.Errorf("%w: subject cannot be empty", ErrInvalidOption)
+		}
+		opts.lastSubjectSeq = &seq
+		opts.lastSubject = subject
+		return nil
+	}
+}
+
 // WithExpectLastMsgID sets the expected message ID the last message on a stream
 // should have. If the last message has a different message ID server will
 // reject the message and publish will fail.

--- a/jetstream/message.go
+++ b/jetstream/message.go
@@ -191,6 +191,12 @@ const (
 	// [WithExpectLastSequencePerSubject] option.
 	ExpectedLastSubjSeqHeader = "Nats-Expected-Last-Subject-Sequence"
 
+	// ExpectedLastSubjSeqSubjHeader contains the subject for which the
+	// expected last sequence number is set. This is used together with
+	// [ExpectedLastSubjSeqHeader] to apply optimistic concurrency control at
+	// subject level. Server will reject the message if it is not the case.
+	ExpectedLastSubjSeqSubjHeader = "Nats-Expected-Last-Subject-Sequence-Subject"
+
 	// ExpectedLastMsgIDHeader contains the expected last message ID on the
 	// subject and can be used to apply optimistic concurrency control at
 	// stream level. Server will reject the message if it is not the case.

--- a/jetstream/publish.go
+++ b/jetstream/publish.go
@@ -47,7 +47,8 @@ type (
 		lastMsgID      string        // Expected last msgId
 		stream         string        // Expected stream name
 		lastSeq        *uint64       // Expected last sequence
-		lastSubjectSeq *uint64       // Expected last sequence per subject
+		lastSubjectSeq *uint64       // Expected last sequence for subject
+		lastSubject    string        // Expected subject for last sequence
 		ttl            time.Duration // Message TTL
 
 		// Publish retries for NoResponders err.
@@ -195,6 +196,10 @@ func (js *jetStream) PublishMsg(ctx context.Context, m *nats.Msg, opts ...Publis
 	if o.lastSubjectSeq != nil {
 		m.Header.Set(ExpectedLastSubjSeqHeader, strconv.FormatUint(*o.lastSubjectSeq, 10))
 	}
+	if o.lastSubject != "" {
+		m.Header.Set(ExpectedLastSubjSeqSubjHeader, o.lastSubject)
+		m.Header.Set(ExpectedLastSubjSeqHeader, strconv.FormatUint(*o.lastSubjectSeq, 10))
+	}
 	if o.ttl > 0 {
 		m.Header.Set(MsgTTLHeader, o.ttl.String())
 	}
@@ -279,6 +284,10 @@ func (js *jetStream) PublishMsgAsync(m *nats.Msg, opts ...PublishOpt) (PubAckFut
 		m.Header.Set(ExpectedLastSeqHeader, strconv.FormatUint(*o.lastSeq, 10))
 	}
 	if o.lastSubjectSeq != nil {
+		m.Header.Set(ExpectedLastSubjSeqHeader, strconv.FormatUint(*o.lastSubjectSeq, 10))
+	}
+	if o.lastSubject != "" {
+		m.Header.Set(ExpectedLastSubjSeqSubjHeader, o.lastSubject)
 		m.Header.Set(ExpectedLastSubjSeqHeader, strconv.FormatUint(*o.lastSubjectSeq, 10))
 	}
 	if o.ttl > 0 {


### PR DESCRIPTION
This utilizes the Nats-Expected-Last-Subject-Sequence-Subject header that became available in 2.11.0.

Signed-off-by: Byron Ruth <byron@nats.io>