### PR TITLE
[FIXED] Preserve websocket auth errors during connect

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -2122,12 +2122,20 @@ func (w *natsWriter) appendBufs(bufs ...[]byte) error {
 }
 
 func (w *natsWriter) writeDirect(strs ...string) error {
-	for _, str := range strs {
-		if _, err := w.w.Write([]byte(str)); err != nil {
-			return err
-		}
+	switch len(strs) {
+	case 0:
+		return nil
+	case 1:
+		_, err := w.w.Write([]byte(strs[0]))
+		return err
 	}
-	return nil
+
+	var buf bytes.Buffer
+	for _, str := range strs {
+		buf.WriteString(str)
+	}
+	_, err := w.w.Write(buf.Bytes())
+	return err
 }
 
 func (w *natsWriter) flush() error {
@@ -2219,7 +2227,23 @@ build_string:
 		s += string(r.buf[r.off:r.n])
 		r.off = -1
 	}
-	if _, err := r.Read(); err != nil {
+	if buf, err := r.Read(); err != nil {
+		if len(buf) == 0 {
+			return s, err
+		}
+		r.off = 0
+		i := bytes.IndexByte(r.buf[r.off:r.n], delim)
+		if i >= 0 {
+			end := r.off + i + 1
+			s += string(r.buf[r.off:end])
+			r.off = end
+			if r.off >= r.n {
+				r.off = -1
+			}
+			return s, nil
+		}
+		s += string(r.buf[r.off:r.n])
+		r.off = -1
 		return s, err
 	}
 	r.off = 0

--- a/test/ws_test.go
+++ b/test/ws_test.go
@@ -104,6 +104,20 @@ func TestWSBasic(t *testing.T) {
 	}
 }
 
+func TestWSConnectAuthFailureReturnsAuthorizationError(t *testing.T) {
+	sopts := testWSGetDefaultOptions(t, false)
+	sopts.Username = "derek"
+	sopts.Password = "foo"
+	s := RunServerWithOptions(sopts)
+	defer s.Shutdown()
+
+	url := fmt.Sprintf("ws://127.0.0.1:%d", sopts.Websocket.Port)
+	_, err := nats.Connect(url)
+	if !errors.Is(err, nats.ErrAuthorization) {
+		t.Fatalf("Expected ErrAuthorization, got: %v", err)
+	}
+}
+
 func TestWSControlFrames(t *testing.T) {
 	sopts := testWSGetDefaultOptions(t, false)
 	s := RunServerWithOptions(sopts)

--- a/ws.go
+++ b/ws.go
@@ -233,7 +233,10 @@ func (r *websocketReader) Read(p []byte) (int, error) {
 		// Get some data from the underlying reader.
 		n, err := r.r.Read(p)
 		if err != nil {
-			return 0, err
+			if n == 0 {
+				return 0, err
+			}
+			r.closeErr = err
 		}
 		buf = p[:n]
 	}
@@ -367,6 +370,11 @@ func (r *websocketReader) Read(p []byte) (int, error) {
 	// In case of compression, there may be nothing to drain
 	if len(r.pending) > 0 {
 		return r.drainPending(p), nil
+	}
+	if r.closeErr != nil {
+		err := r.closeErr
+		r.closeErr = nil
+		return 0, err
 	}
 	return 0, nil
 }

--- a/ws_test.go
+++ b/ws_test.go
@@ -37,6 +37,11 @@ type fakeReader struct {
 	closed bool
 }
 
+type dataAndEOFReader struct {
+	data []byte
+	read bool
+}
+
 func (f *fakeReader) Read(p []byte) (int, error) {
 	f.mu.Lock()
 	closed := f.closed
@@ -65,6 +70,15 @@ func (f *fakeReader) close() {
 	}
 	f.closed = true
 	close(f.ch)
+}
+
+func (r *dataAndEOFReader) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, io.EOF
+	}
+	r.read = true
+	n := copy(p, r.data)
+	return n, io.EOF
 }
 
 func TestWSReader(t *testing.T) {
@@ -267,6 +281,63 @@ func TestWSDataBeforeCloseFrame(t *testing.T) {
 	}
 	if n != 0 {
 		t.Fatalf("Expected 0 bytes on close, got %v", n)
+	}
+}
+
+func TestWSDataBeforeCloseFrameWithUnderlyingEOF(t *testing.T) {
+	errMsg := []byte("-ERR 'Authorization Violation'\r\n")
+	closeBody := "Authentication Failure"
+	closePayloadLen := 2 + len(closeBody)
+
+	frames := make([]byte, 0, len(errMsg)+closePayloadLen+8)
+	frames = append(frames, byte(wsBinaryMessage)|wsFinalBit, byte(len(errMsg)))
+	frames = append(frames, errMsg...)
+	frames = append(frames, byte(wsCloseMessage)|wsFinalBit, byte(closePayloadLen))
+	frames = append(frames, 0x03, 0xE8)
+	frames = append(frames, closeBody...)
+
+	r := wsNewReader(&dataAndEOFReader{data: frames})
+	p := make([]byte, 100)
+
+	n, err := r.Read(p)
+	if err != nil {
+		t.Fatalf("Expected data to be returned before EOF, got error: %v", err)
+	}
+	if !bytes.Equal(p[:n], errMsg) {
+		t.Fatalf("Expected %q, got %q", errMsg, p[:n])
+	}
+
+	n, err = r.Read(p)
+	if err != io.EOF {
+		t.Fatalf("Expected io.EOF, got n=%v err=%v", n, err)
+	}
+	if n != 0 {
+		t.Fatalf("Expected 0 bytes on close, got %v", n)
+	}
+}
+
+func TestNatsReaderReadStringWithDataAndEOF(t *testing.T) {
+	line := []byte("-ERR 'Authorization Violation'\r\n")
+	r := &natsReader{
+		r:   &dataAndEOFReader{data: line},
+		buf: make([]byte, 128),
+		off: -1,
+	}
+
+	s, err := r.ReadString('\n')
+	if err != nil {
+		t.Fatalf("Expected line before EOF, got error: %v", err)
+	}
+	if s != string(line) {
+		t.Fatalf("Expected %q, got %q", string(line), s)
+	}
+
+	s, err = r.ReadString('\n')
+	if err != io.EOF {
+		t.Fatalf("Expected io.EOF after buffered line, got s=%q err=%v", s, err)
+	}
+	if s != "" {
+		t.Fatalf("Expected no buffered data after EOF, got %q", s)
 	}
 }
 


### PR DESCRIPTION
- coalesce CONNECT and PING into a single direct websocket write so auth failures are not exposed as write-side transport errors
- preserve buffered protocol bytes when websocketReader and natsReader receive data alongside EOF, so initial `-ERR` lines are surfaced correctly during connect
- add regression coverage for websocket auth-failure connect and reader EOF edge cases

Resolves #2024

Signed-off-by: Asish Kumar <officialasishkumar@gmail.com>