### PR TITLE
kv: reject keys with consecutive dots in keyValid and searchKeyValid

### DIFF
--- a/jetstream/kv.go
+++ b/jetstream/kv.go
@@ -906,14 +906,14 @@ func bucketValid(bucket string) bool {
 }
 
 func keyValid(key string) bool {
-	if len(key) == 0 || key[0] == '.' || key[len(key)-1] == '.' {
+	if len(key) == 0 || key[0] == '.' || key[len(key)-1] == '.' || strings.Contains(key, "..") {
 		return false
 	}
 	return validKeyRe.MatchString(key)
 }
 
 func searchKeyValid(key string) bool {
-	if len(key) == 0 || key[0] == '.' || key[len(key)-1] == '.' {
+	if len(key) == 0 || key[0] == '.' || key[len(key)-1] == '.' || strings.Contains(key, "..") {
 		return false
 	}
 	return validSearchKeyRe.MatchString(key)

--- a/jetstream/test/kv_test.go
+++ b/jetstream/test/kv_test.go
@@ -620,6 +620,13 @@ func TestKeyValueWatch(t *testing.T) {
 		_, err = kv.Watch(ctx, "foo.")
 		expectErr(t, err, jetstream.ErrInvalidKey)
 
+		// consecutive dots (empty token) must be rejected early, not passed to server
+		_, err = kv.Watch(ctx, "foo..bar")
+		expectErr(t, err, jetstream.ErrInvalidKey)
+
+		_, err = kv.Watch(ctx, "test..")
+		expectErr(t, err, jetstream.ErrInvalidKey)
+
 		// conflicting options
 		_, err = kv.Watch(ctx, "foo", jetstream.IncludeHistory(), jetstream.UpdatesOnly())
 		expectErr(t, err, jetstream.ErrInvalidOption)

--- a/jetstream/test/kv_test.go
+++ b/jetstream/test/kv_test.go
@@ -624,7 +624,7 @@ func TestKeyValueWatch(t *testing.T) {
 		_, err = kv.Watch(ctx, "foo..bar")
 		expectErr(t, err, jetstream.ErrInvalidKey)
 
-		_, err = kv.Watch(ctx, "test..")
+		_, err = kv.Watch(ctx, "a..b.c")
 		expectErr(t, err, jetstream.ErrInvalidKey)
 
 		// conflicting options

--- a/kv.go
+++ b/kv.go
@@ -577,14 +577,14 @@ func bucketValid(bucket string) bool {
 }
 
 func keyValid(key string) bool {
-	if len(key) == 0 || key[0] == '.' || key[len(key)-1] == '.' {
+	if len(key) == 0 || key[0] == '.' || key[len(key)-1] == '.' || strings.Contains(key, "..") {
 		return false
 	}
 	return validKeyRe.MatchString(key)
 }
 
 func searchKeyValid(key string) bool {
-	if len(key) == 0 || key[0] == '.' || key[len(key)-1] == '.' {
+	if len(key) == 0 || key[0] == '.' || key[len(key)-1] == '.' || strings.Contains(key, "..") {
 		return false
 	}
 	return validSearchKeyRe.MatchString(key)

--- a/test/kv_test.go
+++ b/test/kv_test.go
@@ -413,6 +413,9 @@ func TestKeyValueWatch(t *testing.T) {
 
 		_, err = kv.Watch("foo.")
 		expectErr(t, err, nats.ErrInvalidKey)
+
+		_, err = kv.Watch("foo..bar")
+		expectErr(t, err, nats.ErrInvalidKey)
 	})
 
 	t.Run("filtered watch with no filters", func(t *testing.T) {


### PR DESCRIPTION
Fixes #1354.

Keys like `foo..bar` contain an empty token — two adjacent dots with nothing between them — which makes them invalid NATS subjects. Both `keyValid` and `searchKeyValid` (in `kv.go` and `jetstream/kv.go`) only checked for a leading or trailing dot, so these keys passed client-side validation and reached the server, where they'd fail with a misleading `nats: jetstream not enabled` error instead of a clear validation message.

The fix adds a `strings.Contains(key, "..")` check to both functions so keys with consecutive dots are rejected early with `ErrInvalidKey`. The check is consistent with the existing leading/trailing dot logic.

**Test plan:**
- Added `Watch("foo..bar")` and `Watch("test..")` cases to the `invalid watchers` subtest in `jetstream/test/kv_test.go`; both now return `ErrInvalidKey`
- Existing tests pass unchanged