### PR TITLE
[ADDED] Accessors for JS API level and IsSysAccount

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -908,23 +908,26 @@ func (s Server) clone() Server {
 
 // ServerInfo represents the information about the server that is sent in the INFO protocol message.
 type ServerInfo struct {
-	ID           string   `json:"server_id"`
-	Name         string   `json:"server_name"`
-	Proto        int      `json:"proto"`
-	Version      string   `json:"version"`
-	Host         string   `json:"host"`
-	Port         int      `json:"port"`
-	Headers      bool     `json:"headers"`
-	AuthRequired bool     `json:"auth_required,omitempty"`
-	TLSRequired  bool     `json:"tls_required,omitempty"`
-	TLSAvailable bool     `json:"tls_available,omitempty"`
-	MaxPayload   int64    `json:"max_payload"`
-	CID          uint64   `json:"client_id,omitempty"`
-	ClientIP     string   `json:"client_ip,omitempty"`
-	Nonce        string   `json:"nonce,omitempty"`
-	Cluster      string   `json:"cluster,omitempty"`
-	ConnectURLs  []string `json:"connect_urls,omitempty"`
-	LameDuckMode bool     `json:"ldm,omitempty"`
+	ID              string   `json:"server_id"`
+	Name            string   `json:"server_name"`
+	Proto           int      `json:"proto"`
+	Version         string   `json:"version"`
+	Host            string   `json:"host"`
+	Port            int      `json:"port"`
+	Headers         bool     `json:"headers"`
+	AuthRequired    bool     `json:"auth_required,omitempty"`
+	TLSRequired     bool     `json:"tls_required,omitempty"`
+	TLSAvailable    bool     `json:"tls_available,omitempty"`
+	MaxPayload      int64    `json:"max_payload"`
+	CID             uint64   `json:"client_id,omitempty"`
+	ClientIP        string   `json:"client_ip,omitempty"`
+	Nonce           string   `json:"nonce,omitempty"`
+	Cluster         string   `json:"cluster,omitempty"`
+	ConnectURLs     []string `json:"connect_urls,omitempty"`
+	LameDuckMode    bool     `json:"ldm,omitempty"`
+	JetStream       bool     `json:"jetstream,omitempty"`
+	IsSystemAccount bool     `json:"acc_is_sys,omitempty"`
+	JSApiLevel      int      `json:"api_lvl,omitempty"`
 }
 
 const (
@@ -2639,6 +2642,38 @@ func (nc *Conn) ConnectedClusterName() string {
 		return _EMPTY_
 	}
 	return nc.info.Cluster
+}
+
+// ConnectedServerJetStream reports whether the connected server has
+// JetStream enabled and, if so, its API level.
+func (nc *Conn) ConnectedServerJetStream() (bool, int) {
+	if nc == nil {
+		return false, 0
+	}
+
+	nc.mu.RLock()
+	defer nc.mu.RUnlock()
+
+	if nc.status != CONNECTED {
+		return false, 0
+	}
+	return nc.info.JetStream, nc.info.JSApiLevel
+}
+
+// IsSystemAccount reports whether the connected client's account
+// is the system account.
+func (nc *Conn) IsSystemAccount() bool {
+	if nc == nil {
+		return false
+	}
+
+	nc.mu.RLock()
+	defer nc.mu.RUnlock()
+
+	if nc.status != CONNECTED {
+		return false
+	}
+	return nc.info.IsSystemAccount
 }
 
 // Low level setup for structs, etc

--- a/nats.go
+++ b/nats.go
@@ -908,26 +908,31 @@ func (s Server) clone() Server {
 
 // ServerInfo represents the information about the server that is sent in the INFO protocol message.
 type ServerInfo struct {
-	ID              string   `json:"server_id"`
-	Name            string   `json:"server_name"`
-	Proto           int      `json:"proto"`
-	Version         string   `json:"version"`
-	Host            string   `json:"host"`
-	Port            int      `json:"port"`
-	Headers         bool     `json:"headers"`
-	AuthRequired    bool     `json:"auth_required,omitempty"`
-	TLSRequired     bool     `json:"tls_required,omitempty"`
-	TLSAvailable    bool     `json:"tls_available,omitempty"`
-	MaxPayload      int64    `json:"max_payload"`
-	CID             uint64   `json:"client_id,omitempty"`
-	ClientIP        string   `json:"client_ip,omitempty"`
-	Nonce           string   `json:"nonce,omitempty"`
-	Cluster         string   `json:"cluster,omitempty"`
-	ConnectURLs     []string `json:"connect_urls,omitempty"`
-	LameDuckMode    bool     `json:"ldm,omitempty"`
-	JetStream       bool     `json:"jetstream,omitempty"`
-	IsSystemAccount bool     `json:"acc_is_sys,omitempty"`
-	JSApiLevel      int      `json:"api_lvl,omitempty"`
+	ID           string   `json:"server_id"`
+	Name         string   `json:"server_name"`
+	Proto        int      `json:"proto"`
+	Version      string   `json:"version"`
+	Host         string   `json:"host"`
+	Port         int      `json:"port"`
+	Headers      bool     `json:"headers"`
+	AuthRequired bool     `json:"auth_required,omitempty"`
+	TLSRequired  bool     `json:"tls_required,omitempty"`
+	TLSAvailable bool     `json:"tls_available,omitempty"`
+	MaxPayload   int64    `json:"max_payload"`
+	CID          uint64   `json:"client_id,omitempty"`
+	ClientIP     string   `json:"client_ip,omitempty"`
+	Nonce        string   `json:"nonce,omitempty"`
+	Cluster      string   `json:"cluster,omitempty"`
+	ConnectURLs  []string `json:"connect_urls,omitempty"`
+	LameDuckMode bool     `json:"ldm,omitempty"`
+	// JetStream indicates whether the server has JetStream enabled.
+	JetStream bool `json:"jetstream,omitempty"`
+	// IsSystemAccount indicates whether the connected client's account
+	// is the system account.
+	IsSystemAccount bool `json:"acc_is_sys,omitempty"`
+	// JSApiLevel is the JetStream API level advertised by the server.
+	// Requires nats-server v2.12.0 or later; older servers will report 0.
+	JSApiLevel int `json:"api_lvl,omitempty"`
 }
 
 const (
@@ -2645,7 +2650,9 @@ func (nc *Conn) ConnectedClusterName() string {
 }
 
 // ConnectedServerJetStream reports whether the connected server has
-// JetStream enabled and, if so, its API level.
+// JetStream enabled and, if so, its API level. The API level is
+// advertised by nats-server v2.12.0 or later; older servers will
+// report 0 even when JetStream is enabled.
 func (nc *Conn) ConnectedServerJetStream() (bool, int) {
 	if nc == nil {
 		return false, 0

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -147,6 +147,13 @@ func TestConnectedServer(t *testing.T) {
 	if cname == "" {
 		t.Fatalf("Expected a connected server cluster name, got %s", cname)
 	}
+	jsEnabled, _ := nc.ConnectedServerJetStream()
+	if jsEnabled {
+		t.Fatalf("Expected JetStream to be disabled")
+	}
+	if nc.IsSystemAccount() {
+		t.Fatalf("Expected non-system account")
+	}
 
 	nc.Close()
 	u = nc.ConnectedUrl()
@@ -164,6 +171,32 @@ func TestConnectedServer(t *testing.T) {
 	cname = nc.ConnectedClusterName()
 	if cname != "" {
 		t.Fatalf("Expected a nil connect server cluster, got %s", cname)
+	}
+	jsEnabled, _ = nc.ConnectedServerJetStream()
+	if jsEnabled {
+		t.Fatalf("Expected JetStream to be disabled after close")
+	}
+	if nc.IsSystemAccount() {
+		t.Fatalf("Expected non-system account after close")
+	}
+}
+
+func TestConnectedServerJetStream(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer s.Shutdown()
+
+	nc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		t.Fatalf("Error connecting: %v", err)
+	}
+	defer nc.Close()
+
+	jsEnabled, jsApiLevel := nc.ConnectedServerJetStream()
+	if !jsEnabled {
+		t.Fatalf("Expected JetStream to be enabled")
+	}
+	if jsApiLevel == 0 {
+		t.Fatalf("Expected non-zero JetStream API level")
 	}
 }
 

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2023 The NATS Authors
+// Copyright 2012-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 	"regexp"
 	"runtime"
 	"strings"
@@ -197,6 +198,49 @@ func TestConnectedServerJetStream(t *testing.T) {
 	}
 	if jsApiLevel == 0 {
 		t.Fatalf("Expected non-zero JetStream API level")
+	}
+}
+
+func TestIsSystemAccount(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+	listen: 127.0.0.1:-1
+	accounts: {
+		SYS: {
+			users: [ {user: "sys", password: "pass"} ]
+		}
+		APP: {
+			users: [ {user: "app", password: "pass"} ]
+		}
+	}
+	system_account: SYS
+	`))
+	defer os.Remove(conf)
+
+	s, _ := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	nc, err := nats.Connect(s.ClientURL(), nats.UserInfo("sys", "pass"))
+	if err != nil {
+		t.Fatalf("Error connecting: %v", err)
+	}
+	defer nc.Close()
+
+	// IsSystemAccount is sent by the server in an async INFO after connect.
+	checkFor(t, time.Second, 15*time.Millisecond, func() error {
+		if !nc.IsSystemAccount() {
+			return fmt.Errorf("expected system account")
+		}
+		return nil
+	})
+
+	nc2, err := nats.Connect(s.ClientURL(), nats.UserInfo("app", "pass"))
+	if err != nil {
+		t.Fatalf("Error connecting: %v", err)
+	}
+	defer nc2.Close()
+
+	if nc2.IsSystemAccount() {
+		t.Fatalf("Expected non-system account")
 	}
 }
 


### PR DESCRIPTION
- Added `Conn.ConnectedServerJetStream` exposing JS API level (and whether jetstream is anabled)
- Added `Conn.IsSystemAccount`, exposing `acc_is_sys` from `ServerInfo`

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)