### PR TITLE
[IMPROVED] Re-add subject validation

### DIFF
--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -172,3 +172,86 @@ func BenchmarkOldRequest(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkPublishValidation(b *testing.B) {
+	msgPayload := []byte("test")
+	shortSubject := "foo.bar"                                      // 7 chars
+	longSubject := "metrics.production.server01.cpu.usage.percent" // 45 chars
+
+	b.Run("skip validation, short subject", func(b *testing.B) {
+		s := RunDefaultServer()
+		defer s.Shutdown()
+
+		nc, err := nats.Connect(s.ClientURL(), nats.SkipSubjectValidation())
+		if err != nil {
+			b.Fatalf("Failed to connect: %v", err)
+		}
+		defer nc.Close()
+
+		b.ResetTimer()
+		for b.Loop() {
+			if err := nc.Publish(shortSubject, msgPayload); err != nil {
+				b.Fatalf("Error publishing message: %v", err)
+			}
+		}
+		nc.Flush()
+		b.StopTimer()
+	})
+	b.Run("skip validation, long subject", func(b *testing.B) {
+		s := RunDefaultServer()
+		defer s.Shutdown()
+
+		nc, err := nats.Connect(s.ClientURL(), nats.SkipSubjectValidation())
+		if err != nil {
+			b.Fatalf("Failed to connect: %v", err)
+		}
+		defer nc.Close()
+
+		b.ResetTimer()
+		for b.Loop() {
+			if err := nc.Publish(longSubject, msgPayload); err != nil {
+				b.Fatalf("Error publishing message: %v", err)
+			}
+		}
+		nc.Flush()
+		b.StopTimer()
+	})
+	b.Run("with validation, short subject", func(b *testing.B) {
+		s := RunDefaultServer()
+		defer s.Shutdown()
+
+		nc, err := nats.Connect(s.ClientURL())
+		if err != nil {
+			b.Fatalf("Failed to connect: %v", err)
+		}
+		defer nc.Close()
+
+		b.ResetTimer()
+		for b.Loop() {
+			if err := nc.Publish(shortSubject, msgPayload); err != nil {
+				b.Fatalf("Error publishing message: %v", err)
+			}
+		}
+		nc.Flush()
+		b.StopTimer()
+	})
+	b.Run("with validation, long subject", func(b *testing.B) {
+		s := RunDefaultServer()
+		defer s.Shutdown()
+
+		nc, err := nats.Connect(s.ClientURL())
+		if err != nil {
+			b.Fatalf("Failed to connect: %v", err)
+		}
+		defer nc.Close()
+
+		b.ResetTimer()
+		for b.Loop() {
+			if err := nc.Publish(longSubject, msgPayload); err != nil {
+				b.Fatalf("Error publishing message: %v", err)
+			}
+		}
+		nc.Flush()
+		b.StopTimer()
+	})
+}

--- a/test/nats_test.go
+++ b/test/nats_test.go
@@ -1194,3 +1194,20 @@ func TestInProcessConn(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestSkipSubjectValidation(t *testing.T) {
+	s := RunServerOnPort(-1)
+	defer s.Shutdown()
+
+	nc, err := nats.Connect(s.ClientURL(), nats.SkipSubjectValidation())
+	if err != nil {
+		t.Fatalf("Expected to connect to server, got %v", err)
+	}
+	defer nc.Close()
+
+	// Try to publish to a bad subject.
+	badSubj := "foo bar"
+	if err := nc.Publish(badSubj, []byte("hello")); err != nil {
+		t.Fatalf("Expected to publish to bad subject %q, got error: %v", badSubj, err)
+	}
+}


### PR DESCRIPTION
This re-adds subject validation, also adding Conn option to skip it and benchmarks.

Benchmark results:
```
goos: darwin
goarch: arm64
pkg: github.com/nats-io/nats.go/test
cpu: Apple M1 Pro
BenchmarkPublishValidation
BenchmarkPublishValidation/skip_validation,_short_subject
BenchmarkPublishValidation/skip_validation,_short_subject-10         	11640670	       104.4 ns/op	       7 B/op	       0 allocs/op
BenchmarkPublishValidation/skip_validation,_long_subject
BenchmarkPublishValidation/skip_validation,_long_subject-10          	 5791136	       215.9 ns/op	      47 B/op	       0 allocs/op
BenchmarkPublishValidation/with_validation,_short_subject
BenchmarkPublishValidation/with_validation,_short_subject-10         	12151098	       104.8 ns/op	       7 B/op	       0 allocs/op
BenchmarkPublishValidation/with_validation,_long_subject
BenchmarkPublishValidation/with_validation,_long_subject-10          	 5686694	       216.0 ns/op	      47 B/op	       0 allocs/op
```

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)