### PR TITLE
fix: honor per-request Domain option in consumer APIs

### DIFF
--- a/js.go
+++ b/js.go
@@ -445,11 +445,15 @@ func StreamListFilter(subject string) JSOpt {
 }
 
 func (js *js) apiSubj(subj string) string {
-	if js.opts.pre == _EMPTY_ {
+	return apiSubjWithPrefix(js.opts.pre, subj)
+}
+
+func apiSubjWithPrefix(pre, subj string) string {
+	if pre == _EMPTY_ {
 		return subj
 	}
 	var b strings.Builder
-	b.WriteString(js.opts.pre)
+	b.WriteString(pre)
 	b.WriteString(subj)
 	return b.String()
 }
@@ -3507,12 +3511,12 @@ func (o *pullOpts) checkCtxErr(err error) error {
 func (js *js) getConsumerInfo(stream, consumer string) (*ConsumerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), js.opts.wait)
 	defer cancel()
-	return js.getConsumerInfoContext(ctx, stream, consumer)
+	return js.getConsumerInfoContext(ctx, stream, consumer, js.opts.pre)
 }
 
-func (js *js) getConsumerInfoContext(ctx context.Context, stream, consumer string) (*ConsumerInfo, error) {
+func (js *js) getConsumerInfoContext(ctx context.Context, stream, consumer, pre string) (*ConsumerInfo, error) {
 	ccInfoSubj := fmt.Sprintf(apiConsumerInfoT, stream, consumer)
-	resp, err := js.apiRequestWithContext(ctx, js.apiSubj(ccInfoSubj), nil)
+	resp, err := js.apiRequestWithContext(ctx, apiSubjWithPrefix(pre, ccInfoSubj), nil)
 	if err != nil {
 		if errors.Is(err, ErrNoResponders) {
 			err = ErrJetStreamNotEnabled

--- a/jsm.go
+++ b/jsm.go
@@ -533,7 +533,7 @@ func (js *js) upsertConsumer(stream, consumerName string, cfg *ConsumerConfig, o
 		}
 	}
 
-	resp, err := js.apiRequestWithContext(o.ctx, js.apiSubj(ccSubj), req)
+	resp, err := js.apiRequestWithContext(o.ctx, apiSubjWithPrefix(o.pre, ccSubj), req)
 	if err != nil {
 		if errors.Is(err, ErrNoResponders) {
 			err = ErrJetStreamNotEnabled
@@ -645,7 +645,7 @@ func (js *js) ConsumerInfo(stream, consumer string, opts ...JSOpt) (*ConsumerInf
 	if cancel != nil {
 		defer cancel()
 	}
-	return js.getConsumerInfoContext(o.ctx, stream, consumer)
+	return js.getConsumerInfoContext(o.ctx, stream, consumer, o.pre)
 }
 
 // consumerLister fetches pages of ConsumerInfo objects. This object is not

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -9000,6 +9000,10 @@ func TestJetStreamDomain(t *testing.T) {
 	}
 	jsd.Publish("foo", []byte("first"))
 
+	if _, err = jsd.AddConsumer("foo", &nats.ConsumerConfig{Durable: "c1"}); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
 	sub, err := jsd.SubscribeSync("foo")
 	if err != nil {
 		t.Fatal(err)
@@ -9053,6 +9057,18 @@ func TestJetStreamDomain(t *testing.T) {
 	expected = "second"
 	if got != expected {
 		t.Errorf("Got %v, expected: %v", got, expected)
+	}
+
+	// Per-request Domain option should be honored for consumer management APIs.
+	ci, err := js.ConsumerInfo("foo", "c1", nats.Domain("ABC"))
+	if err != nil {
+		t.Fatalf("ConsumerInfo with Domain opt failed: %v", err)
+	}
+	if ci == nil || ci.Name != "c1" {
+		t.Fatalf("Unexpected consumer info: %+v", ci)
+	}
+	if _, err = js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "c2"}, nats.Domain("ABC")); err != nil {
+		t.Fatalf("AddConsumer with Domain opt failed: %v", err)
 	}
 
 	// Using different domain not configured is an error.


### PR DESCRIPTION
## Summary

- Fixes `ConsumerInfo` and `AddConsumer`/`UpdateConsumer` ignoring per-request `JSOpt` values such as `nats.Domain()`
- These methods already merged options via `getJSContextOpts`, but API subjects were still built from the JetStream context defaults (`js.opts.pre`)
- Use the merged API prefix (`o.pre`) when issuing consumer info and create requests

## Test plan

- [x] Extended `TestJetStreamDomain` to cover `ConsumerInfo` and `AddConsumer` with per-request `nats.Domain("ABC")`
- [ ] CI integration tests

Fixes #1104