### PR TITLE
[IMPROVED] Performance enhancement when publishing core NATS messages with headers

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -853,7 +853,11 @@ func (m *Msg) headerBytes() ([]byte, error) {
 		return hdr, nil
 	}
 
-	// Validate the keys/values and calculate the total encoded size
+	// Validate the keys/values and calculate an upper bound for the total
+	// encoded size. The size calculation may not be exact if any values
+	// contain leading/trailing whitespace (as those will be trimmed later),
+	// but a slight over-estimation here is more preferable than an
+	// under-estimation (which could lead to unnecessary memory allocations).
 	hdrSize := len(hdrLine) + len(crlf)
 	for k, vs := range m.Header {
 		if !isHeaderKeyValid(k) {
@@ -967,10 +971,7 @@ func makeValidHeaderKeyAsciiSet() asciiSet {
 }
 
 func isHeaderKeyValid(k string) bool {
-	if len(k) == 0 {
-		return false
-	}
-	return validHeaderKeyChars.MatchesString(k)
+	return len(k) > 0 && validHeaderKeyChars.MatchesString(k)
 }
 
 func isHeaderValueValid(v string) bool {

--- a/nats.go
+++ b/nats.go
@@ -853,23 +853,140 @@ func (m *Msg) headerBytes() ([]byte, error) {
 		return hdr, nil
 	}
 
+	// Validate the keys/values and calculate the total encoded size
+	hdrSize := len(hdrLine) + len(crlf)
+	for k, vs := range m.Header {
+		if !isHeaderKeyValid(k) {
+			return nil, ErrBadHeaderMsg
+		}
+		for _, v := range vs {
+			if !isHeaderValueValid(v) {
+				return nil, ErrBadHeaderMsg
+			}
+			hdrSize += len(k) + len(v) + 4 // 4 is for the colon, space, CR, and LF
+		}
+	}
+
+	// NOTE: bytes.Buffer.WriteString() returns an error because bytes.Buffer
+	// is intended to be a valid implementation of the io.StringWriter interface.
+	// This implementation cannot actually fail in practice, so it is safe to
+	// ignore write errors here.
 	var b bytes.Buffer
-	_, err := b.WriteString(hdrLine)
-	if err != nil {
-		return nil, ErrBadHeaderMsg
+	b.Grow(hdrSize)
+	_, _ = b.WriteString(hdrLine)
+	for k, vs := range m.Header {
+		for _, v := range vs {
+			_, _ = b.WriteString(k)
+			_, _ = b.WriteString(": ")
+			_, _ = b.WriteString(textproto.TrimString(v))
+			_, _ = b.WriteString(crlf)
+		}
 	}
-
-	err = http.Header(m.Header).Write(&b)
-	if err != nil {
-		return nil, ErrBadHeaderMsg
-	}
-
-	_, err = b.WriteString(crlf)
-	if err != nil {
-		return nil, ErrBadHeaderMsg
-	}
+	_, _ = b.WriteString(crlf)
 
 	return b.Bytes(), nil
+}
+
+// asciiSet is a 256-byte lookup table for fast ASCII character membership testing.
+// This implementation mirrors the one Go uses internally for many string operations,
+// including strings.Contains().
+//
+// References:
+//   - https://github.com/golang/go/blob/master/src/strings/strings.go
+type asciiSet [256]bool
+
+func (as *asciiSet) MatchesString(s string) bool {
+
+	// Implementation note: Our high level strategy is to compare each byte in
+	// 's' with the corresponding entry in 'as'. If the entry is 'true', the
+	// character is valid, so we can move forward with the next byte in 's'. If
+	// the entry in 'as' is 'false', the character is invalid, so we can bail
+	// out.
+	//
+	// Benchmarking shows there to be some benefit to manually unrolling the
+	// loop (up to ~35% faster in some cases), so that's what we've done here.
+
+	i := 0
+
+	// Process the string in batches of 8 bytes
+	for ; i <= len(s)-8; i += 8 {
+		if !as[s[i]] {
+			return false
+		}
+		if !as[s[i+1]] {
+			return false
+		}
+		if !as[s[i+2]] {
+			return false
+		}
+		if !as[s[i+3]] {
+			return false
+		}
+		if !as[s[i+4]] {
+			return false
+		}
+		if !as[s[i+5]] {
+			return false
+		}
+		if !as[s[i+6]] {
+			return false
+		}
+		if !as[s[i+7]] {
+			return false
+		}
+	}
+
+	// Handle any remaining bytes at the end of the string
+	for ; i < len(s); i++ {
+		if !as[s[i]] {
+			return false
+		}
+	}
+	return true
+}
+
+// The asciiSet that represents valid header keys can be precalculated and
+// cached since it will never change during the lifetime of the application.
+var validHeaderKeyChars = makeValidHeaderKeyAsciiSet()
+
+func makeValidHeaderKeyAsciiSet() asciiSet {
+
+	// ADR-4 specifies that header keys must be printable ASCII characters
+	// (e.g. those in the range [33, 126]), except for colons. This
+	// implementation is very slightly stricter, as it disallows several
+	// additional special characters.
+	const forbiddenChars = "\"()/,:;<=>?@[\\]{}"
+
+	var as asciiSet
+	for i := rune(33); i <= rune(126); i++ {
+		if !strings.ContainsRune(forbiddenChars, i) {
+			as[i] = true
+		}
+	}
+	return as
+}
+
+func isHeaderKeyValid(k string) bool {
+	if len(k) == 0 {
+		return false
+	}
+	return validHeaderKeyChars.MatchesString(k)
+}
+
+func isHeaderValueValid(v string) bool {
+
+	// ADR-4 specifies that header values must be ASCII characters and cannot
+	// include CR/LF, but the Go client implementation has historically been
+	// more lenient in that it also permits Unicode values. Because existing
+	// user code may rely on that behavior, we need to continue supporting the
+	// more lenient alphabet.
+
+	// NOTE: strings.IndexByte is SIMD-optimized (handling 16+ bytes at a time),
+	// making it (currently) faster to iterate over the strings twice (once for
+	// each invalid character) than it is to call `strings.ContainsAny(v, "\r\n")`
+	// directly.
+	return strings.IndexByte(v, '\r') == -1 &&
+		strings.IndexByte(v, '\n') == -1
 }
 
 type barrierInfo struct {

--- a/nats.go
+++ b/nats.go
@@ -853,20 +853,23 @@ func (m *Msg) headerBytes() ([]byte, error) {
 		return hdr, nil
 	}
 
-	// Validate the keys/values and calculate an upper bound for the total
-	// encoded size. The size calculation may not be exact if any values
-	// contain leading/trailing whitespace (as those will be trimmed later),
-	// but a slight over-estimation here is more preferable than an
-	// under-estimation (which could lead to unnecessary memory allocations).
+	// Validate the keys and calculate an upper bound for the total encoded
+	// size.
+	//
+	// The size calculation may not be exact if any values contain
+	// leading/trailing whitespace (as those will be trimmed later), but a
+	// slight over-estimation here is more preferable than an under-estimation
+	// (which could lead to unnecessary memory allocations).
+	//
+	// We don't perform any special validation on header values because we
+	// consider all strings to be valid values (including Unicode strings,
+	// special characters, etc.).
 	hdrSize := len(hdrLine) + len(crlf)
 	for k, vs := range m.Header {
 		if !isHeaderKeyValid(k) {
 			return nil, ErrBadHeaderMsg
 		}
 		for _, v := range vs {
-			if !isHeaderValueValid(v) {
-				return nil, ErrBadHeaderMsg
-			}
 			hdrSize += len(k) + len(v) + 4 // 4 is for the colon, space, CR, and LF
 		}
 	}
@@ -882,7 +885,7 @@ func (m *Msg) headerBytes() ([]byte, error) {
 		for _, v := range vs {
 			_, _ = b.WriteString(k)
 			_, _ = b.WriteString(": ")
-			_, _ = b.WriteString(textproto.TrimString(v))
+			writeHeaderValue(&b, v)
 			_, _ = b.WriteString(crlf)
 		}
 	}
@@ -974,20 +977,20 @@ func isHeaderKeyValid(k string) bool {
 	return len(k) > 0 && validHeaderKeyChars.MatchesString(k)
 }
 
-func isHeaderValueValid(v string) bool {
+var headerValueNewlineReplacer = strings.NewReplacer("\r", " ", "\n", " ")
 
-	// ADR-4 specifies that header values must be ASCII characters and cannot
-	// include CR/LF, but the Go client implementation has historically been
-	// more lenient in that it also permits Unicode values. Because existing
-	// user code may rely on that behavior, we need to continue supporting the
-	// more lenient alphabet.
+func writeHeaderValue(buffer *bytes.Buffer, value string) {
 
-	// NOTE: strings.IndexByte is SIMD-optimized (handling 16+ bytes at a time),
-	// making it (currently) faster to iterate over the strings twice (once for
-	// each invalid character) than it is to call `strings.ContainsAny(v, "\r\n")`
-	// directly.
-	return strings.IndexByte(v, '\r') == -1 &&
-		strings.IndexByte(v, '\n') == -1
+	// ADR-4 specifies that header values must be ASCII characters (except for
+	// '\r' or '\n'), however the Go implementation is slightly more lenient
+	// to maintain backwards compatibility with older versions of the library.
+	// We allow arbitrary UTF-8 strings to be used as values and deliberately
+	// sanitize '\r' and '\n' characters by replacing them with spaces.
+
+	// NOTE: It is safe to ignore the error returned by WriteString because
+	// we're writing to a bytes.Buffer object, and that implementation never
+	// returns an error.
+	_, _ = headerValueNewlineReplacer.WriteString(buffer, textproto.TrimString(value))
 }
 
 type barrierInfo struct {

--- a/nats_test.go
+++ b/nats_test.go
@@ -1692,6 +1692,7 @@ func TestHeaderValidKeys(t *testing.T) {
 
 func TestHeaderInvalidKeys(t *testing.T) {
 	testKeys := []string{
+		"",       // Empty string
 		":",      // Illegal printable ASCII character
 		"\r",     // Non-printable ASCII character
 		"\n",     // Non-printable ASCII character

--- a/nats_test.go
+++ b/nats_test.go
@@ -13,9 +13,9 @@
 
 package nats
 
-////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////
 // Package scoped specific tests here..
-////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////
 
 import (
 	"bufio"
@@ -207,9 +207,9 @@ func TestExpandPath(t *testing.T) {
 	}
 }
 
-////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////
 // ServerPool tests
-////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////
 
 var testServers = []string{
 	"nats://localhost:1222",
@@ -1636,7 +1636,6 @@ func TestHeaderMultiLine(t *testing.T) {
 	http.Header(m.Header).Add("AUTHORIZATION", "s3cr3t")
 
 	// Multi Value Header becomes represented as multi-lines in the wire
-	// since internally using same Write from http stdlib.
 	m.Header.Set("X-Test", "First")
 	m.Header.Add("X-Test", "Second")
 	m.Header.Add("X-Test", "Third")
@@ -1647,24 +1646,102 @@ func TestHeaderMultiLine(t *testing.T) {
 	}
 	result := string(b)
 
-	expectedHeader := `NATS/1.0
-Accept-Encoding: json
-Authorization: s3cr3t
-CorrelationID: 123
-Msg-ID: 456
-X-NATS-Keys: A
-X-NATS-Keys: B
-X-NATS-Keys: C
-X-Test: First
-X-Test: Second
-X-Test: Third
-X-Test-Keys: D
-X-Test-Keys: E
-X-Test-Keys: F
+	// Require the header string to have a known prefix and suffix
+	if !strings.HasPrefix(result, "NATS/1.0\r\n") {
+		t.Fatalf("header prefix not present")
+	}
+	if !strings.HasSuffix(result, "\r\n\r\n") {
+		t.Fatalf("header suffix not present")
+	}
 
-`
-	if strings.Replace(expectedHeader, "\n", "\r\n", -1) != result {
-		t.Fatalf("Expected: %q, got: %q", expectedHeader, result)
+	// Require the header string to contain each of the following rows. Note
+	// that headers can be written in any order.
+	expectedHeaderLines := []string{
+		"Accept-Encoding: json\r\n",
+		"Authorization: s3cr3t\r\n",
+		"CorrelationID: 123\r\n",
+		"Msg-ID: 456\r\n",
+		"X-NATS-Keys: A\r\n",
+		"X-NATS-Keys: B\r\n",
+		"X-NATS-Keys: C\r\n",
+		"X-Test: First\r\n",
+		"X-Test: Second\r\n",
+		"X-Test: Third\r\n",
+		"X-Test-Keys: D\r\n",
+		"X-Test-Keys: E\r\n",
+		"X-Test-Keys: F\r\n",
+	}
+	for _, h := range expectedHeaderLines {
+		if !strings.Contains(result, h) {
+			t.Fatalf("expected header line '%s' to be present", h)
+		}
+	}
+}
+
+func TestHeaderValidKeys(t *testing.T) {
+	const validChars = "!#$%&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~"
+
+	m := NewMsg("foo")
+	m.Header = Header{
+		validChars: []string{"value"},
+	}
+	if _, err := m.headerBytes(); err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
+func TestHeaderInvalidKeys(t *testing.T) {
+	testKeys := []string{
+		":",      // Illegal printable ASCII character
+		"\r",     // Non-printable ASCII character
+		"\n",     // Non-printable ASCII character
+		"\t",     // Non-printable ASCII character
+		"\x00",   // Non-printable ASCII character
+		"→",      // Standard Unicode character
+		"\u200b", // Non-printable Unicode character
+	}
+	for _, key := range testKeys {
+		m := NewMsg("foo")
+		m.Header = Header{
+			key: []string{"value"},
+		}
+		if _, err := m.headerBytes(); err == nil {
+			t.Fatalf("expected error for key '%s'", key)
+		}
+	}
+}
+
+func TestHeaderValidValues(t *testing.T) {
+	testValues := []string{
+		"!\"#$%&'()*+,-./0123456789;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",                              // Printable ASCII characters
+		"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0b\x0c\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1c\x1d\x1e\x1f", // Invisible ASCII characters (except CR/LF)
+		"→",      // Standard Unicode characters
+		"\u200b", // Non-printable Unicode characters
+	}
+	for _, v := range testValues {
+		m := NewMsg(v)
+		m.Header = Header{
+			"key": []string{v},
+		}
+		if _, err := m.headerBytes(); err != nil {
+			t.Fatal(err.Error())
+		}
+	}
+}
+
+func TestHeaderInvalidValues(t *testing.T) {
+	testValues := []string{
+		"\r",
+		"\n",
+	}
+	for _, value := range testValues {
+		m := NewMsg("foo")
+		m.Header = Header{
+			"key": []string{value},
+		}
+		if _, err := m.headerBytes(); err == nil {
+			t.Fatalf("expected error for value '%s'", value)
+		}
 	}
 }
 

--- a/nats_test.go
+++ b/nats_test.go
@@ -1730,19 +1730,17 @@ func TestHeaderValidValues(t *testing.T) {
 	}
 }
 
-func TestHeaderInvalidValues(t *testing.T) {
-	testValues := []string{
-		"\r",
-		"\n",
+func TestHeaderNewlineValue(t *testing.T) {
+	m := NewMsg("foo")
+	m.Header.Set("X-Test", "line1\nline2\rline3")
+
+	b, err := m.headerBytes()
+	if err != nil {
+		t.Fatal(err.Error())
 	}
-	for _, value := range testValues {
-		m := NewMsg("foo")
-		m.Header = Header{
-			"key": []string{value},
-		}
-		if _, err := m.headerBytes(); err == nil {
-			t.Fatalf("expected error for value '%s'", value)
-		}
+	out := string(b)
+	if !strings.Contains(out, "X-Test: line1 line2 line3") {
+		t.Fatalf("expected sanitized 'X-Test: line1 line2 line3', got: %q", out)
 	}
 }
 

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -15,6 +15,7 @@ package test
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -40,6 +41,47 @@ func BenchmarkPublishSpeed(b *testing.B) {
 	// Make sure they are all processed.
 	nc.Flush()
 	b.StopTimer()
+}
+
+func BenchmarkPublishSpeedHeaders(b *testing.B) {
+	b.StopTimer()
+	s := RunDefaultServer()
+	defer s.Shutdown()
+	nc := NewDefaultConnection(b)
+	defer nc.Close()
+
+	headers := make(nats.Header, 10)
+	for i := range 10 {
+		headers.Add(
+			fmt.Sprintf("header_%d", i),
+			generateRandomString(32),
+		)
+	}
+	msg := &nats.Msg{
+		Subject: "foo",
+		Header:  headers,
+		Data:    []byte("Hello World"),
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if err := nc.PublishMsg(msg); err != nil {
+			b.Fatalf("Error in benchmark during PublishMsg: %v\n", err)
+		}
+	}
+
+	// Make sure they are all processed.
+	nc.Flush()
+	b.StopTimer()
+}
+
+func generateRandomString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.IntN(len(charset))]
+	}
+	return string(b)
 }
 
 func BenchmarkPubSubSpeed(b *testing.B) {


### PR DESCRIPTION
This PR (partially) addresses #2068.

### Summary
The goal is to reduce the amount of overhead associated with publishing messages that use headers. The existing implementation uses more memory allocations than strictly needed and incurs extra overhead by sorting header keys before they're written. This implementation addresses those concerns by iterating over the headers twice, once to validate the keys and to calculate the total encoded size, and again to actually write the data. Benchmarks show this new approach improves performance of the `PublishMsg()` API by about 1.7x on the testing machine.

### Benchmark Results

Before / After:
```
>>> go test -bench=. -benchmem -run=xxx
goos: darwin
goarch: arm64
pkg: pub
cpu: Apple M1 Pro
BenchmarkPublish_Before          389253              2902 ns/op            1009 B/op          5 allocs/op
BenchmarkPublish_After           611394              1718 ns/op             480 B/op          1 allocs/op
```

NOTE: See Appendix 1 below for benchmark source. I've included a similar benchmark in `test/bench_test.go` to check for future regressions.

### Behavior Changes
  - Invalid header keys will be rejected, rather than ignored. The alphabet used to determine valid/invalid header keys is unchanged to maintain backwards compatibility. The behavior for values is unchanged. We allow for any UTF-8 string to be used as a value, and any '\r' or '\n' characters present in a value will be transparently replaced with spaces.
  - Headers are no longer written in sorted order by key. They will instead be written in an unspecified order.
  - The lookup table used to identify valid keys requires an extra 256 bytes of space. This may be relevant to anyone working in the embedded space, but it is unlikely to impact most users.

### Future Work
  - All but one of the memory allocations used to encode the headers have been removed with this PR, but it is also possible to remove the final memory allocation with some amount of additional refactoring. Doing so would be an additional performance improvement.
  - The performance of `isHeaderKeyValid` could theoretically be improved further with a SIMD-accelerated implementation. Go is considering adding native support for SIMD in upcoming releases, but using those instructions today would require a significant amount of maintenance overhead that probably isn't justifiable at the moment.

### Implementation Details
Performance is heavily dependent on the `isHeaderKeyValid` helper function, so an attempt has been made to optimize it as much as reasonably possible.

`isHeaderKeyValid` requires ASCII inputs. Here, we've taken inspiration from the Go standard library. Much of Go's string handling code (e.g. `strings.Contains`) internally uses an abstraction called an `asciiSet` to quickly determine whether a particular byte is "valid" or not without incurring the overhead associated with multi-byte Unicode string decoding. 

We use the same pattern to create a lookup table of valid characters for header keys. The first 127 bytes of the table represent the standard ASCII character set, and the remaining bytes are zeroed out. We set individual bytes of the table based on which ASCII characters we want to allow. In this case, [ADR-4](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-4.md) specifies that headers should contain only printable ASCII characters (except for colons). We also exclude several other special characters to maintain backwards-compatibility with older versions of the client library.

This lookup table is pre-calculated and cached because it never changes during program execution, but doing so does require the client to allocate an additional 256 bytes. We believe this to be an acceptable tradeoff relative to the associated performance gains, but the table could (conceptually) be regenerated from scratch for each message if needed.

Another small callout: the implementation of `asciiSet.MatchesString` uses some manual loop unrolling to further improve performance. On the test machine, doing so is about 1.5x faster than the naive approach with a simple for-loop.

### Appendix 1: Benchmark Source
```Go
func BenchmarkPublish(b *testing.B) {
	// Connect to Nats server on localhost
	nc, err := nats.Connect("nats://localhost:4222")
	if err != nil {
		b.Fatal(err)
	}
	defer nc.Close()

	// Prepare message
	payload := make([]byte, 128)
	headers := make(nats.Header)
	for i := range 10 {
		headers.Add(
			fmt.Sprintf("header_%d", i),
			generateRandomString(32),
		)
	}
	msg := &nats.Msg{
		Subject: "test.subject",
		Header:  headers,
		Data:    payload,
	}

	// Run benchmark
	b.ReportAllocs()
	b.ResetTimer()
	for b.Loop() {
		_ = nc.PublishMsg(msg)
	}
}

func generateRandomString(length int) string {
	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
	b := make([]byte, length)
	for i := range b {
		b[i] = charset[rand.IntN(len(charset))]
	}
	return string(b)
}
```

Signed-off-by: Jon C. Hammer