### PR TITLE
fix: wrap invalid server INFO parse errors with context

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -4052,7 +4052,7 @@ func (nc *Conn) processInfo(info string) error {
 	}
 	var ncInfo ServerInfo
 	if err := json.Unmarshal([]byte(info), &ncInfo); err != nil {
-		return err
+		return fmt.Errorf("nats: invalid INFO message from server: %w", err)
 	}
 
 	// Copy content into connection's info structure.

--- a/nats_test.go
+++ b/nats_test.go
@@ -1244,6 +1244,30 @@ func TestNoEchoOldServer(t *testing.T) {
 	}
 }
 
+func TestProcessInfoInvalidMessage(t *testing.T) {
+	nc := &Conn{}
+
+	tests := []struct {
+		name string
+		info string
+	}{
+		{name: "empty json object fragment", info: "{"},
+		{name: "whitespace only", info: "   "},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := nc.processInfo(test.info)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "invalid INFO message from server") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestExpiredAuthentication(t *testing.T) {
 	// The goal of these tests was to check how a client with an expiring JWT
 	// behaves. It should receive an async -ERR indicating that the auth


### PR DESCRIPTION
## Summary

Fixes #1103

When the initial INFO payload is truncated or malformed (for example behind a WAF on TLS port 443), `json.Unmarshal` returned a bare `EOF` or syntax error that was difficult to diagnose.

This change wraps INFO parse failures with `nats: invalid INFO message from server: ...` so callers can distinguish protocol/handshake issues from other connection errors.

## Test plan

- [x] `go test -run TestProcessInfoInvalidMessage -v`
- [ ] Added tests for truncated JSON and whitespace-only INFO payloads