### PR TITLE
fix: Memory Leak when create PullConsumer 

### DIFF
--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -341,6 +341,11 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 	sub.Unlock()
 
 	go func() {
+		defer func() {
+			nc := sub.consumer.js.conn
+			nc.RemoveStatusListener(sub.connStatusChanged)
+		}()
+
 		isConnected := true
 		for {
 			if sub.closed.Load() == 1 {


### PR DESCRIPTION
fix: Memory Leak when create PullConsumer. So, add RemoveStatusListener in Consumer

Additional explanation

When create Consumer, allocate `sub.connStatusChanged` 
```go
sub.connStatusChanged = p.js.conn.StatusChanged(nats.CONNECTED, nats.RECONNECTING, nats.CLOSED)
```
But not delete map when Delete Consumer! 