### PR TITLE
Fix subject validation to reject whitespace characters

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -4079,7 +4079,7 @@ func (nc *Conn) publish(subj, reply string, hdr, data []byte) error {
 	if nc == nil {
 		return ErrInvalidConnection
 	}
-	if subj == "" {
+	if badSubject(subj) {
 		return ErrBadSubject
 	}
 	nc.mu.Lock()

--- a/test/nats_test.go
+++ b/test/nats_test.go
@@ -653,6 +653,15 @@ func TestBadSubjectsAndQueueNames(t *testing.T) {
 		}
 	}
 
+	// Also test that bad subjects are rejected in Publish
+	// This prevents protocol violations
+	badPubs := []string{"foo bar", "foo..bar", ".foo", "bar.baz.", "baz\t.foo", "test\nfoo", "test\rfoo", ""}
+	for _, subj := range badPubs {
+		if err := nc.Publish(subj, []byte("test")); err != nats.ErrBadSubject {
+			t.Fatalf("Expected an error of ErrBadSubject for publish to %q, got %v", subj, err)
+		}
+	}
+
 	badQueues := []string{"foo group", "group\t1", "g1\r\n2"}
 	for _, q := range badQueues {
 		if _, err := nc.QueueSubscribeSync("foo", q); err != nats.ErrBadQueueName {


### PR DESCRIPTION
Fixes issue where publishing to a subject containing whitespace characters causes a Protocol Violation error and disconnects the client.

  **Changes**
  - Added validation in publish() to reject subjects containing whitespace
  - Added unit tests for whitespace scenarios

  Resolves #1809