### PR TITLE
Wrap EOF/connection reset errors with TLS context after handshake

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -151,6 +151,7 @@ var (
 	ErrMaxConnectionsExceeded        = errors.New("nats: server maximum connections exceeded")
 	ErrMaxAccountConnectionsExceeded = errors.New("nats: maximum account active connections exceeded")
 	ErrConnectionNotTLS              = errors.New("nats: connection is not tls")
+	ErrTLS                           = errors.New("nats: tls error")
 	ErrMaxSubscriptionsExceeded      = errors.New("nats: server maximum subscriptions exceeded")
 	ErrWebSocketHeadersAlreadySet    = errors.New("nats: websocket connection headers already set")
 	ErrServerNotInPool               = errors.New("nats: selected server is not in the pool")
@@ -2343,7 +2344,7 @@ func (nc *Conn) makeTLSConn() error {
 	nc.conn = tls.Client(nc.conn, tlsCopy)
 	conn := nc.conn.(*tls.Conn)
 	if err := conn.Handshake(); err != nil {
-		return err
+		return fmt.Errorf("%w: %w", ErrTLS, err)
 	}
 	nc.bindToNewConn()
 	return nil
@@ -2597,13 +2598,16 @@ func (nc *Conn) tlsHandshakeEOF(err error) error {
 		return err
 	}
 	if errors.Is(err, io.EOF) || isConnClosedError(err) {
-		return fmt.Errorf("nats: connection closed by remote after TLS handshake: %w", err)
+		return fmt.Errorf("%w: connection closed by remote after TLS handshake: %w", ErrTLS, err)
 	}
 	return err
 }
 
 // isConnClosedError reports whether the error indicates the remote
 // side closed the connection (broken pipe or connection reset).
+// NOTE: On Windows, connection resets use WSAECONNRESET which may not
+// match syscall.ECONNRESET. In that case, the error will not be
+// detected here but will still be returned unwrapped by the caller.
 func isConnClosedError(err error) bool {
 	return errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET)
 }

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -3389,9 +3389,9 @@ func TestTLSHandshakeFirstEOFAfterHandshake(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error, got nil")
 	}
-	// Should contain descriptive TLS context, not bare EOF.
-	if !strings.Contains(err.Error(), "TLS handshake") {
-		t.Fatalf("Expected error about TLS handshake, got: %v", err)
+	// Should be detectable as a TLS error.
+	if !errors.Is(err, nats.ErrTLS) {
+		t.Fatalf("Expected error to wrap nats.ErrTLS, got: %v", err)
 	}
 	// Should still wrap io.EOF for backwards compatibility.
 	if !errors.Is(err, io.EOF) {
@@ -3440,7 +3440,7 @@ func TestTLSHandshakeFirstMTLSReject(t *testing.T) {
 	}
 	// Should contain a TLS-related error message.
 	errStr := err.Error()
-	if !strings.Contains(errStr, "tls:") && !strings.Contains(errStr, "certificate") {
+	if !strings.Contains(errStr, "tls:") {
 		t.Fatalf("Expected TLS certificate error, got: %v", err)
 	}
 }
@@ -3498,10 +3498,8 @@ func TestTLSEOFAfterHandshakeNonTLSFirst(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error, got nil")
 	}
-	// Should contain descriptive TLS context. Depending on timing,
-	// the underlying error may be EOF (read) or broken pipe (write).
-	if !strings.Contains(err.Error(), "TLS handshake") {
-		t.Fatalf("Expected error about TLS handshake, got: %v", err)
+	if !errors.Is(err, nats.ErrTLS) {
+		t.Fatalf("Expected error to wrap nats.ErrTLS, got: %v", err)
 	}
 }
 
@@ -3561,7 +3559,7 @@ func TestTLSEOFAfterHandshakeBrokenPipe(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "TLS handshake") {
-		t.Fatalf("Expected error about TLS handshake, got: %v", err)
+	if !errors.Is(err, nats.ErrTLS) {
+		t.Fatalf("Expected error to wrap nats.ErrTLS, got: %v", err)
 	}
 }


### PR DESCRIPTION
When a TLS proxy (e.g. nginx with mTLS) completes the TLS handshake but then closes the connection due to an untrusted client certificate, the client would receive a bare "EOF" most of the time, making it difficult to to troubleshoot (since not sending tls alerts):

```
  ┌───────┬───────────────────────────────────────────────────────────────┬──────────────────────────────────────────┐
  │       │                            TLS 1.3                            │                 TLS 1.2                  │
  ├───────┼───────────────────────────────────────────────────────────────┼──────────────────────────────────────────┤
  │ nginx │ Handshake succeeds → Read() returns EOF                       │ Handshake succeeds → Read() returns EOF  │
  ├───────┼───────────────────────────────────────────────────────────────┼──────────────────────────────────────────┤
  │ NATS  │ Handshake succeeds → Read() returns tls: certificate required │ Handshake fails → tls: handshake failure │
  └───────┴───────────────────────────────────────────────────────────────┴──────────────────────────────────────────┘
```

Now we wrap these `io.EOF`  errors with more context that this happened after the TLS handshake:

```
  "nats: connection closed by remote after TLS handshake: EOF"
```

The wrapped error preserves the original via %w for backwards compatibility (`errors.Is(err, io.EOF)` still returns true).