### PR TITLE
Fix ObjectInfo.ModTime parity across clients - store mtime in metadata JSON so that the time isn't zeroed out in the JSON

### DIFF
--- a/jetstream/object.go
+++ b/jetstream/object.go
@@ -763,6 +763,9 @@ func (obs *obs) Put(ctx context.Context, meta ObjectMeta, r io.Reader) (*ObjectI
 		}
 	}
 
+	// Set ModTime before marshaling so it is stored in the metadata and readable by other clients.
+	info.ModTime = time.Now().UTC()
+
 	// Prepare the meta message
 	metaSubj := fmt.Sprintf(objMetaPreTmpl, obs.name, encodeName(meta.Name))
 	mm := nats.NewMsg(metaSubj)
@@ -796,8 +799,6 @@ func (obs *obs) Put(ctx context.Context, meta ObjectMeta, r io.Reader) (*ObjectI
 	case <-ctx.Done():
 		return nil, nats.ErrTimeout
 	}
-
-	info.ModTime = time.Now().UTC() // This time is not actually the correct time
 
 	// Delete any original chunks.
 	if einfo != nil && !einfo.Deleted {
@@ -977,8 +978,8 @@ func (obs *obs) Delete(ctx context.Context, name string) error {
 }
 
 func publishMeta(ctx context.Context, info *ObjectInfo, js *jetStream) error {
-	// marshal the object into json, don't store an actual time
-	info.ModTime = time.Time{}
+	// Set ModTime before marshaling so it is stored in the metadata and readable by other clients.
+	info.ModTime = time.Now().UTC()
 	data, err := json.Marshal(info)
 	if err != nil {
 		return err
@@ -992,8 +993,6 @@ func publishMeta(ctx context.Context, info *ObjectInfo, js *jetStream) error {
 		return err
 	}
 
-	// set the ModTime in case it's returned to the user, even though it's not the correct time.
-	info.ModTime = time.Now().UTC()
 	return nil
 }
 

--- a/object.go
+++ b/object.go
@@ -468,6 +468,9 @@ func (obs *obs) Put(meta *ObjectMeta, r io.Reader, opts ...ObjectOpt) (*ObjectIn
 		}
 	}
 
+	// Set ModTime before marshaling so it is stored in the metadata and readable by other clients.
+	info.ModTime = time.Now().UTC()
+
 	// Prepare the meta message
 	metaSubj := fmt.Sprintf(objMetaPreTmpl, obs.name, encodeName(meta.Name))
 	mm := NewMsg(metaSubj)
@@ -507,8 +510,6 @@ func (obs *obs) Put(meta *ObjectMeta, r io.Reader, opts ...ObjectOpt) (*ObjectIn
 	case <-time.After(obs.js.opts.wait):
 		return nil, ErrTimeout
 	}
-
-	info.ModTime = time.Now().UTC() // This time is not actually the correct time
 
 	// Delete any original chunks.
 	if einfo != nil && !einfo.Deleted {
@@ -732,8 +733,8 @@ func (obs *obs) Delete(name string) error {
 }
 
 func publishMeta(info *ObjectInfo, js JetStreamContext) error {
-	// marshal the object into json, don't store an actual time
-	info.ModTime = time.Time{}
+	// Set ModTime before marshaling so it is stored in the metadata and readable by other clients.
+	info.ModTime = time.Now().UTC()
 	data, err := json.Marshal(info)
 	if err != nil {
 		return err
@@ -747,8 +748,6 @@ func publishMeta(info *ObjectInfo, js JetStreamContext) error {
 		return err
 	}
 
-	// set the ModTime in case it's returned to the user, even though it's not the correct time.
-	info.ModTime = time.Now().UTC()
 	return nil
 }
 


### PR DESCRIPTION
Fixes #1252

## Problem
The Go client was storing `"mtime":"0001-01-01T00:00:00Z"` (zero time) in the object metadata JSON because `ModTime` was set after `json.Marshal`. The Go client worked around this on reads by using the server-assigned `m.Time` from the JetStream message metadata, but other clients (Rust, Deno, etc.) read `mtime` directly from the JSON and always got zero time. I did go ahead and confirm that the Rust client was indeed directly reading from the JSON.

## Changes
- Set `ModTime = time.Now().UTC()` before `json.Marshal` in `Put` and `publishMeta` in both legacy (`object.go`) and new JetStream API (`jetstream/object.go`)
- This ensures `mtime` is stored with a real timestamp in the metadata JSON, fixing cross-client parity

Signed-off-by: Prasant Koirala <koiralaprashanta10@gmail.com>