### PR TITLE
jetstream: surface ErrMaxBytesExceeded to ConsumeErrHandler

### DIFF
--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -747,6 +747,16 @@ func (s *pullSubscription) handleStatusMsg(msg *nats.Msg, msgErr error) (error, 
 			s.pending.byteCount = 0
 		}
 	}
+	// ErrTimeout and ErrBatchCompleted are part of normal pull flow control
+	// and intentionally do not reach the user's ErrHandler.
+	// ErrMaxBytesExceeded, however, signals that a message in the stream is
+	// larger than the configured PullMaxBytes and the consumer will keep
+	// retrying until the offending message is removed or PullMaxBytes is
+	// raised. Surface it so callers using ConsumeErrHandler can observe the
+	// condition instead of seeing the consumer silently spin.
+	if errors.Is(msgErr, ErrMaxBytesExceeded) {
+		return nil, msgErr
+	}
 	return nil, nil
 }
 

--- a/jetstream/test/pull_test.go
+++ b/jetstream/test/pull_test.go
@@ -2611,6 +2611,69 @@ func TestPullConsumerConsume(t *testing.T) {
 		}
 	})
 
+	// Regression for https://github.com/nats-io/nats.go/issues/1718:
+	// when a message in the stream is larger than the configured PullMaxBytes,
+	// the consumer was previously stuck in a tight retry loop without ever
+	// surfacing the error to the user. Verify the ErrHandler now sees the
+	// ErrMaxBytesExceeded status.
+	t.Run("max bytes exceeded surfaces to ErrHandler", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{AckPolicy: jetstream.AckExplicitPolicy})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		// Publish a single message that comfortably exceeds the
+		// PullMaxBytes set on the consumer below.
+		if _, err := js.Publish(ctx, "FOO.1", make([]byte, 1024)); err != nil {
+			t.Fatalf("Unexpected error publishing: %v", err)
+		}
+
+		errCh := make(chan error, 8)
+		l, err := c.Consume(
+			func(msg jetstream.Msg) {
+				t.Errorf("Unexpected message delivered: %s", string(msg.Data()))
+			},
+			jetstream.PullMaxBytes(100),
+			jetstream.ConsumeErrHandler(func(_ jetstream.ConsumeContext, err error) {
+				select {
+				case errCh <- err:
+				default:
+				}
+			}),
+		)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer l.Stop()
+
+		select {
+		case got := <-errCh:
+			if !errors.Is(got, jetstream.ErrMaxBytesExceeded) {
+				t.Fatalf("Expected ErrMaxBytesExceeded, got: %v", got)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("Timeout waiting for ErrMaxBytesExceeded on ConsumeErrHandler")
+		}
+	})
+
 	t.Run("with auto unsubscribe", func(t *testing.T) {
 		srv := RunBasicJetStreamServer()
 		defer shutdownJSServerAndRemoveStorage(t, srv)


### PR DESCRIPTION
Closes #1718.

## Problem

When a single message in the stream is larger than the configured `PullMaxBytes`, the server responds with `409 Message Size Exceeds MaxBytes` on every `MSG.NEXT`. `handleStatusMsg` already detects the status but returns `(nil, nil)`, so neither the terminal error path nor the user's `ConsumeErrHandler` ever sees the condition. The consumer keeps retrying silently and burns CPU on both client and server until either the offending message is removed or `PullMaxBytes` is raised.

Maintainer discussion in the issue thread confirmed this is a client-side concern.

## Change

Return `ErrMaxBytesExceeded` as the non-terminal notification error from `handleStatusMsg`. The error then flows through the existing `Consume` notification path and is delivered to the user's `ConsumeErrHandler`. `ErrTimeout` and `ErrBatchCompleted` continue to fall through silently — those are internal pull-flow signals, not user-facing errors.

The retry behaviour itself is intentionally unchanged. Whether the loop should stop, back off, or auto-raise `PullMaxBytes` is a separate design question (see #1718 discussion); this change just makes the situation observable.

## Test plan

A new subtest `TestPullConsumerConsume/max_bytes_exceeded_surfaces_to_ErrHandler` in `jetstream/test/pull_test.go` publishes a single 1 KiB message, starts `Consume` with `PullMaxBytes(100)`, and asserts that the registered `ConsumeErrHandler` receives an `ErrMaxBytesExceeded` within 3 s.

```
$ go test -run "TestPullConsumerConsume/max_bytes_exceeded_surfaces_to_ErrHandler" -v ./jetstream/test/
=== RUN   TestPullConsumerConsume
=== RUN   TestPullConsumerConsume/max_bytes_exceeded_surfaces_to_ErrHandler
--- PASS: TestPullConsumerConsume (0.04s)
    --- PASS: TestPullConsumerConsume/max_bytes_exceeded_surfaces_to_ErrHandler (0.04s)
PASS
```
