### PR TITLE
fix bug in constant name TimeStampHeader

### DIFF
--- a/jetstream/message.go
+++ b/jetstream/message.go
@@ -227,8 +227,8 @@ const (
 	// SequenceHeader contains the original sequence number of the message.
 	SequenceHeader = "Nats-Sequence"
 
-	// TimeStampHeader contains the original timestamp of the message.
-	TimeStampHeader = "Nats-Time-Stamp"
+	// TimeStampHeaer contains the original timestamp of the message.
+	TimeStampHeaer = "Nats-Time-Stamp"
 
 	// SubjectHeader contains the original subject the message was published to.
 	SubjectHeader = "Nats-Subject"

--- a/jetstream/stream.go
+++ b/jetstream/stream.go
@@ -622,7 +622,7 @@ func convertDirectGetMsgResponseToMsg(r *nats.Msg) (*RawStreamMsg, error) {
 	if err != nil {
 		return nil, fmt.Errorf("nats: invalid sequence header '%s': %v", seqStr, err)
 	}
-	timeStr := r.Header.Get(TimeStampHeader)
+	timeStr := r.Header.Get(TimeStampHeaer)
 	if timeStr == "" {
 		return nil, errors.New("nats: missing timestamp header")
 	}


### PR DESCRIPTION
Fixed misspelled exported constant TimeStampHeaer to TimeStampHeader, corrected a fe typos and improved doc comments.