### PR TITLE
[FIXED] Deadlock in Consume() whe calling Stop/Drain from ConsumeErrHandler

### DIFF
--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -265,8 +265,8 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 			}
 
 			sub.Lock()
-			err := sub.handleStatusMsg(msg, msgErr)
-			if err == nil {
+			termErr, notifyErr := sub.handleStatusMsg(msg, msgErr)
+			if termErr == nil {
 				sub.checkPending()
 				if sub.hbMonitor != nil {
 					sub.hbMonitor.Reset(2 * consumeOpts.Heartbeat)
@@ -274,12 +274,15 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 			}
 			sub.Unlock()
 
-			if err != nil {
+			if sub.consumeOpts.ErrHandler != nil && notifyErr != nil {
+				sub.consumeOpts.ErrHandler(sub, notifyErr)
+			}
+			if termErr != nil {
 				if sub.closed.Load() == 1 {
 					return
 				}
 				if sub.consumeOpts.ErrHandler != nil {
-					sub.consumeOpts.ErrHandler(sub, err)
+					sub.consumeOpts.ErrHandler(sub, termErr)
 				}
 				sub.Stop()
 			}
@@ -390,9 +393,6 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 				}
 			case err := <-sub.errs:
 				sub.Lock()
-				if sub.consumeOpts.ErrHandler != nil {
-					sub.consumeOpts.ErrHandler(sub, err)
-				}
 				if errors.Is(err, ErrNoHeartbeat) {
 					batchSize := sub.consumeOpts.MaxMessages
 					if sub.consumeOpts.StopAfter > 0 {
@@ -415,6 +415,9 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 					sub.resetPendingMsgs()
 				}
 				sub.Unlock()
+				if sub.consumeOpts.ErrHandler != nil {
+					sub.consumeOpts.ErrHandler(sub, err)
+				}
 				if errors.Is(err, ErrConnectionClosed) {
 					sub.Stop()
 				}
@@ -666,9 +669,9 @@ func (s *pullSubscription) Next(opts ...NextOpt) (Msg, error) {
 				if msgErr == nil {
 					continue
 				}
-				if err := s.handleStatusMsg(msg, msgErr); err != nil {
+				if termErr, _ := s.handleStatusMsg(msg, msgErr); termErr != nil {
 					s.Stop()
-					return nil, err
+					return nil, termErr
 				}
 				continue
 			}
@@ -717,28 +720,29 @@ func (s *pullSubscription) Next(opts ...NextOpt) (Msg, error) {
 	}
 }
 
-func (s *pullSubscription) handleStatusMsg(msg *nats.Msg, msgErr error) error {
+// handleStatusMsg processes a status message from the server.
+// It returns a terminal error (caller should stop) and a non-terminal
+// error to notify the user about via ErrHandler. The caller should invoke
+// ErrHandler outside the lock to avoid deadlocks.
+func (s *pullSubscription) handleStatusMsg(msg *nats.Msg, msgErr error) (error, error) {
 	if !errors.Is(msgErr, nats.ErrTimeout) && !errors.Is(msgErr, ErrMaxBytesExceeded) && !errors.Is(msgErr, ErrBatchCompleted) {
 		if errors.Is(msgErr, ErrConsumerDeleted) || errors.Is(msgErr, ErrBadRequest) {
-			return msgErr
+			return msgErr, nil
 		}
 		if errors.Is(msgErr, ErrPinIDMismatch) {
 			s.consumer.setPinID("")
 			s.pending.msgCount = 0
 			s.pending.byteCount = 0
 		}
-		if s.consumeOpts.ErrHandler != nil {
-			s.consumeOpts.ErrHandler(s, msgErr)
-		}
 		if errors.Is(msgErr, ErrConsumerLeadershipChanged) {
 			s.pending.msgCount = 0
 			s.pending.byteCount = 0
 		}
-		return nil
+		return nil, msgErr
 	}
 	msgsLeft, bytesLeft, err := parsePending(msg)
 	if err != nil {
-		return err
+		return err, nil
 	}
 	s.pending.msgCount -= msgsLeft
 	if s.pending.msgCount < 0 {
@@ -750,7 +754,7 @@ func (s *pullSubscription) handleStatusMsg(msg *nats.Msg, msgErr error) error {
 			s.pending.byteCount = 0
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func (hb *hbMonitor) Stop() {

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -258,14 +258,6 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 			}
 			return
 		}
-		defer func() {
-			sub.Lock()
-			sub.checkPending()
-			if sub.hbMonitor != nil {
-				sub.hbMonitor.Reset(2 * consumeOpts.Heartbeat)
-			}
-			sub.Unlock()
-		}()
 		if !userMsg {
 			// heartbeat message
 			if msgErr == nil {
@@ -274,6 +266,12 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 
 			sub.Lock()
 			err := sub.handleStatusMsg(msg, msgErr)
+			if err == nil {
+				sub.checkPending()
+				if sub.hbMonitor != nil {
+					sub.hbMonitor.Reset(2 * consumeOpts.Heartbeat)
+				}
+			}
 			sub.Unlock()
 
 			if err != nil {
@@ -294,6 +292,10 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 		sub.Lock()
 		sub.decrementPendingMsgs(msg)
 		sub.incrementDeliveredMsgs()
+		sub.checkPending()
+		if sub.hbMonitor != nil {
+			sub.hbMonitor.Reset(2 * consumeOpts.Heartbeat)
+		}
 		sub.Unlock()
 
 		if sub.consumeOpts.StopAfter > 0 && sub.consumeOpts.StopAfter == sub.delivered {

--- a/jetstream/test/pull_test.go
+++ b/jetstream/test/pull_test.go
@@ -3946,6 +3946,144 @@ func TestPullConsumerConnectionClosed(t *testing.T) {
 	})
 }
 
+func TestConsumeErrHandlerNoDeadlock(t *testing.T) {
+	t.Run("error handler from background goroutine", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		ctx := context.Background()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{
+			Name:     "TEST",
+			Subjects: []string{"FOO.>"},
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		c, err := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+			AckPolicy: jetstream.AckExplicitPolicy,
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		errHandlerDone := make(chan struct{}, 1)
+		l, err := c.Consume(func(msg jetstream.Msg) {
+			msg.Ack()
+		}, jetstream.ConsumeErrHandler(func(cc jetstream.ConsumeContext, err error) {
+			// Closed() acquires the lock
+			cc.Closed()
+			select {
+			case errHandlerDone <- struct{}{}:
+			default:
+			}
+		}))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		// Closing the connection sends ErrConnectionClosed through
+		// sub.errs
+		nc.Close()
+
+		select {
+		case <-errHandlerDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Deadlock: ErrHandler did not complete")
+		}
+
+		done := make(chan struct{})
+		go func() {
+			l.Stop()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Deadlock: Stop() blocked")
+		}
+	})
+
+	t.Run("error handler from status message", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		ctx := context.Background()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{
+			Name:     "TEST",
+			Subjects: []string{"FOO.>"},
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		c, err := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+			AckPolicy: jetstream.AckExplicitPolicy,
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		errHandlerDone := make(chan struct{}, 1)
+		l, err := c.Consume(func(msg jetstream.Msg) {
+			msg.Ack()
+		}, jetstream.ConsumeErrHandler(func(cc jetstream.ConsumeContext, err error) {
+			cc.Closed()
+			select {
+			case errHandlerDone <- struct{}{}:
+			default:
+			}
+		}))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		// Deleting the consumer triggers a 409 status message
+		// processed by handleStatusMsg resulting in the ConsumeErrHandler being called
+		if err := s.DeleteConsumer(ctx, c.CachedInfo().Name); err != nil {
+			t.Fatalf("Error deleting consumer: %s", err)
+		}
+
+		select {
+		case <-errHandlerDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Deadlock: ErrHandler did not complete")
+		}
+
+		done := make(chan struct{})
+		go func() {
+			l.Stop()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Deadlock: Stop() blocked")
+		}
+	})
+}
+
 func TestPullConsumerMaxReconnectsExceeded(t *testing.T) {
 	t.Run("messages", func(t *testing.T) {
 		srv := RunBasicJetStreamServer()

--- a/jetstream/test/pull_test.go
+++ b/jetstream/test/pull_test.go
@@ -3983,10 +3983,7 @@ func TestConsumeErrHandlerNoDeadlock(t *testing.T) {
 		}, jetstream.ConsumeErrHandler(func(cc jetstream.ConsumeContext, err error) {
 			// Closed() acquires the lock
 			cc.Closed()
-			select {
-			case errHandlerDone <- struct{}{}:
-			default:
-			}
+			errHandlerDone <- struct{}{}
 		}))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
@@ -4045,22 +4042,35 @@ func TestConsumeErrHandlerNoDeadlock(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 
+		// Publish a message and wait for it to be consumed, ensuring
+		if _, err := js.Publish(ctx, "FOO.test", []byte("msg")); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		msgReceived := make(chan struct{}, 1)
 		errHandlerDone := make(chan struct{}, 1)
 		l, err := c.Consume(func(msg jetstream.Msg) {
 			msg.Ack()
-		}, jetstream.ConsumeErrHandler(func(cc jetstream.ConsumeContext, err error) {
-			cc.Closed()
 			select {
-			case errHandlerDone <- struct{}{}:
+			case msgReceived <- struct{}{}:
 			default:
 			}
+		}, jetstream.ConsumeErrHandler(func(cc jetstream.ConsumeContext, err error) {
+			cc.Closed()
+			errHandlerDone <- struct{}{}
 		}))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 
+		select {
+		case <-msgReceived:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Timed out waiting for message")
+		}
+
 		// Deleting the consumer triggers a 409 status message
-		// processed by handleStatusMsg resulting in the ConsumeErrHandler being called
+		// processed by handleStatusMsg in the internalHandler path.
 		if err := s.DeleteConsumer(ctx, c.CachedInfo().Name); err != nil {
 			t.Fatalf("Error deleting consumer: %s", err)
 		}


### PR DESCRIPTION
Call `ConsumerErrHandler` from outside the lock so that is error handler panics or calls `ConsumeContext.Stop()`/`ConsumeContext.Drain()` the client no longer deadlocks.

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)