### PR TITLE
[FIXED] Fix nil pointer dereference in ConsumerInfo

### DIFF
--- a/js.go
+++ b/js.go
@@ -2835,12 +2835,15 @@ func ConsumerFilterSubjects(subjects ...string) SubOpt {
 func (sub *Subscription) ConsumerInfo() (*ConsumerInfo, error) {
 	sub.mu.Lock()
 	// TODO(dlc) - Better way to mark especially if we attach.
-	if sub.jsi == nil || sub.jsi.consumer == _EMPTY_ {
-		if sub.jsi.ordered {
-			sub.mu.Unlock()
+	if sub.jsi == nil {
+		sub.mu.Unlock()
+		return nil, ErrTypeSubscription
+	} else if sub.jsi.consumer == _EMPTY_ {
+		ordered := sub.jsi.ordered
+		sub.mu.Unlock()
+		if ordered {
 			return nil, ErrConsumerInfoOnOrderedReset
 		}
-		sub.mu.Unlock()
 		return nil, ErrTypeSubscription
 	}
 

--- a/test/nats_test.go
+++ b/test/nats_test.go
@@ -661,6 +661,27 @@ func TestBadSubjectsAndQueueNames(t *testing.T) {
 	}
 }
 
+func TestTypeSubscription(t *testing.T) {
+	s := RunServerOnPort(TEST_PORT)
+	defer s.Shutdown()
+
+	nc, err := nats.Connect(fmt.Sprintf("127.0.0.1:%d", TEST_PORT))
+	if err != nil {
+		t.Fatalf("Error connecting: %v", err)
+	}
+	defer nc.Close()
+
+	// Make sure that ConsumerInfo() returns invalid subscription type error
+	sub, err := nc.Subscribe("foo", func(_ *nats.Msg) {})
+	if err != nil {
+		t.Fatalf("Error subscribing: %v", err)
+	}
+
+	if _, err := sub.ConsumerInfo(); err != nats.ErrTypeSubscription {
+		t.Fatalf("Expected an error about invalid subscription type, got %v", err)
+	}
+}
+
 func BenchmarkNextMsgNoTimeout(b *testing.B) {
 	s := RunServerOnPort(TEST_PORT)
 	defer s.Shutdown()


### PR DESCRIPTION
Resolves #1986.

Also add test case that checks that correct error is returned when no jetstream is avalilable on subscription.

Signed-off-by: John Smith <johnysfao@gmail.com>