### PR TITLE
fix: Memory Leak when create PullConsumer

### DIFF
--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -1082,11 +1082,12 @@ func (s *pullSubscription) cleanup() {
 	// is already holding the lock and waiting.
 	// The fields that are read (subscription, hbMonitor)
 	// are read only (Only written on creation of pullSubscription).
-	nc := s.consumer.js.conn
-	nc.RemoveStatusListener(s.connStatusChanged)
-
 	if s.subscription == nil || !s.subscription.IsValid() {
 		return
+	}
+	if s.consumer != nil {
+		nc := s.consumer.js.conn
+		nc.RemoveStatusListener(s.connStatusChanged)
 	}
 	if s.hbMonitor != nil {
 		s.hbMonitor.Stop()


### PR DESCRIPTION
fix: Memory Leak when create PullConsumer. So, add RemoveStatusListener in Consumer

Additional explanation

When create Consumer, allocate sub.connStatusChanged
```go
sub.connStatusChanged = p.js.conn.StatusChanged(nats.CONNECTED, nats.RECONNECTING, nats.CLOSED)
```
But not delete map when Delete Consumer!