### PR TITLE
[FIXED] Make websocket frame validation more robust

### DIFF
--- a/ws.go
+++ b/ws.go
@@ -193,11 +193,8 @@ func wsNewReader(r io.Reader) *websocketReader {
 func (r *websocketReader) maxFrameSize() uint64 {
 	if r.nc != nil {
 		mp := r.nc.info.MaxPayload
-		if mp > 0 {
-			limit := uint64(mp) * wsMaxMsgPayloadMultiple
-			if limit < wsMaxMsgPayloadLimit {
-				return limit
-			}
+		if mp > 0 && uint64(mp) <= wsMaxMsgPayloadLimit/wsMaxMsgPayloadMultiple {
+			return uint64(mp) * wsMaxMsgPayloadMultiple
 		}
 	}
 	return wsMaxMsgPayloadLimit

--- a/ws_test.go
+++ b/ws_test.go
@@ -378,7 +378,7 @@ func TestWSParseInvalidFrames(t *testing.T) {
 	// 64-bit frame length exceeding MaxPayload-derived limit
 	mr, r = newReader()
 	r.nc = &Conn{}
-	r.nc.info.MaxPayload = 1024 * 1024 // 1MB -> max frame = 8MB
+	r.nc.info.MaxPayload = 1024 * 1024                     // 1MB -> max frame = 8MB
 	mr.buf.Write([]byte{130, 127, 0, 0, 0, 0, 1, 0, 0, 0}) // 16MB
 	n, err = r.Read(p)
 	if n != 0 || err == nil || !strings.Contains(err.Error(), "too large") {


### PR DESCRIPTION
- validate the MSB of 64-bit websocket frame lengths, preventing a panic from negative slice bounds when most significant bit is set
- cap maximum websocket frame size based on server max payload, capp (×8, up to 64MB), matching the server logic

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)