### PR TITLE
fix: honor per-request JSOpt API prefix across JetStream APIs

### DIFF
--- a/js.go
+++ b/js.go
@@ -458,6 +458,10 @@ func apiSubjWithPrefix(pre, subj string) string {
 	return b.String()
 }
 
+func (o *jsOpts) apiSubj(subj string) string {
+	return apiSubjWithPrefix(o.pre, subj)
+}
+
 // PubOpt configures options for publishing JetStream messages.
 type PubOpt interface {
 	configurePublish(opts *pubOpts) error
@@ -3511,12 +3515,12 @@ func (o *pullOpts) checkCtxErr(err error) error {
 func (js *js) getConsumerInfo(stream, consumer string) (*ConsumerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), js.opts.wait)
 	defer cancel()
-	return js.getConsumerInfoContext(ctx, stream, consumer, js.opts.pre)
+	return js.getConsumerInfoContext(ctx, stream, consumer, js.opts)
 }
 
-func (js *js) getConsumerInfoContext(ctx context.Context, stream, consumer, pre string) (*ConsumerInfo, error) {
+func (js *js) getConsumerInfoContext(ctx context.Context, stream, consumer string, o *jsOpts) (*ConsumerInfo, error) {
 	ccInfoSubj := fmt.Sprintf(apiConsumerInfoT, stream, consumer)
-	resp, err := js.apiRequestWithContext(ctx, apiSubjWithPrefix(pre, ccInfoSubj), nil)
+	resp, err := js.apiRequestWithContext(ctx, o.apiSubj(ccInfoSubj), nil)
 	if err != nil {
 		if errors.Is(err, ErrNoResponders) {
 			err = ErrJetStreamNotEnabled

--- a/js.go
+++ b/js.go
@@ -445,11 +445,15 @@ func StreamListFilter(subject string) JSOpt {
 }
 
 func (js *js) apiSubj(subj string) string {
-	if js.opts.pre == _EMPTY_ {
+	return apiSubjWithPrefix(js.opts.pre, subj)
+}
+
+func apiSubjWithPrefix(pre, subj string) string {
+	if pre == _EMPTY_ {
 		return subj
 	}
 	var b strings.Builder
-	b.WriteString(js.opts.pre)
+	b.WriteString(pre)
 	b.WriteString(subj)
 	return b.String()
 }
@@ -3507,12 +3511,12 @@ func (o *pullOpts) checkCtxErr(err error) error {
 func (js *js) getConsumerInfo(stream, consumer string) (*ConsumerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), js.opts.wait)
 	defer cancel()
-	return js.getConsumerInfoContext(ctx, stream, consumer)
+	return js.getConsumerInfoContext(ctx, stream, consumer, js.opts.pre)
 }
 
-func (js *js) getConsumerInfoContext(ctx context.Context, stream, consumer string) (*ConsumerInfo, error) {
+func (js *js) getConsumerInfoContext(ctx context.Context, stream, consumer, pre string) (*ConsumerInfo, error) {
 	ccInfoSubj := fmt.Sprintf(apiConsumerInfoT, stream, consumer)
-	resp, err := js.apiRequestWithContext(ctx, js.apiSubj(ccInfoSubj), nil)
+	resp, err := js.apiRequestWithContext(ctx, apiSubjWithPrefix(pre, ccInfoSubj), nil)
 	if err != nil {
 		if errors.Is(err, ErrNoResponders) {
 			err = ErrJetStreamNotEnabled

--- a/jsm.go
+++ b/jsm.go
@@ -406,7 +406,7 @@ func (js *js) AccountInfo(opts ...JSOpt) (*AccountInfo, error) {
 		defer cancel()
 	}
 
-	resp, err := js.apiRequestWithContext(o.ctx, js.apiSubj(apiAccountInfo), nil)
+	resp, err := js.apiRequestWithContext(o.ctx, o.apiSubj(apiAccountInfo), nil)
 	if err != nil {
 		// todo maybe nats server should never have no responder on this subject and always respond if they know there is no js to be had
 		if errors.Is(err, ErrNoResponders) {
@@ -533,7 +533,7 @@ func (js *js) upsertConsumer(stream, consumerName string, cfg *ConsumerConfig, o
 		}
 	}
 
-	resp, err := js.apiRequestWithContext(o.ctx, apiSubjWithPrefix(o.pre, ccSubj), req)
+	resp, err := js.apiRequestWithContext(o.ctx, o.apiSubj(ccSubj), req)
 	if err != nil {
 		if errors.Is(err, ErrNoResponders) {
 			err = ErrJetStreamNotEnabled
@@ -611,7 +611,7 @@ func (js *js) DeleteConsumer(stream, consumer string, opts ...JSOpt) error {
 		defer cancel()
 	}
 
-	dcSubj := js.apiSubj(fmt.Sprintf(apiConsumerDeleteT, stream, consumer))
+	dcSubj := o.apiSubj(fmt.Sprintf(apiConsumerDeleteT, stream, consumer))
 	r, err := js.apiRequestWithContext(o.ctx, dcSubj, nil)
 	if err != nil {
 		return err
@@ -645,7 +645,7 @@ func (js *js) ConsumerInfo(stream, consumer string, opts ...JSOpt) (*ConsumerInf
 	if cancel != nil {
 		defer cancel()
 	}
-	return js.getConsumerInfoContext(o.ctx, stream, consumer, o.pre)
+	return js.getConsumerInfoContext(o.ctx, stream, consumer, o)
 }
 
 // consumerLister fetches pages of ConsumerInfo objects. This object is not
@@ -920,7 +920,7 @@ func (js *js) AddStream(cfg *StreamConfig, opts ...JSOpt) (*StreamInfo, error) {
 		return nil, err
 	}
 
-	csSubj := js.apiSubj(fmt.Sprintf(apiStreamCreateT, cfg.Name))
+	csSubj := o.apiSubj(fmt.Sprintf(apiStreamCreateT, cfg.Name))
 	r, err := js.apiRequestWithContext(o.ctx, csSubj, req)
 	if err != nil {
 		return nil, err
@@ -1001,7 +1001,7 @@ func (js *js) StreamInfo(stream string, opts ...JSOpt) (*StreamInfo, error) {
 			}
 		}
 
-		siSubj := js.apiSubj(fmt.Sprintf(apiStreamInfoT, stream))
+		siSubj := o.apiSubj(fmt.Sprintf(apiStreamInfoT, stream))
 
 		r, err := js.apiRequestWithContext(o.ctx, siSubj, req)
 		if err != nil {
@@ -1135,7 +1135,7 @@ func (js *js) UpdateStream(cfg *StreamConfig, opts ...JSOpt) (*StreamInfo, error
 		return nil, err
 	}
 
-	usSubj := js.apiSubj(fmt.Sprintf(apiStreamUpdateT, cfg.Name))
+	usSubj := o.apiSubj(fmt.Sprintf(apiStreamUpdateT, cfg.Name))
 	r, err := js.apiRequestWithContext(o.ctx, usSubj, req)
 	if err != nil {
 		return nil, err
@@ -1189,7 +1189,7 @@ func (js *js) DeleteStream(name string, opts ...JSOpt) error {
 		defer cancel()
 	}
 
-	dsSubj := js.apiSubj(fmt.Sprintf(apiStreamDeleteT, name))
+	dsSubj := o.apiSubj(fmt.Sprintf(apiStreamDeleteT, name))
 	r, err := js.apiRequestWithContext(o.ctx, dsSubj, nil)
 	if err != nil {
 		return err
@@ -1265,7 +1265,7 @@ func (js *js) getMsg(name string, mreq *apiMsgGetRequest, opts ...JSOpt) (*RawSt
 	var apiSubj string
 	if o.directGet && mreq.LastFor != _EMPTY_ {
 		apiSubj = apiDirectMsgGetLastBySubjectT
-		dsSubj := js.apiSubj(fmt.Sprintf(apiSubj, name, mreq.LastFor))
+		dsSubj := o.apiSubj(fmt.Sprintf(apiSubj, name, mreq.LastFor))
 		r, err := js.apiRequestWithContext(o.ctx, dsSubj, nil)
 		if err != nil {
 			return nil, err
@@ -1285,7 +1285,7 @@ func (js *js) getMsg(name string, mreq *apiMsgGetRequest, opts ...JSOpt) (*RawSt
 		return nil, err
 	}
 
-	dsSubj := js.apiSubj(fmt.Sprintf(apiSubj, name))
+	dsSubj := o.apiSubj(fmt.Sprintf(apiSubj, name))
 	r, err := js.apiRequestWithContext(o.ctx, dsSubj, req)
 	if err != nil {
 		return nil, err
@@ -1416,7 +1416,7 @@ func (js *js) DeleteMsg(name string, seq uint64, opts ...JSOpt) error {
 		defer cancel()
 	}
 
-	return js.deleteMsg(o.ctx, name, &msgDeleteRequest{Seq: seq, NoErase: true})
+	return js.deleteMsg(o, name, &msgDeleteRequest{Seq: seq, NoErase: true})
 }
 
 // SecureDeleteMsg deletes a message from a stream. The deleted message is overwritten with random data
@@ -1430,10 +1430,10 @@ func (js *js) SecureDeleteMsg(name string, seq uint64, opts ...JSOpt) error {
 		defer cancel()
 	}
 
-	return js.deleteMsg(o.ctx, name, &msgDeleteRequest{Seq: seq})
+	return js.deleteMsg(o, name, &msgDeleteRequest{Seq: seq})
 }
 
-func (js *js) deleteMsg(ctx context.Context, stream string, req *msgDeleteRequest) error {
+func (js *js) deleteMsg(o *jsOpts, stream string, req *msgDeleteRequest) error {
 	if err := checkStreamName(stream); err != nil {
 		return err
 	}
@@ -1442,8 +1442,8 @@ func (js *js) deleteMsg(ctx context.Context, stream string, req *msgDeleteReques
 		return err
 	}
 
-	dsSubj := js.apiSubj(fmt.Sprintf(apiMsgDeleteT, stream))
-	r, err := js.apiRequestWithContext(ctx, dsSubj, reqJSON)
+	dsSubj := o.apiSubj(fmt.Sprintf(apiMsgDeleteT, stream))
+	r, err := js.apiRequestWithContext(o.ctx, dsSubj, reqJSON)
 	if err != nil {
 		return err
 	}
@@ -1505,7 +1505,7 @@ func (js *js) purgeStream(stream string, req *StreamPurgeRequest, opts ...JSOpt)
 		}
 	}
 
-	psSubj := js.apiSubj(fmt.Sprintf(apiStreamPurgeT, stream))
+	psSubj := o.apiSubj(fmt.Sprintf(apiStreamPurgeT, stream))
 	r, err := js.apiRequestWithContext(o.ctx, psSubj, b)
 	if err != nil {
 		return err
@@ -1749,7 +1749,7 @@ func (jsc *js) StreamNameBySubject(subj string, opts ...JSOpt) (string, error) {
 		return _EMPTY_, err
 	}
 
-	resp, err := jsc.apiRequestWithContext(o.ctx, jsc.apiSubj(apiStreams), j)
+	resp, err := jsc.apiRequestWithContext(o.ctx, o.apiSubj(apiStreams), j)
 	if err != nil {
 		if errors.Is(err, ErrNoResponders) {
 			err = ErrJetStreamNotEnabled

--- a/jsm.go
+++ b/jsm.go
@@ -533,7 +533,7 @@ func (js *js) upsertConsumer(stream, consumerName string, cfg *ConsumerConfig, o
 		}
 	}
 
-	resp, err := js.apiRequestWithContext(o.ctx, js.apiSubj(ccSubj), req)
+	resp, err := js.apiRequestWithContext(o.ctx, apiSubjWithPrefix(o.pre, ccSubj), req)
 	if err != nil {
 		if errors.Is(err, ErrNoResponders) {
 			err = ErrJetStreamNotEnabled
@@ -645,7 +645,7 @@ func (js *js) ConsumerInfo(stream, consumer string, opts ...JSOpt) (*ConsumerInf
 	if cancel != nil {
 		defer cancel()
 	}
-	return js.getConsumerInfoContext(o.ctx, stream, consumer)
+	return js.getConsumerInfoContext(o.ctx, stream, consumer, o.pre)
 }
 
 // consumerLister fetches pages of ConsumerInfo objects. This object is not

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -9000,6 +9000,10 @@ func TestJetStreamDomain(t *testing.T) {
 	}
 	jsd.Publish("foo", []byte("first"))
 
+	if _, err = jsd.AddConsumer("foo", &nats.ConsumerConfig{Durable: "c1"}); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
 	sub, err := jsd.SubscribeSync("foo")
 	if err != nil {
 		t.Fatal(err)
@@ -9053,6 +9057,18 @@ func TestJetStreamDomain(t *testing.T) {
 	expected = "second"
 	if got != expected {
 		t.Errorf("Got %v, expected: %v", got, expected)
+	}
+
+	// Per-request Domain option should be honored for consumer management APIs.
+	ci, err := js.ConsumerInfo("foo", "c1", nats.Domain("ABC"))
+	if err != nil {
+		t.Fatalf("ConsumerInfo with Domain opt failed: %v", err)
+	}
+	if ci == nil || ci.Name != "c1" {
+		t.Fatalf("Unexpected consumer info: %+v", ci)
+	}
+	if _, err = js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "c2"}, nats.Domain("ABC")); err != nil {
+		t.Fatalf("AddConsumer with Domain opt failed: %v", err)
 	}
 
 	// Using different domain not configured is an error.

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -9070,6 +9070,16 @@ func TestJetStreamDomain(t *testing.T) {
 	if _, err = js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "c2"}, nats.Domain("ABC")); err != nil {
 		t.Fatalf("AddConsumer with Domain opt failed: %v", err)
 	}
+	si, err := js.StreamInfo("foo", nats.Domain("ABC"))
+	if err != nil {
+		t.Fatalf("StreamInfo with Domain opt failed: %v", err)
+	}
+	if si == nil || si.Config.Name != "foo" {
+		t.Fatalf("Unexpected stream info: %+v", si)
+	}
+	if err = js.DeleteConsumer("foo", "c2", nats.Domain("ABC")); err != nil {
+		t.Fatalf("DeleteConsumer with Domain opt failed: %v", err)
+	}
 
 	// Using different domain not configured is an error.
 	jsb, err := nc.JetStream(nats.Domain("XYZ"))


### PR DESCRIPTION
## Summary

- Fixes legacy JetStream APIs that accept `JSOpt` but ignored per-request options such as `nats.Domain()` and `nats.APIPrefix()` when building API subjects
- These methods already merged options via `getJSContextOpts`, but most calls still used `js.apiSubj()` which reads the JetStream context defaults
- Adds `(*jsOpts).apiSubj()` and uses the merged options for AccountInfo, stream/consumer management, message delete, purge, and stream lookup APIs

## Test plan

- [x] Extended `TestJetStreamDomain` to cover `ConsumerInfo`, `AddConsumer`, `StreamInfo`, and `DeleteConsumer` with per-request `nats.Domain("ABC")`
- [ ] CI integration tests

Fixes #742
Fixes #1104

Note: supersedes #2086 with the broader prefix fix.