### PR TITLE
Release v1.50.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 go get github.com/nats-io/nats.go@latest
 
 # To get a specific version:
-go get github.com/nats-io/nats.go@v1.49.0
+go get github.com/nats-io/nats.go@v1.50.0
 
 # Note that the latest major version for NATS Server is v2:
 go get github.com/nats-io/nats-server/v2@latest

--- a/nats.go
+++ b/nats.go
@@ -49,7 +49,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.49.0"
+	Version                   = "1.50.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60


### PR DESCRIPTION
## Changelog

### FIXED

- Core NATS:
  - Fix WebSocket close frame discarding buffered data frames (#2032)
- JetStream:
  - Remove status listener in Consume()/Messages() cleanup (#1993)
  - Fix race condition in `orderedSubscription.Drain()` (#2030)
  - Fixed `OrderedConsumer.Consume()` race in handler (#2043)

### IMPROVED

- Core NATS:
  - De-flake TestAlwaysReconnectOnAccountMaxConnectionsExceededErr (#2042)
  - Wrap EOF/connection reset errors with TLS context after handshake (#2031)
- JetStream:
  - Reject control characters in stream and consumer names (#2038)
  - Add missing `AccountLimits` fields in `jetstream` package (#2041)
  - Fix flaky TestConsumerPrioritized/messages test (#2033)
- KeyValue:
  - Deduplicate keys in KeyValue.Keys() and document ListKeys behavior (#2029)
  - Fix flaky TestKeyValueWithSources (#2036)

### CHANGED

- Bump go version to 1.25 and update dependencies (#2044, #2039)

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)