### PR TITLE
[FIXED] Fix function pointer check in js.apiRequestWithContext()

### DIFF
--- a/js.go
+++ b/js.go
@@ -3560,7 +3560,7 @@ func (js *js) apiRequestWithContext(ctx context.Context, subj string, data []byt
 	}
 	if js.opts.shouldTrace {
 		ctrace := js.opts.ctrace
-		if ctrace.RequestSent != nil {
+		if ctrace.ResponseReceived != nil {
 			ctrace.ResponseReceived(subj, resp.Data, resp.Header)
 		}
 	}


### PR DESCRIPTION
Most likely a copy'n'paste bug, the code should check the function pointer that it is about to call.