### PR TITLE
Fix incorrect comments for JetStream API constants

### DIFF
--- a/jetstream/api.go
+++ b/jetstream/api.go
@@ -50,11 +50,11 @@ const (
 	// apiConsumerCreateT is used to create consumers.
 	apiConsumerCreateT = "CONSUMER.CREATE.%s.%s"
 
-	// apiConsumerCreateT is used to create consumers.
+	// apiConsumerCreateWithFilterSubjectT is used to create consumers with a filter subject.
 	// it accepts stream name, consumer name and filter subject
 	apiConsumerCreateWithFilterSubjectT = "CONSUMER.CREATE.%s.%s.%s"
 
-	// apiConsumerInfoT is used to create consumers.
+	// apiConsumerInfoT is used to retrieve consumer information.
 	apiConsumerInfoT = "CONSUMER.INFO.%s.%s"
 
 	// apiRequestNextT is the prefix for the request next message(s) for a consumer in worker/pull mode.
@@ -96,7 +96,7 @@ const (
 	// apiMsgGetT is the endpoint to get a message.
 	apiMsgGetT = "STREAM.MSG.GET.%s"
 
-	// apiMsgGetT is the endpoint to perform a direct get of a message.
+	// apiDirectMsgGetT is the endpoint to perform a direct get of a message.
 	apiDirectMsgGetT = "DIRECT.GET.%s"
 
 	// apiDirectMsgGetLastBySubjectT is the endpoint to perform a direct get of a message by subject.


### PR DESCRIPTION
Seems like three copy-paste errors in constant comments that don't match their actual purpose.