### PR TITLE
[FIXED] MsgsTimeout iterator yields spurious (nil, nil) after a timeout

### DIFF
--- a/nats_iter.go
+++ b/nats_iter.go
@@ -63,6 +63,7 @@ func (sub *Subscription) MsgsTimeout(timeout time.Duration) iter.Seq2[*Msg, erro
 				if !errors.Is(err, ErrTimeout) {
 					return
 				}
+				continue
 			}
 			if !yield(msg, nil) {
 				return

--- a/test/nats_iter_test.go
+++ b/test/nats_iter_test.go
@@ -79,6 +79,41 @@ func TestSubscribeIterator(t *testing.T) {
 		}
 	})
 
+	t.Run("timeout keeps yielding only ErrTimeout", func(t *testing.T) {
+		s := RunServerOnPort(-1)
+		defer s.Shutdown()
+
+		nc, err := nats.Connect(s.ClientURL(), nats.PermissionErrOnSubscribe(true))
+		if err != nil {
+			t.Fatalf("Error on connect: %v", err)
+		}
+		defer nc.Close()
+
+		sub, err := nc.SubscribeSync("foo")
+		if err != nil {
+			t.Fatal("Failed to subscribe: ", err)
+		}
+		defer sub.Unsubscribe()
+
+		// No message is ever published, so every NextMsg call times out.
+		// ErrTimeout is not fatal, so a consumer is allowed to keep iterating.
+		// In that case the iterator must only ever yield (nil, ErrTimeout); it
+		// must not yield a spurious (nil, nil) pair between timeouts.
+		iterations := 0
+		for msg, err := range sub.MsgsTimeout(50 * time.Millisecond) {
+			if err == nil {
+				t.Fatalf("iteration %d: got msg=%v with nil error, expected ErrTimeout", iterations, msg)
+			}
+			if !errors.Is(err, nats.ErrTimeout) {
+				t.Fatalf("iteration %d: unexpected error: %v", iterations, err)
+			}
+			iterations++
+			if iterations >= 3 {
+				break
+			}
+		}
+	})
+
 	t.Run("no timeout", func(t *testing.T) {
 		s := RunServerOnPort(-1)
 		defer s.Shutdown()


### PR DESCRIPTION
`MsgsTimeout` returns a range-over-func iterator. When `NextMsg` times out it
yields `(nil, ErrTimeout)`. `ErrTimeout` is not fatal, so a consumer is allowed
to keep iterating (e.g. to wait for more messages or do periodic work between
batches). In that case the loop falls through to `yield(msg, nil)` with
`msg == nil` and `err == nil`, so the consumer gets a spurious `(nil, nil)` pair
after every timeout. Code that treats `err == nil` as "got a message" then
operates on a nil `*Msg`.

The `Msgs()` iterator returns after any error and doesn't have this. The fix is
a `continue` after the non-fatal timeout branch so it loops back to `NextMsg`
instead of falling through.

The existing `with timeout` test didn't catch it because it breaks on the first
timeout, so the iterator returns before reaching the second yield. The added
test keeps iterating across timeouts:

```
# before the fix
--- FAIL: TestSubscribeIterator/timeout_keeps_yielding_only_ErrTimeout
    nats_iter_test.go:105: iteration 1: got msg=<nil> with nil error, expected ErrTimeout
# after
ok  github.com/nats-io/nats.go/test
```

`TestSubscribeIterator` and `TestQueueSubscribeIterator` pass with `-race`.

AI assistance disclosure: this fix and test were prepared with the help of an AI
coding assistant; I reviewed and verified the change and tests myself.

Signed-off-by: Sueun Cho <sueun.dev@gmail.com>
