### PR TITLE
fix: websocket connection with path

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1561,8 +1561,9 @@ func Compression(enabled bool) Option {
 // ProxyPath sets a path added to every WebSocket connection URL. This is
 // useful when NATS is behind a reverse proxy that routes by path. Unlike a
 // path in the connect URL, ProxyPath is also applied to server-discovered
-// URLs (which are bare host:port), so reconnects through the proxy still
-// work. When set, it overrides any path in the connection URL.
+// URLs (which are bare host:port). Use ProxyPath for clustered setups
+// behind a proxy, so the client can connect to discovered servers on
+// failover. When set, it overrides any path in the connection URL.
 func ProxyPath(path string) Option {
 	return func(o *Options) error {
 		o.ProxyPath = path

--- a/nats.go
+++ b/nats.go
@@ -1558,8 +1558,11 @@ func Compression(enabled bool) Option {
 	}
 }
 
-// ProxyPath is an option for websocket connections that adds a path to connections url.
-// This is useful when connecting to NATS behind a proxy.
+// ProxyPath sets a path added to every WebSocket connection URL. This is
+// useful when NATS is behind a reverse proxy that routes by path. Unlike a
+// path in the connect URL, ProxyPath is also applied to server-discovered
+// URLs (which are bare host:port), so reconnects through the proxy still
+// work. When set, it overrides any path in the connection URL.
 func ProxyPath(path string) Option {
 	return func(o *Options) error {
 		o.ProxyPath = path

--- a/ws.go
+++ b/ws.go
@@ -625,6 +625,9 @@ func (nc *Conn) wsInitHandshake(u *url.URL) error {
 	} else if u.Path != "" {
 		ustr += u.Path
 	}
+	if u.RawQuery != "" {
+		ustr += "?" + u.RawQuery
+	}
 
 	u, err = url.Parse(ustr)
 	if err != nil {

--- a/ws.go
+++ b/ws.go
@@ -622,6 +622,8 @@ func (nc *Conn) wsInitHandshake(u *url.URL) error {
 			proxyPath = "/" + proxyPath
 		}
 		ustr += proxyPath
+	} else if u.Path != "" {
+		ustr += u.Path
 	}
 
 	u, err = url.Parse(ustr)

--- a/ws_test.go
+++ b/ws_test.go
@@ -681,6 +681,68 @@ func TestWSProxyPath(t *testing.T) {
 	}
 }
 
+func TestWSURLPath(t *testing.T) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Error in listen: %v", err)
+	}
+	defer l.Close()
+
+	port := l.Addr().(*net.TCPAddr).Port
+
+	ch := make(chan string, 1)
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ch <- r.URL.Path
+		}),
+	}
+	defer srv.Shutdown(context.Background())
+	go srv.Serve(l)
+
+	for _, test := range []struct {
+		name string
+		path string
+	}{
+		{"with path", "/mypath"},
+		{"with nested path", "/my/nested/path"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			url := fmt.Sprintf("ws://127.0.0.1:%d%s", port, test.path)
+			nc, err := Connect(url)
+			if err == nil {
+				nc.Close()
+				t.Fatal("Did not expect to connect")
+			}
+			select {
+			case got := <-ch:
+				if got != test.path {
+					t.Fatalf("Expected path %q, got %q", test.path, got)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("Server was not reached")
+			}
+		})
+	}
+
+	// ProxyPath option should take precedence over URL path.
+	t.Run("proxy path overrides url path", func(t *testing.T) {
+		url := fmt.Sprintf("ws://127.0.0.1:%d/url-path", port)
+		nc, err := Connect(url, ProxyPath("/override"))
+		if err == nil {
+			nc.Close()
+			t.Fatal("Did not expect to connect")
+		}
+		select {
+		case got := <-ch:
+			if got != "/override" {
+				t.Fatalf("Expected path %q, got %q", "/override", got)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("Server was not reached")
+		}
+	})
+}
+
 // --- helpers ---
 
 func startHeaderCatcher(t *testing.T) (addr string, got chan []string, closer func()) {

--- a/ws_test.go
+++ b/ws_test.go
@@ -693,18 +693,23 @@ func TestWSURLPath(t *testing.T) {
 	ch := make(chan string, 1)
 	srv := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ch <- r.URL.Path
+			ch <- r.URL.RequestURI()
 		}),
 	}
 	defer srv.Shutdown(context.Background())
 	go srv.Serve(l)
 
 	for _, test := range []struct {
-		name string
-		path string
+		name     string
+		path     string
+		expected string
 	}{
-		{"with path", "/mypath"},
-		{"with nested path", "/my/nested/path"},
+		{"with path", "/mypath", "/mypath"},
+		{"with nested path", "/my/nested/path", "/my/nested/path"},
+		{"with query params", "/mypath?token=abc&foo=bar", "/mypath?token=abc&foo=bar"},
+		{"query only", "/?token=abc", "/?token=abc"},
+		{"encoded query value", "/mypath?msg=hello%20world", "/mypath?msg=hello%20world"},
+		{"trailing slash with query", "/mypath/?key=val", "/mypath/?key=val"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			url := fmt.Sprintf("ws://127.0.0.1:%d%s", port, test.path)
@@ -715,8 +720,8 @@ func TestWSURLPath(t *testing.T) {
 			}
 			select {
 			case got := <-ch:
-				if got != test.path {
-					t.Fatalf("Expected path %q, got %q", test.path, got)
+				if got != test.expected {
+					t.Fatalf("Expected URI %q, got %q", test.expected, got)
 				}
 			case <-time.After(time.Second):
 				t.Fatal("Server was not reached")
@@ -735,7 +740,25 @@ func TestWSURLPath(t *testing.T) {
 		select {
 		case got := <-ch:
 			if got != "/override" {
-				t.Fatalf("Expected path %q, got %q", "/override", got)
+				t.Fatalf("Expected URI %q, got %q", "/override", got)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("Server was not reached")
+		}
+	})
+
+	// Query params from the URL should be preserved even when ProxyPath is set.
+	t.Run("proxy path preserves query params", func(t *testing.T) {
+		url := fmt.Sprintf("ws://127.0.0.1:%d/ignored?token=secret", port)
+		nc, err := Connect(url, ProxyPath("/proxy"))
+		if err == nil {
+			nc.Close()
+			t.Fatal("Did not expect to connect")
+		}
+		select {
+		case got := <-ch:
+			if got != "/proxy?token=secret" {
+				t.Fatalf("Expected URI %q, got %q", "/proxy?token=secret", got)
 			}
 		case <-time.After(time.Second):
 			t.Fatal("Server was not reached")


### PR DESCRIPTION
Fix WebSocket connections when the URL has a path

> [!IMPORTANT]  
> I also opened a PR to fix this solely in `natscli`, https://github.com/nats-io/natscli/pull/1672. I think the pure-CLI change is the more correct fix.

```shell
# before
❯ nats -s 'ws://localhost:8080/api/cp-nats/' pub 'xyz' test
nats: error: invalid websocket connection

# after
❯ nats -s 'ws://localhost:8080/api/cp-nats/' pub 'xyz' test
10:22:37 Published 4 bytes to "xyz"
````