### PR TITLE
Release v1.46.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 go get github.com/nats-io/nats.go@latest
 
 # To get a specific version:
-go get github.com/nats-io/nats.go@v1.45.0
+go get github.com/nats-io/nats.go@v1.46.0
 
 # Note that the latest major version for NATS Server is v2:
 go get github.com/nats-io/nats-server/v2@latest

--- a/nats.go
+++ b/nats.go
@@ -48,7 +48,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.45.0"
+	Version                   = "1.46.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
### Overview
This release enables features introduced in [nats-server@v2.12.0](https://github.com/nats-io/nats-server/releases/tag/v2.12.0).

### ADDED
- JetStream:
  - Stream counters configuration option (#1932, #1939)
  - New fields in `ClusterInfo` (#1935)
  - `AllowAtomicPublish` stream configuration option (#1940)
  - `PersistMode` stream config option for configurable stream persistence settings (#1943)
  - `AllowMsgSchedules` stream configuration option to enable message scheduling (#1942)
  - Context and timeout options to `Messages.Next()` plus `Fetch` context support (#1938)
  - Support custom name prefix for ordered consumers (#1928)
- KeyValue:
  - Added KeyValue bucket metadada support (#1944)

### IMPROVED
- JetStream:
  - Add max consumers limit error (code=10026) (#1922)
  - Return more specific cons info error on ordered consumer recreation (#1931)

### Complete Changes

https://github.com/nats-io/nats.go/compare/v1.45.0...v1.46.0

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>