### PR TITLE
[FIXED] Fix flaky TestConsumerPrioritized/messages test

### DIFF
--- a/jetstream/test/consumer_test.go
+++ b/jetstream/test/consumer_test.go
@@ -1400,6 +1400,8 @@ func TestConsumerPrioritized(t *testing.T) {
 			}
 		}()
 
+		time.Sleep(100 * time.Millisecond)
+
 		msgs2, err := cons2.Messages(jetstream.PullPriorityGroup("A"), jetstream.PullPrioritized(1), jetstream.PullMaxMessages(10))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
@@ -1409,7 +1411,6 @@ func TestConsumerPrioritized(t *testing.T) {
 			for {
 				msg, err := msgs2.Next()
 				if err != nil {
-					fmt.Println("err", err)
 					return
 				}
 				errs <- fmt.Errorf("Should not receive message")
@@ -1419,7 +1420,7 @@ func TestConsumerPrioritized(t *testing.T) {
 				wg.Done()
 			}
 		}()
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			_, err = js.Publish(ctx, "FOO.bar", []byte("hello"))
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)


### PR DESCRIPTION
Unlike `Consume()`, `Messages()` defers the initial pull request until `Next()` is called asynchronously. This meant both priority consumers' pull requests could arrive at the server simultaneously with no ordering guarantee, occasionally causing the lower priority consumer to receive messages.

Add a brief sleep after starting the priority 0 consumer to ensure its pull request is registered before the priority 1 consumer begins pulling.

Signed-off-by: Piotr Piotrowski <piotr@synadia.com>