### PR TITLE
[ADDED] Option to customize write buffer size

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1763,6 +1763,10 @@ func (o Options) Connect() (*Conn, error) {
 	if nc.Opts.ReconnectBufSize == 0 {
 		nc.Opts.ReconnectBufSize = DefaultReconnectBufSize
 	}
+	// Default WriteBufferSize
+	if nc.Opts.WriteBufferSize <= 0 {
+		nc.Opts.WriteBufferSize = DefaultWriteBufSize
+	}
 	// Ensure that Timeout is not 0
 	if nc.Opts.Timeout == 0 {
 		nc.Opts.Timeout = DefaultTimeout
@@ -2097,16 +2101,12 @@ func (nc *Conn) shufflePool(offset int) {
 }
 
 func (nc *Conn) newReaderWriter() {
-	writeBufSize := nc.Opts.WriteBufferSize
-	if writeBufSize <= 0 {
-		writeBufSize = DefaultWriteBufSize
-	}
 	nc.br = &natsReader{
 		buf: make([]byte, defaultBufSize),
 		off: -1,
 	}
 	nc.bw = &natsWriter{
-		limit:  writeBufSize,
+		limit:  nc.Opts.WriteBufferSize,
 		plimit: nc.Opts.ReconnectBufSize,
 	}
 }

--- a/nats.go
+++ b/nats.go
@@ -61,6 +61,7 @@ const (
 	DefaultMaxPingOut         = 2
 	DefaultMaxChanLen         = 64 * 1024       // 64k
 	DefaultReconnectBufSize   = 8 * 1024 * 1024 // 8MB
+	DefaultWriteBufSize       = defaultBufSize
 	RequestChanLen            = 8
 	DefaultDrainTimeout       = 30 * time.Second
 	DefaultFlusherTimeout     = time.Minute
@@ -574,6 +575,14 @@ type Options struct {
 	// IgnoreDiscoveredServers will disable adding advertised server URLs
 	// from INFO messages to the server pool.
 	IgnoreDiscoveredServers bool
+
+	// WriteBufferSize is an advanced option that sets the flush threshold
+	// of the write buffer used to batch outgoing data before writing to
+	// the underlying connection. In most cases, the default value should
+	// not be changed. A smaller buffer reduces the amount of data that
+	// can be lost on blocked writes but may significantly reduce throughput.
+	// Defaults to 32768 bytes (32KB).
+	WriteBufferSize int
 }
 
 const (
@@ -1168,6 +1177,19 @@ func MaxPingsOutstanding(max int) Option {
 func ReconnectBufSize(size int) Option {
 	return func(o *Options) error {
 		o.ReconnectBufSize = size
+		return nil
+	}
+}
+
+// WriteBufferSize is an advanced option that sets the flush threshold
+// of the write buffer used to batch outgoing data before writing to
+// the underlying connection. In most cases, the default value should
+// not be changed. A smaller buffer reduces the amount of data that
+// can be lost on blocked writes but may significantly reduce throughput.
+// Defaults to 32768 bytes (32KB).
+func WriteBufferSize(size int) Option {
+	return func(o *Options) error {
+		o.WriteBufferSize = size
 		return nil
 	}
 }
@@ -2075,12 +2097,16 @@ func (nc *Conn) shufflePool(offset int) {
 }
 
 func (nc *Conn) newReaderWriter() {
+	writeBufSize := nc.Opts.WriteBufferSize
+	if writeBufSize <= 0 {
+		writeBufSize = DefaultWriteBufSize
+	}
 	nc.br = &natsReader{
 		buf: make([]byte, defaultBufSize),
 		off: -1,
 	}
 	nc.bw = &natsWriter{
-		limit:  defaultBufSize,
+		limit:  writeBufSize,
 		plimit: nc.Opts.ReconnectBufSize,
 	}
 }

--- a/nats_test.go
+++ b/nats_test.go
@@ -1933,6 +1933,7 @@ func TestWriteBufferSize(t *testing.T) {
 
 func TestWriteBufferSizeDefault(t *testing.T) {
 	opts := GetDefaultOptions()
+	opts.WriteBufferSize = DefaultWriteBufSize
 	opts.Servers = []string{"nats://127.0.0.1:4222"}
 	nc := &Conn{Opts: opts}
 	nc.newReaderWriter()

--- a/nats_test.go
+++ b/nats_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2023 The NATS Authors
+// Copyright 2012-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -1913,5 +1913,31 @@ func TestValidateSubject(t *testing.T) {
 				t.Errorf("validateSubject(%q) unexpected error: %v", tt.subject, err)
 			}
 		})
+	}
+}
+
+func TestWriteBufferSize(t *testing.T) {
+	opts := GetDefaultOptions()
+	opts.WriteBufferSize = 64 * 1024
+	opts.Servers = []string{"nats://127.0.0.1:4222"}
+	nc := &Conn{Opts: opts}
+	nc.newReaderWriter()
+
+	if nc.bw.limit != 64*1024 {
+		t.Fatalf("Expected write buffer limit of %d, got %d", 64*1024, nc.bw.limit)
+	}
+	if len(nc.br.buf) != defaultBufSize {
+		t.Fatalf("Expected read buffer size of %d, got %d", defaultBufSize, len(nc.br.buf))
+	}
+}
+
+func TestWriteBufferSizeDefault(t *testing.T) {
+	opts := GetDefaultOptions()
+	opts.Servers = []string{"nats://127.0.0.1:4222"}
+	nc := &Conn{Opts: opts}
+	nc.newReaderWriter()
+
+	if nc.bw.limit != defaultBufSize {
+		t.Fatalf("Expected default write buffer limit of %d, got %d", defaultBufSize, nc.bw.limit)
 	}
 }

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -14,6 +14,7 @@
 package test
 
 import (
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -254,4 +255,42 @@ func BenchmarkPublishValidation(b *testing.B) {
 		nc.Flush()
 		b.StopTimer()
 	})
+}
+
+func BenchmarkPublishWithWriteBufferSize(b *testing.B) {
+	payloads := []struct {
+		name string
+		size int
+	}{
+		{"16B", 16},
+		{"128B", 128},
+		{"512B", 512},
+	}
+	bufSizes := []int{512, 4096, 8192, 16384, 32768, 65536, 131072}
+
+	for _, p := range payloads {
+		msg := make([]byte, p.size)
+		for i := range msg {
+			msg[i] = byte(i)
+		}
+		for _, sz := range bufSizes {
+			b.Run(fmt.Sprintf("payload_%s/buf_%d", p.name, sz), func(b *testing.B) {
+				s := RunDefaultServer()
+				defer s.Shutdown()
+				nc, err := nats.Connect(s.ClientURL(), nats.WriteBufferSize(sz))
+				if err != nil {
+					b.Fatalf("Failed to connect: %v", err)
+				}
+				defer nc.Close()
+				b.ResetTimer()
+				for range b.N {
+					if err := nc.Publish("foo", msg); err != nil {
+						b.Fatalf("Error publishing: %v", err)
+					}
+				}
+				b.StopTimer()
+				nc.Flush()
+			})
+		}
+	}
 }

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -3563,3 +3563,29 @@ func TestTLSEOFAfterHandshakeBrokenPipe(t *testing.T) {
 		t.Fatalf("Expected error to wrap nats.ErrTLS, got: %v", err)
 	}
 }
