### PR TITLE
[FIXED] Panic in DecodeHeadersMsg on status tokens shorter than 3 characters

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -4439,7 +4439,10 @@ func DecodeHeadersMsg(data []byte) (Header, error) {
 	if len(l) > hdrPreEnd {
 		var description string
 		status := strings.TrimSpace(l[hdrPreEnd:])
-		if len(status) != statusLen {
+		if len(status) < statusLen {
+			return nil, ErrBadHeaderMsg
+		}
+		if len(status) > statusLen {
 			description = strings.TrimSpace(status[statusLen:])
 			status = status[:statusLen]
 		}

--- a/nats_test.go
+++ b/nats_test.go
@@ -1599,6 +1599,9 @@ func TestHeaderParser(t *testing.T) {
 	shouldErr("NATS/1.0\r\n")
 	shouldErr("NATS/1.0\r\nk1:v1")
 	shouldErr("NATS/1.0\r\nk1:v1\r\n")
+	shouldErr("NATS/1.0 5\r\n")
+	shouldErr("NATS/1.0 41\r\n")
+	shouldErr("NATS/1.0 \r\n")
 
 	// Check that we can do inline status and descriptions
 	checkStatus := func(hdr string, status int, description string) {


### PR DESCRIPTION
**Problem**: DecodeHeadersMsg panics with "slice bounds out of range" when the inline status token (e.g. `NATS/1.0 5`) is shorter than 3 characters. The guard `len(status) != statusLen` was meant to detect a trailing description but also matched short tokens, then attempted `status[3:]` on a 0-2 byte string.

**Fix**: Change the condition to `len(status) < statusLen` and return `ErrBadHeaderMsg` for malformed status tokens. Use `len(status) > statusLen` for the description split.

Resolves #2100

Signed-off-by: Nikitha Mohithe <mohitenikki2002@gmail.com>