### PR TITLE
[FIXED] Fix data race when closing watcher updates channel in kv.go

### DIFF
--- a/jetstream/kv.go
+++ b/jetstream/kv.go
@@ -1291,6 +1291,8 @@ func (kv *kvs) WatchFiltered(ctx context.Context, keys []string, opts ...WatchOp
 		return nil, err
 	}
 	sub.SetClosedHandler(func(_ string) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
 		close(w.updates)
 	})
 	// If there were no pending messages at the time of the creation


### PR DESCRIPTION
Fixes #1964

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)