### PR TITLE
Release v1.45.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 go get github.com/nats-io/nats.go@latest
 
 # To get a specific version:
-go get github.com/nats-io/nats.go@v1.44.0
+go get github.com/nats-io/nats.go@v1.45.0
 
 # Note that the latest major version for NATS Server is v2:
 go get github.com/nats-io/nats-server/v2@latest

--- a/nats.go
+++ b/nats.go
@@ -48,7 +48,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.44.0"
+	Version                   = "1.45.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
## Changelog

### ADDED
- Core NATS:
  - `WithExpectLastSequenceForSubject` publish option (#1920)
- JetStream:
  - Handling for maximum account active connections exceeded (#1921)

### FIXED
- Core NATS:
  - Track delivered count and auto-unsubscribe for channel subscriptions (#1913)
  - Clear status listeners map on `SubscriptionClosed` event to prevent race condition (#1914)
  - Call `ReconnectErrHandler` for initial connection failures with `RetryOnFailedConnect` (#1915)
- JetStream:
  - `CreateOrUpdateStream` preserves domain prefix during updates (#1917)
  - Handle empty response when creating a consumer (#1912)

### IMPROVED
- KeyValue:
  - Add test checking KV TTL watcher updates (#1916)

### Complete Changes

https://github.com/nats-io/nats.go/compare/v1.44.0...v1.45.0