### PR TITLE
Code linting: remove functions min and max

### DIFF
--- a/bench/bench.go
+++ b/bench/bench.go
@@ -338,20 +338,6 @@ func HumanBytes(bytes float64, si bool) string {
 	return fmt.Sprintf("%.2f %s", bytes/math.Pow(float64(base), float64(exp)), units)
 }
 
-func min(x, y int64) int64 {
-	if x < y {
-		return x
-	}
-	return y
-}
-
-func max(x, y int64) int64 {
-	if x > y {
-		return x
-	}
-	return y
-}
-
 // MsgsPerClient divides the number of messages by the number of clients and tries to distribute them as evenly as possible
 func MsgsPerClient(numMsgs, numClients int) []int {
 	var counts []int

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -194,13 +194,6 @@ const (
 	unset                    = -1
 )
 
-func min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 // Consume can be used to continuously receive messages and handle them
 // with the provided callback function. Consume cannot be used concurrently
 // when using ordered consumer.

--- a/js.go
+++ b/js.go
@@ -2029,10 +2029,7 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, isSync,
 	// If maxap is greater than the default sub's pending limit, use that.
 	if maxap > DefaultSubPendingMsgsLimit {
 		// For bytes limit, use the min of maxp*1MB or DefaultSubPendingBytesLimit
-		bl := maxap * 1024 * 1024
-		if bl < DefaultSubPendingBytesLimit {
-			bl = DefaultSubPendingBytesLimit
-		}
+		bl := max(maxap*1024*1024, DefaultSubPendingBytesLimit)
 		if err := sub.SetPendingLimits(maxap, bl); err != nil {
 			return nil, err
 		}
@@ -3114,10 +3111,7 @@ func (sub *Subscription) Fetch(batch int, opts ...PullOpt) ([]*Msg, error) {
 			}
 
 			// Make our request expiration a bit shorter than the current timeout.
-			expiresDiff := time.Duration(float64(ttl) * 0.1)
-			if expiresDiff > 5*time.Second {
-				expiresDiff = 5 * time.Second
-			}
+			expiresDiff := min(time.Duration(float64(ttl)*0.1), 5*time.Second)
 			expires := ttl - expiresDiff
 
 			nr.Batch = batch - len(msgs)
@@ -3398,10 +3392,7 @@ func (sub *Subscription) FetchBatch(batch int, opts ...PullOpt) (MessageBatch, e
 	ttl = time.Until(deadline)
 
 	// Make our request expiration a bit shorter than the current timeout.
-	expiresDiff := time.Duration(float64(ttl) * 0.1)
-	if expiresDiff > 5*time.Second {
-		expiresDiff = 5 * time.Second
-	}
+	expiresDiff := min(time.Duration(float64(ttl)*0.1), 5*time.Second)
 	expires := ttl - expiresDiff
 
 	connStatusChanged := nc.StatusChanged()

--- a/ws.go
+++ b/ws.go
@@ -114,10 +114,7 @@ func (d *wsDecompressor) Read(dst []byte) (int, error) {
 	copied := 0
 	rem := len(dst)
 	for buf := d.bufs[0]; buf != nil && rem > 0; {
-		n := len(buf[d.off:])
-		if n > rem {
-			n = rem
-		}
+		n := min(len(buf[d.off:]), rem)
 		copy(dst[copied:], buf[d.off:d.off+n])
 		copied += n
 		rem -= n


### PR DESCRIPTION
This PR removes function `min` and `max`, these functions are available in golang itself as of Go 1.21. It also simplifies code by using `min`of `max` function. 