### PR TITLE
Fix expected error in test for stream name requirement

### DIFF
--- a/jetstream/test/errors_test.go
+++ b/jetstream/test/errors_test.go
@@ -163,7 +163,7 @@ func TestJetStreamErrors(t *testing.T) {
 
 		// check directly to var (backwards compatible)
 		if err != jetstream.ErrStreamNameRequired {
-			t.Fatalf("Expected: %v; got: %v", jetstream.ErrInvalidStreamName, err)
+			t.Fatalf("Expected: %v; got: %v", jetstream.ErrStreamNameRequired, err)
 		}
 
 		// matching via errors.Is


### PR DESCRIPTION
This PR fixes an incorrect error constant in a test failure message 
where the error message doesn't match the actual error being tested.