### PR TITLE
fix: issue new pull request after consumer leadership change

### DIFF
--- a/jetstream/MIGRATION.md
+++ b/jetstream/MIGRATION.md
@@ -573,7 +573,7 @@ Some errors are terminal (stop consumption), while others are recoverable
 - `ErrNoHeartbeat` — missed idle heartbeats from server; a new pull request
   is issued automatically
 - `ErrConsumerLeadershipChanged` — consumer moved to a different server in the
-  cluster; pending counts are reset
+  cluster; pending counts are reset and a new pull request is issued automatically
 - `nats.ErrNoResponders` — no JetStream service available (temporary)
 
 #### Error handling with `Consume()`

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -449,6 +449,7 @@ func (s *pullSubscription) requestNextPullLocked() {
 		pinID = s.consumer.getPinID()
 	}
 
+	s.resetPendingMsgs()
 	select {
 	case s.fetchNext <- &pullRequest{
 		Expires:       s.consumeOpts.Expires,
@@ -461,7 +462,6 @@ func (s *pullSubscription) requestNextPullLocked() {
 		Group:         s.consumeOpts.Group,
 		PinID:         pinID,
 	}:
-		s.resetPendingMsgs()
 	default:
 	}
 }
@@ -749,6 +749,10 @@ func (s *pullSubscription) handleStatusMsg(msg *nats.Msg, msgErr error) (error, 
 		if errors.Is(msgErr, ErrConsumerLeadershipChanged) {
 			s.pending.msgCount = 0
 			s.pending.byteCount = 0
+			// Clear the in-flight marker before queuing the replacement pull. The
+			// active pull goroutine may still store 0 after its publish returns, but
+			// a duplicate pull during that short window is benign and preferable to
+			// stalling recovery after a leadership change.
 			s.fetchInProgress.Store(0)
 			s.requestNextPullLocked()
 		}

--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -387,25 +387,10 @@ func (p *pullConsumer) Consume(handler MessageHandler, opts ...PullConsumeOpt) (
 			case err := <-sub.errs:
 				sub.Lock()
 				if errors.Is(err, ErrNoHeartbeat) {
-					batchSize := sub.consumeOpts.MaxMessages
-					if sub.consumeOpts.StopAfter > 0 {
-						batchSize = min(batchSize, sub.consumeOpts.StopAfter-sub.delivered)
-					}
-					sub.fetchNext <- &pullRequest{
-						Expires:       sub.consumeOpts.Expires,
-						Batch:         batchSize,
-						MaxBytes:      sub.consumeOpts.MaxBytes,
-						Heartbeat:     sub.consumeOpts.Heartbeat,
-						MinPending:    sub.consumeOpts.MinPending,
-						MinAckPending: sub.consumeOpts.MinAckPending,
-						Priority:      sub.consumeOpts.Priority,
-						Group:         sub.consumeOpts.Group,
-						PinID:         p.getPinID(),
-					}
+					sub.requestNextPullLocked()
 					if sub.hbMonitor != nil {
 						sub.hbMonitor.Reset(2 * sub.consumeOpts.Heartbeat)
 					}
-					sub.resetPendingMsgs()
 				}
 				sub.Unlock()
 				if sub.consumeOpts.ErrHandler != nil {
@@ -446,6 +431,39 @@ func (s *pullSubscription) decrementPendingMsgs(msg *nats.Msg) {
 // lock should be held before calling this method
 func (s *pullSubscription) incrementDeliveredMsgs() {
 	s.delivered++
+}
+
+// requestNextPullLocked schedules a new pull request.
+// lock should be held before calling this method.
+func (s *pullSubscription) requestNextPullLocked() {
+	batchSize := s.consumeOpts.MaxMessages
+	if s.consumeOpts.StopAfter > 0 {
+		batchSize = min(batchSize, s.consumeOpts.StopAfter-s.delivered)
+	}
+	if batchSize <= 0 {
+		return
+	}
+
+	pinID := ""
+	if s.consumer != nil {
+		pinID = s.consumer.getPinID()
+	}
+
+	select {
+	case s.fetchNext <- &pullRequest{
+		Expires:       s.consumeOpts.Expires,
+		Batch:         batchSize,
+		MaxBytes:      s.consumeOpts.MaxBytes,
+		Heartbeat:     s.consumeOpts.Heartbeat,
+		MinPending:    s.consumeOpts.MinPending,
+		MinAckPending: s.consumeOpts.MinAckPending,
+		Priority:      s.consumeOpts.Priority,
+		Group:         s.consumeOpts.Group,
+		PinID:         pinID,
+	}:
+		s.resetPendingMsgs()
+	default:
+	}
 }
 
 // checkPending verifies whether there are enough messages in
@@ -666,6 +684,7 @@ func (s *pullSubscription) Next(opts ...NextOpt) (Msg, error) {
 					s.Stop()
 					return nil, termErr
 				}
+				s.checkPending()
 				continue
 			}
 			if pinId := msg.Header.Get("Nats-Pin-Id"); pinId != "" {
@@ -730,6 +749,8 @@ func (s *pullSubscription) handleStatusMsg(msg *nats.Msg, msgErr error) (error, 
 		if errors.Is(msgErr, ErrConsumerLeadershipChanged) {
 			s.pending.msgCount = 0
 			s.pending.byteCount = 0
+			s.fetchInProgress.Store(0)
+			s.requestNextPullLocked()
 		}
 		return nil, msgErr
 	}

--- a/jetstream/pull_leadership_test.go
+++ b/jetstream/pull_leadership_test.go
@@ -53,6 +53,30 @@ func TestPullSubscriptionLeadershipChangeRequestsNextPull(t *testing.T) {
 	}
 }
 
+func TestPullSubscriptionRequestNextPullResetsPendingWhenRequestAlreadyQueued(t *testing.T) {
+	consumeOpts, err := parseConsumeOpts(false)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	sub := &pullSubscription{
+		fetchNext:   make(chan *pullRequest, 1),
+		consumeOpts: consumeOpts,
+	}
+	sub.fetchNext <- &pullRequest{}
+
+	sub.Lock()
+	sub.requestNextPullLocked()
+	sub.Unlock()
+
+	if sub.pending.msgCount != consumeOpts.MaxMessages {
+		t.Fatalf("Expected pending message count %d, got %d", consumeOpts.MaxMessages, sub.pending.msgCount)
+	}
+	if len(sub.fetchNext) != 1 {
+		t.Fatalf("Expected queued pull request to be preserved, got queue length %d", len(sub.fetchNext))
+	}
+}
+
 func TestCheckMsgLeadershipChange(t *testing.T) {
 	msg := &nats.Msg{
 		Header: nats.Header{

--- a/jetstream/pull_leadership_test.go
+++ b/jetstream/pull_leadership_test.go
@@ -1,0 +1,71 @@
+package jetstream
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+)
+
+func TestPullSubscriptionLeadershipChangeRequestsNextPull(t *testing.T) {
+	consumeOpts, err := parseConsumeOpts(false)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	sub := &pullSubscription{
+		fetchNext:   make(chan *pullRequest, 1),
+		consumeOpts: consumeOpts,
+	}
+	sub.fetchInProgress.Store(1)
+
+	msg := &nats.Msg{
+		Header: nats.Header{
+			"Status":      []string{statusConflict},
+			"Description": []string{leadershipChange},
+		},
+	}
+
+	sub.Lock()
+	termErr, notifyErr := sub.handleStatusMsg(msg, ErrConsumerLeadershipChanged)
+	sub.Unlock()
+
+	if termErr != nil {
+		t.Fatalf("Expected non-terminal error, got %v", termErr)
+	}
+	if !errors.Is(notifyErr, ErrConsumerLeadershipChanged) {
+		t.Fatalf("Expected %v, got %v", ErrConsumerLeadershipChanged, notifyErr)
+	}
+	if sub.fetchInProgress.Load() != 0 {
+		t.Fatalf("Expected fetchInProgress to be cleared")
+	}
+
+	select {
+	case req := <-sub.fetchNext:
+		if req.Batch != consumeOpts.MaxMessages {
+			t.Fatalf("Expected batch size %d, got %d", consumeOpts.MaxMessages, req.Batch)
+		}
+		if sub.pending.msgCount != consumeOpts.MaxMessages {
+			t.Fatalf("Expected pending message count %d, got %d", consumeOpts.MaxMessages, sub.pending.msgCount)
+		}
+	default:
+		t.Fatal("Expected a new pull request after leadership change")
+	}
+}
+
+func TestCheckMsgLeadershipChange(t *testing.T) {
+	msg := &nats.Msg{
+		Header: nats.Header{
+			"Status":      []string{statusConflict},
+			"Description": []string{leadershipChange},
+		},
+	}
+
+	userMsg, err := checkMsg(msg)
+	if userMsg {
+		t.Fatal("Expected leadership change status message")
+	}
+	if !errors.Is(err, ErrConsumerLeadershipChanged) {
+		t.Fatalf("Expected %v, got %v", ErrConsumerLeadershipChanged, err)
+	}
+}

--- a/jetstream/test/pull_test.go
+++ b/jetstream/test/pull_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -1097,6 +1098,172 @@ func TestPullConsumerFetch_WithCluster(t *testing.T) {
 			msg := <-msgs.Messages()
 			if msg != nil {
 				t.Fatalf("Expected no messages; got: %s", string(msg.Data()))
+			}
+		})
+	})
+}
+
+func TestPullConsumerRecoversAfterConsumerLeaderStepDown(t *testing.T) {
+	const (
+		streamName   = "LEADER_CHANGE"
+		consumerName = "leader-change-consumer"
+		subject      = "LC.1"
+	)
+
+	stream := jetstream.StreamConfig{
+		Name:     streamName,
+		Replicas: 3,
+		Subjects: []string{"LC.*"},
+	}
+
+	publish := func(t *testing.T, js jetstream.JetStream, payload string) {
+		t.Helper()
+		if _, err := js.Publish(context.Background(), subject, []byte(payload)); err != nil {
+			t.Fatalf("Unexpected error during publish: %s", err)
+		}
+	}
+
+	stepDown := func(t *testing.T, nc *nats.Conn) {
+		t.Helper()
+		resp, err := nc.Request(
+			fmt.Sprintf(server.JSApiConsumerLeaderStepDownT, streamName, consumerName),
+			nil,
+			2*time.Second)
+		if err != nil {
+			t.Fatalf("Unexpected error during consumer leader stepdown: %v", err)
+		}
+		if bytes.Contains(resp.Data, []byte(`"error"`)) {
+			t.Fatalf("Unexpected consumer leader stepdown response: %s", string(resp.Data))
+		}
+	}
+
+	t.Run("messages next", func(t *testing.T) {
+		withJSClusterAndStream(t, streamName, 3, stream, func(t *testing.T, subject string, srvs ...*jsServer) {
+			nc, err := nats.Connect(srvs[0].ClientURL())
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			defer nc.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			js, err := jetstream.New(nc)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			s, err := js.Stream(ctx, streamName)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			c, err := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+				Name:      consumerName,
+				AckPolicy: jetstream.AckExplicitPolicy,
+				Replicas:  3,
+			})
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			it, err := c.Messages(
+				jetstream.PullMaxMessages(1),
+				jetstream.PullHeartbeat(500*time.Millisecond),
+				jetstream.PullExpiry(1*time.Second))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			defer it.Stop()
+
+			publish(t, js, "m1")
+			msg, err := it.Next(jetstream.NextMaxWait(5 * time.Second))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if err := msg.Ack(); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			stepDown(t, nc)
+			publish(t, js, "m2")
+			deadline := time.Now().Add(5 * time.Second)
+			for {
+				msg, err = it.Next(jetstream.NextMaxWait(1 * time.Second))
+				if err == nil {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatalf("Unexpected error after consumer leader stepdown: %v", err)
+				}
+				if !errors.Is(err, jetstream.ErrNoHeartbeat) && !errors.Is(err, nats.ErrTimeout) {
+					t.Fatalf("Unexpected error after consumer leader stepdown: %v", err)
+				}
+			}
+			if got := string(msg.Data()); got != "m2" {
+				t.Fatalf("Invalid msg; expected: m2; got: %s", got)
+			}
+			if err := msg.Ack(); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
+	})
+
+	t.Run("consume callback", func(t *testing.T) {
+		withJSClusterAndStream(t, streamName, 3, stream, func(t *testing.T, subject string, srvs ...*jsServer) {
+			nc, err := nats.Connect(srvs[0].ClientURL())
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			defer nc.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			js, err := jetstream.New(nc)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			s, err := js.Stream(ctx, streamName)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			c, err := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+				Name:      consumerName,
+				AckPolicy: jetstream.AckExplicitPolicy,
+				Replicas:  3,
+			})
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			received := make(chan string, 2)
+			l, err := c.Consume(func(msg jetstream.Msg) {
+				received <- string(msg.Data())
+				if err := msg.Ack(); err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}, jetstream.PullMaxMessages(1), jetstream.PullHeartbeat(500*time.Millisecond), jetstream.PullExpiry(1*time.Second))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			defer l.Stop()
+
+			publish(t, js, "m1")
+			select {
+			case got := <-received:
+				if got != "m1" {
+					t.Fatalf("Invalid msg; expected: m1; got: %s", got)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("Timed out waiting for first message")
+			}
+
+			stepDown(t, nc)
+			publish(t, js, "m2")
+			select {
+			case got := <-received:
+				if got != "m2" {
+					t.Fatalf("Invalid msg; expected: m2; got: %s", got)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("Timed out waiting for message after consumer leader stepdown")
 			}
 		})
 	})


### PR DESCRIPTION
## Summary

Fixes #2063

When JetStream returns `ErrConsumerLeadershipChanged`, pull consumers reset pending counts but could stall if `checkPending` was blocked by `fetchInProgress`. `Consume()` then stopped delivering messages until restart.

This clears the in-flight fetch flag and schedules a new pull request, matching `ErrNoHeartbeat` recovery. `Next()` also calls `checkPending()` after recoverable status messages.

## Test plan

- [x] Added `TestPullSubscriptionLeadershipChangeRequestsNextPull`
- [x] Added `TestCheckMsgLeadershipChange`
- [x] `go test ./jetstream`

Made with [Cursor](https://cursor.com)