### PR TITLE
[FIXED] Fix Subscription.StatusChanged channel closure on Closed Subscription

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -4955,6 +4955,15 @@ func (s *Subscription) StatusChanged(statuses ...SubStatus) <-chan SubStatus {
 	ch := make(chan SubStatus, 10)
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if s.status == SubscriptionClosed {
+		if slices.Contains(statuses, SubscriptionClosed) {
+			ch <- SubscriptionClosed
+		}
+		close(ch)
+		return ch
+	}
+
 	for _, status := range statuses {
 		s.registerStatusChangeListener(status, ch)
 		// initial status

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -1736,6 +1736,67 @@ func TestSubscriptionEvents(t *testing.T) {
 		WaitOnChannel(t, status, nats.SubscriptionSlowConsumer)
 	})
 
+	t.Run("return closed channel if subscription is closed", func(t *testing.T) {
+		s := RunDefaultServer()
+		defer s.Shutdown()
+
+		nc := NewDefaultConnection(t)
+		defer nc.Close()
+
+		sub, err := nc.Subscribe("foo", func(_ *nats.Msg) {})
+		nc.SetErrorHandler(func(c *nats.Conn, s *nats.Subscription, e error) {})
+		if err != nil {
+			t.Fatalf("Error subscribing: %v", err)
+		}
+		// Unsubscribe first to set status to SubscriptionClosed.
+		if err = sub.Unsubscribe(); err != nil {
+			t.Fatalf("Error unsubscribing: %v", err)
+		}
+		// Ensure StatusChanged channel is closed after receiving current status.
+		statusCh := sub.StatusChanged()
+		select {
+		case status := <-statusCh:
+			if status != nats.SubscriptionClosed {
+				t.Fatalf("Current subscription status is not closed")
+			}
+		case <-time.After(1 * time.Second):
+			t.Fatalf("StatusChanged() channel does not receive current status")
+		}
+		select {
+		case _, ok := <-statusCh:
+			if ok {
+				t.Fatalf("StatusChanged() channel is not closed")
+			}
+		default:
+			t.Fatalf("StatusChanged() channel exists and is blocking")
+		}
+	})
+
+	t.Run("return closed channel without status if not listening for closed", func(t *testing.T) {
+		s := RunDefaultServer()
+		defer s.Shutdown()
+
+		nc := NewDefaultConnection(t)
+		defer nc.Close()
+
+		sub, err := nc.Subscribe("foo", func(_ *nats.Msg) {})
+		if err != nil {
+			t.Fatalf("Error subscribing: %v", err)
+		}
+		if err = sub.Unsubscribe(); err != nil {
+			t.Fatalf("Error unsubscribing: %v", err)
+		}
+		statusCh := sub.StatusChanged(nats.SubscriptionSlowConsumer)
+		select {
+		case _, ok := <-statusCh:
+			if ok {
+				t.Fatalf("Expected channel to be closed without sending a value")
+			}
+		default:
+			t.Fatalf("StatusChanged() channel exists and is blocking")
+		}
+	})
+
 	t.Run("do not block channel if it's not read", func(t *testing.T) {
 		s := RunDefaultServer()
 		defer s.Shutdown()


### PR DESCRIPTION
The Subscription.StatusChanged godoc mentions that the returned channel will be closed when the subscription is closed. However, this is the case only if the subscription is closed after the StatusChanged channel is created and registered to listen for changes.

To prevent consumers from waiting on signals from closed subscriptions, lets close the channel if the current status of the Subscription is already SubscriptionClosed. We run this check in a defer statement to avoid races against the subscription status changing and allow backward compatibility with usages that expect to receive the current status.