### PR TITLE
Reset the TTL when calling `kv.Update()`

### DIFF
--- a/jetstream/test/kv_test.go
+++ b/jetstream/test/kv_test.go
@@ -2009,6 +2009,10 @@ func TestKeyValueLimitMarkerTTL(t *testing.T) {
 
 		_, err = kv.Get(ctx, "age")
 		expectOk(t, err)
+
+		_, err = kv.Update(ctx, "age", []byte("27"), 1)
+		expectOk(t, err)
+
 		time.Sleep(1500 * time.Millisecond)
 
 		_, err = kv.Get(ctx, "age")
@@ -2023,6 +2027,14 @@ func TestKeyValueLimitMarkerTTL(t *testing.T) {
 		checkMsgNotFound(t, js, kv, "age")
 
 		entry := <-watcher.Updates()
+		if entry == nil {
+			t.Fatalf("Expected entry, got nil")
+		}
+		if entry.Operation() != jetstream.KeyValuePut {
+			t.Fatalf("Expected put operation, got %v", entry.Operation())
+		}
+
+		entry = <-watcher.Updates()
 		if entry == nil {
 			t.Fatalf("Expected entry, got nil")
 		}


### PR DESCRIPTION
The `Update` method of the `KeyValue` interface promises to update the key TTL. 
At the moment,  the TTL is automatically set to 0 when calling `Update` instead of it being reset to its creation value.
Store the TTL set for each key at creation in the kvs struct so that it can be used by `kvs.Update()`.
Resolves #1994