### PR TITLE
fix: populate object watch ModTime when metadata timestamp is zero

### DIFF
--- a/jetstream/object.go
+++ b/jetstream/object.go
@@ -997,6 +997,23 @@ func publishMeta(ctx context.Context, info *ObjectInfo, js *jetStream) error {
 	return nil
 }
 
+func objectModTimeFromMeta(ctx context.Context, stream Stream, meta *nats.MsgMetadata) time.Time {
+	if meta == nil {
+		return time.Time{}
+	}
+	if !meta.Timestamp.IsZero() {
+		return meta.Timestamp
+	}
+	if meta.Sequence.Stream == 0 {
+		return time.Time{}
+	}
+	rm, err := stream.GetMsg(ctx, meta.Sequence.Stream)
+	if err != nil || rm == nil || rm.Time.IsZero() {
+		return time.Time{}
+	}
+	return rm.Time
+}
+
 // AddLink will add a link to another object if it's not deleted and not another link
 // name is the name of this link object
 // obj is what is being linked too
@@ -1300,7 +1317,7 @@ func (obs *obs) Watch(ctx context.Context, opts ...WatchOpt) (ObjectWatcher, err
 		}
 
 		if !o.ignoreDeletes || !info.Deleted {
-			info.ModTime = meta.Timestamp
+			info.ModTime = objectModTimeFromMeta(ctx, obs.stream, meta)
 			w.updates <- &info
 		}
 

--- a/object.go
+++ b/object.go
@@ -752,6 +752,23 @@ func publishMeta(info *ObjectInfo, js JetStreamContext) error {
 	return nil
 }
 
+func objectModTimeFromMeta(js *js, stream string, meta *MsgMetadata) time.Time {
+	if meta == nil {
+		return time.Time{}
+	}
+	if !meta.Timestamp.IsZero() {
+		return meta.Timestamp
+	}
+	if meta.Sequence.Stream == 0 {
+		return time.Time{}
+	}
+	rm, err := js.GetMsg(stream, meta.Sequence.Stream)
+	if err != nil || rm == nil || rm.Time.IsZero() {
+		return time.Time{}
+	}
+	return rm.Time
+}
+
 // AddLink will add a link to another object if it's not deleted and not another link
 // name is the name of this link object
 // obj is what is being linked too
@@ -1087,7 +1104,7 @@ func (obs *obs) Watch(opts ...WatchOpt) (ObjectWatcher, error) {
 		}
 
 		if !o.ignoreDeletes || !info.Deleted {
-			info.ModTime = meta.Timestamp
+			info.ModTime = objectModTimeFromMeta(obs.js, obs.stream, meta)
 			w.updates <- &info
 		}
 

--- a/test/object_test.go
+++ b/test/object_test.go
@@ -588,6 +588,38 @@ func TestObjectWatch(t *testing.T) {
 		expectErr(t, err, nats.ErrUpdateMetaDeleted)
 	})
 
+	t.Run("watch modtime", func(t *testing.T) {
+		s := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, s)
+
+		nc, js := jsClient(t, s)
+		defer nc.Close()
+
+		obs, err := js.CreateObjectStore(&nats.ObjectStoreConfig{Bucket: "WATCH-MODTIME"})
+		expectOk(t, err)
+
+		_, err = obs.PutString("A", "AAA")
+		expectOk(t, err)
+
+		watcher, err := obs.Watch(nats.IncludeHistory())
+		expectOk(t, err)
+		defer watcher.Stop()
+
+		for {
+			select {
+			case info := <-watcher.Updates():
+				if info == nil {
+					return
+				}
+				if info.ModTime.IsZero() {
+					t.Fatalf("Expected watch update to include ModTime, got %+v", info)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for watch updates")
+			}
+		}
+	})
+
 	t.Run("watcher with update", func(t *testing.T) {
 		s := RunBasicJetStreamServer()
 		defer shutdownJSServerAndRemoveStorage(t, s)


### PR DESCRIPTION
## Summary

Object store metadata is published with a zero `mtime` JSON field; callers are expected to derive modification time from the JetStream message timestamp.

`GetInfo` already uses the stream message time from a direct get, but `Watch` only copied `MsgMetadata.Timestamp`, which can be zero on some ordered-consumer deliveries. That surfaced as `0001-01-01T00:00:00Z` mtime values in watch results (#2053).

When metadata timestamp is zero, fall back to a stream message lookup by sequence (same source as `GetInfo`).

Fixes #2053

## Test plan

- [x] `go build ./jetstream/...`
- [x] Added `TestObjectWatch/watch modtime` integration test (requires nats-server in CI)