### PR TITLE
[ADDED] `micro.WithEndpointMetadataKey`

### DIFF
--- a/micro/service.go
+++ b/micro/service.go
@@ -967,6 +967,9 @@ func WithEndpointMetadata(metadata map[string]string) EndpointOpt {
 
 func WithEndpointMetadataKey(key, value string) EndpointOpt {
 	return func(e *endpointOpts) error {
+		if e.metadata == nil {
+			e.metadata = map[string]string{}
+		}
 		e.metadata[key] = value
 		return nil
 	}

--- a/micro/service.go
+++ b/micro/service.go
@@ -965,6 +965,13 @@ func WithEndpointMetadata(metadata map[string]string) EndpointOpt {
 	}
 }
 
+func WithEndpointMetadataKey(key, value string) EndpointOpt {
+	return func(e *endpointOpts) error {
+		e.metadata[key] = value
+		return nil
+	}
+}
+
 func WithEndpointQueueGroup(queueGroup string) EndpointOpt {
 	return func(e *endpointOpts) error {
 		e.queueGroup = queueGroup

--- a/micro/service.go
+++ b/micro/service.go
@@ -965,6 +965,9 @@ func WithEndpointMetadata(metadata map[string]string) EndpointOpt {
 	}
 }
 
+// WithEndpointMetadataKey adds a key-value pair to the endpoints's metadata.
+// Prefer using WithEndpointMetadata when you have all the key-value pairs you
+// want to add at once or when you want to replace any existing metadata.
 func WithEndpointMetadataKey(key, value string) EndpointOpt {
 	return func(e *endpointOpts) error {
 		if e.metadata == nil {

--- a/micro/test/service_test.go
+++ b/micro/test/service_test.go
@@ -1046,30 +1046,65 @@ func TestAddEndpoint_Options(t *testing.T) {
 		req.Respond([]byte("OK"))
 	})
 
-	err = srv.AddEndpoint("test", micro.HandlerFunc(handler),
-		micro.WithEndpointMetadata(map[string]string{
-			"foo":   "bar",
-			"hello": "world",
-		}),
-		// override value from WithEndpointMetadata
-		micro.WithEndpointMetadataKey("foo", "baz"),
-	)
-	if err != nil {
-		t.Fatalf("Error adding endpoint: %v", err)
+	tests := []struct {
+		name     string
+		options  []micro.EndpointOpt
+		expected map[string]string
+	}{
+		{
+			name: "WithEndpointMetadata and WithEndpointMetadataKey",
+			options: []micro.EndpointOpt{
+				micro.WithEndpointMetadata(map[string]string{
+					"hello": "world",
+					"foo":   "bar",
+				}),
+				// override value from WithEndpointMetadata
+				micro.WithEndpointMetadataKey("foo", "baz"),
+			},
+			expected: map[string]string{
+				"hello": "world",
+				"foo":   "baz",
+			},
+		},
+		{
+			name: "WithEndpointMetadataKey",
+			options: []micro.EndpointOpt{
+				micro.WithEndpointMetadataKey("foo", "baz"),
+			},
+			expected: map[string]string{
+				"foo": "baz",
+			},
+		},
 	}
+	for i, test := range tests {
+		name := fmt.Sprintf("test%v", i+1)
+		err = srv.AddEndpoint(name, micro.HandlerFunc(handler), test.options...)
+		if err != nil {
+			t.Fatalf("Error adding endpoint: %v", err)
+		}
 
-	// Verify endpoint was created with metadata
-	info := srv.Info()
-	if len(info.Endpoints) != 1 {
-		t.Fatalf("Expected 1 endpoint, got %d", len(info.Endpoints))
-	}
+		// Verify endpoint was created with metadata
+		info := srv.Info()
 
-	endpoint := info.Endpoints[0]
-	if endpoint.Metadata["foo"] != "baz" {
-		t.Fatalf(`Expected "foo" to equal "baz", got %q`, endpoint.Metadata["foo"])
-	}
-	if endpoint.Metadata["hello"] != "world" {
-		t.Fatalf(`Expected "hello" to equal "world", got %q`, endpoint.Metadata["hello"])
+		var endpoint *micro.EndpointInfo
+		for _, ep := range info.Endpoints {
+			if ep.Name == name {
+				endpoint = &ep
+				break
+			}
+		}
+		if endpoint == nil {
+			t.Fatalf("Expected endpoint %q to exist", name)
+		}
+
+		if len(test.expected) != len(endpoint.Metadata) {
+			t.Fatalf("Expected %v metadata values, got %v", len(test.expected), len(endpoint.Metadata))
+		}
+		for key, value := range test.expected {
+			if value != endpoint.Metadata[key] {
+				t.Fatalf(`Expected %q to equal %q, got %q`, key, value, endpoint.Metadata[key])
+			}
+		}
 	}
 }
 

--- a/micro/test/service_test.go
+++ b/micro/test/service_test.go
@@ -1097,13 +1097,8 @@ func TestAddEndpoint_Options(t *testing.T) {
 			t.Fatalf("Expected endpoint %q to exist", name)
 		}
 
-		if len(test.expected) != len(endpoint.Metadata) {
-			t.Fatalf("Expected %v metadata values, got %v", len(test.expected), len(endpoint.Metadata))
-		}
-		for key, value := range test.expected {
-			if value != endpoint.Metadata[key] {
-				t.Fatalf(`Expected %q to equal %q, got %q`, key, value, endpoint.Metadata[key])
-			}
+		if !reflect.DeepEqual(test.expected, endpoint.Metadata) {
+			t.Fatalf("want: %v; got: %v", test.expected, endpoint.Metadata)
 		}
 	}
 }

--- a/micro/test/service_test.go
+++ b/micro/test/service_test.go
@@ -1021,6 +1021,58 @@ func TestContextHandler(t *testing.T) {
 	}
 }
 
+func TestAddEndpoint_Options(t *testing.T) {
+	s := RunServerOnPort(-1)
+	defer s.Shutdown()
+
+	nc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		t.Fatalf("Expected to connect to server, got %v", err)
+	}
+	defer nc.Close()
+
+	config := micro.Config{
+		Name:    "test_service",
+		Version: "0.1.0",
+	}
+
+	srv, err := micro.AddService(nc, config)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer srv.Stop()
+
+	handler := micro.HandlerFunc(func(req micro.Request) {
+		req.Respond([]byte("OK"))
+	})
+
+	err = srv.AddEndpoint("test", micro.HandlerFunc(handler),
+		micro.WithEndpointMetadata(map[string]string{
+			"foo":   "bar",
+			"hello": "world",
+		}),
+		// override value from WithEndpointMetadata
+		micro.WithEndpointMetadataKey("foo", "baz"),
+	)
+	if err != nil {
+		t.Fatalf("Error adding endpoint: %v", err)
+	}
+
+	// Verify endpoint was created with metadata
+	info := srv.Info()
+	if len(info.Endpoints) != 1 {
+		t.Fatalf("Expected 1 endpoint, got %d", len(info.Endpoints))
+	}
+
+	endpoint := info.Endpoints[0]
+	if endpoint.Metadata["foo"] != "baz" {
+		t.Fatalf(`Expected "foo" to equal "baz", got %q`, endpoint.Metadata["foo"])
+	}
+	if endpoint.Metadata["hello"] != "world" {
+		t.Fatalf(`Expected "hello" to equal "world", got %q`, endpoint.Metadata["foo"])
+	}
+}
+
 func TestAddEndpoint_Concurrency(t *testing.T) {
 	s := RunServerOnPort(-1)
 	defer s.Shutdown()

--- a/micro/test/service_test.go
+++ b/micro/test/service_test.go
@@ -1069,7 +1069,7 @@ func TestAddEndpoint_Options(t *testing.T) {
 		t.Fatalf(`Expected "foo" to equal "baz", got %q`, endpoint.Metadata["foo"])
 	}
 	if endpoint.Metadata["hello"] != "world" {
-		t.Fatalf(`Expected "hello" to equal "world", got %q`, endpoint.Metadata["foo"])
+		t.Fatalf(`Expected "hello" to equal "world", got %q`, endpoint.Metadata["hello"])
 	}
 }
 


### PR DESCRIPTION
closes https://github.com/nats-io/nats.go/issues/2078

See also https://github.com/nats-io/nats.go/pull/2080 for an alternate solution to the issue.