+
+func TestWriteBufferSizeOption(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	nc, err := nats.Connect(s.ClientURL(), nats.WriteBufferSize(64*1024))
+	if err != nil {
+		t.Fatalf("Expected to connect, got: %v", err)
+	}
+	defer nc.Close()
+
+	if nc.Opts.WriteBufferSize != 64*1024 {
+		t.Fatalf("Expected WriteBufferSize 64KB, got %d", nc.Opts.WriteBufferSize)
+	}
+
+	sub, err := nc.SubscribeSync("foo")
+	if err != nil {
+		t.Fatalf("Error subscribing: %v", err)
+	}
+	if err := nc.Publish("foo", []byte("hello")); err != nil {
+		t.Fatalf("Error publishing: %v", err)
+	}
+	if _, err := sub.NextMsg(2 * time.Second); err != nil {
+		t.Fatalf("Error receiving message: %v", err)
+	}
+}


### PR DESCRIPTION
Benchmark results (on localhost):

| Buffer Size | 16B payload | vs 32KB | 128B payload | vs 32KB | 512B payload | vs 32KB |
|-------------|-------------|---------|--------------|---------|--------------|---------|
| 512 | 380 ns/op | 4.4x slower | 1,339 ns/op | 13.6x slower | 4,895 ns/op | 19.3x slower |
| 4,096 | 110 ns/op | 1.3x slower | 300 ns/op | 3.0x slower | 809 ns/op | 3.2x slower |
| 8,192 | 86 ns/op | ~same | 204 ns/op | 2.1x slower | 498 ns/op | 2.0x slower |
| 16,384 | 85 ns/op | ~same | 152 ns/op | 1.5x slower | 365 ns/op | 1.4x slower |
| **32,768** | **86 ns/op** | **baseline** | **99 ns/op** | **baseline** | **254 ns/op** | **baseline** |
| 65,536 | 85 ns/op | ~same | 98 ns/op | ~same | 182 ns/op | 1.4x faster |
| 131,072 | 85 ns/op | ~same | 98 ns/op | ~same | 147 ns/op | 1.7x faster |

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)