### PR TITLE
iter: don't yield a phantom (nil, nil) after MsgsTimeout's ErrTimeout

### DIFF
--- a/nats_iter.go
+++ b/nats_iter.go
@@ -63,6 +63,7 @@ func (sub *Subscription) MsgsTimeout(timeout time.Duration) iter.Seq2[*Msg, erro
 				if !errors.Is(err, ErrTimeout) {
 					return
 				}
+				continue
 			}
 			if !yield(msg, nil) {
 				return

--- a/test/nats_iter_test.go
+++ b/test/nats_iter_test.go
@@ -222,6 +222,39 @@ func TestSubscribeIterator(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("timeout does not yield phantom nil message", func(t *testing.T) {
+		s := RunServerOnPort(-1)
+		defer s.Shutdown()
+
+		nc, err := nats.Connect(s.ClientURL())
+		if err != nil {
+			t.Fatalf("Error on connect: %v", err)
+		}
+		defer nc.Close()
+
+		sub, err := nc.SubscribeSync("foo")
+		if err != nil {
+			t.Fatal("Failed to subscribe: ", err)
+		}
+		defer sub.Unsubscribe()
+
+		// No messages are published, so every NextMsg should hit ErrTimeout.
+		// Read three iterations and confirm each one yielded the timeout
+		// error and not a phantom (nil, nil) following it.
+		var got []error
+		for _, err := range sub.MsgsTimeout(20 * time.Millisecond) {
+			got = append(got, err)
+			if len(got) == 3 {
+				break
+			}
+		}
+		for i, e := range got {
+			if !errors.Is(e, nats.ErrTimeout) {
+				t.Fatalf("yield %d: expected ErrTimeout, got %v", i, e)
+			}
+		}
+	})
 }
 
 func TestQueueSubscribeIterator(t *testing.T) {


### PR DESCRIPTION
Spotted while reading nats_iter.go. After NextMsg returns ErrTimeout, MsgsTimeout yields (nil, err), honors the caller's keep-going signal, and then falls through to `if !yield(msg, nil)` with `msg` still nil. So a `for msg, err := range sub.MsgsTimeout(...)` loop that continues past a timeout (per the doc: "the iterator will return nats.ErrTimeout but it will not be closed") gets two yields per tick: one `(nil, ErrTimeout)` and one phantom `(nil, nil)`.

The existing TestSubscribeIterator/with_timeout test breaks on the first ErrTimeout so it never observed the phantom.

Fix is a one-line `continue` after the timeout-recovery branch. Added a regression test that pulls three iterations on a quiet subject and asserts each one was ErrTimeout, no phantoms; fails on master.