### PR TITLE
docs: document HTTP header name requirement for Msg.Header

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -4230,12 +4230,22 @@ func (nc *Conn) Publish(subj string, data []byte) error {
 	return nc.publish(subj, _EMPTY_, false, nil, data)
 }
 
-// Header represents the optional Header for a NATS message,
-// based on the implementation of http.Header.
+// Header represents the optional Header for a NATS message.
+//
+// Header is a map-based type modeled after net/http.Header. When messages are
+// encoded for the wire, headers are serialized via http.Header.Write, which only
+// emits field names valid for HTTP (RFC 7230 token syntax). Field names that are
+// valid under NATS ADR-4 but invalid for HTTP—such as those containing '/'—are
+// stored in the map but silently omitted from the encoded message. Use
+// HTTP-compatible header names (e.g. "Thing-With-Slash" instead of
+// "thing/with/slash") when publishing headers that must survive a round trip.
 type Header map[string][]string
 
 // Add adds the key, value pair to the header. It is case-sensitive
 // and appends to any existing values associated with key.
+//
+// Keys must be valid HTTP header field names to be included when the message
+// is published; see Header for details.
 func (h Header) Add(key, value string) {
 	h[key] = append(h[key], value)
 }
@@ -4243,6 +4253,9 @@ func (h Header) Add(key, value string) {
 // Set sets the header entries associated with key to the single
 // element value. It is case-sensitive and replaces any existing
 // values associated with key.
+//
+// Keys must be valid HTTP header field names to be included when the message
+// is published; see Header for details.
 func (h Header) Set(key, value string) {
 	h[key] = []string{value}
 }

--- a/nats_test.go
+++ b/nats_test.go
@@ -1668,6 +1668,25 @@ X-Test-Keys: F
 	}
 }
 
+func TestHeaderNonHTTPFieldNameOmitted(t *testing.T) {
+	m := NewMsg("foo")
+	m.Header.Set("Valid-Header", "ok")
+	m.Header.Set("thing/with/slash", "dropped")
+
+	b, err := m.headerBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := string(b)
+
+	if !strings.Contains(result, "Valid-Header: ok") {
+		t.Fatalf("expected valid header in encoded output, got: %q", result)
+	}
+	if strings.Contains(result, "thing/with/slash") {
+		t.Fatalf("expected non-HTTP header name to be omitted, got: %q", result)
+	}
+}
+
 func TestLameDuckMode(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {


### PR DESCRIPTION
## Summary

- Documents that `Header` encoding uses `http.Header.Write`, which only emits HTTP-valid field names
- Notes that ADR-4-valid names with non-HTTP characters (e.g. `/`) are stored locally but omitted on publish
- Adds `TestHeaderNonHTTPFieldNameOmitted` to lock in the current wire behavior

Fixes #1276

## Context

Per discussion on the issue and NATS Slack, the immediate fix is documentation rather than changing the wire encoding format. Callers who need headers to survive a round trip should use HTTP-compatible field names.

## Test plan

- [x] `go test -run 'TestHeaderNonHTTPFieldNameOmitted|TestHeaderMultiLine' -v`