### PR TITLE
[FIXED] micro: endpoint subject prefix over-match

### DIFF
--- a/micro/service.go
+++ b/micro/service.go
@@ -646,7 +646,10 @@ func matchEndpointSubject(endpointSubject, literalSubject string) bool {
 			return false
 		}
 	}
-	return true
+	// Without a trailing ">", every subject token must be consumed; otherwise a
+	// shorter endpoint would over-match a longer subject (e.g. "foo" vs
+	// "foo.bar").
+	return len(endpointTokens) == len(subjectTokens)
 }
 
 // addVerbHandlers generates control handlers for a specific verb.

--- a/micro/service_internal_test.go
+++ b/micro/service_internal_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package micro
+
+import "testing"
+
+func TestMatchEndpointSubject(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		endpointSubject string
+		literalSubject  string
+		match           bool
+	}{
+		{"exact", "foo.bar", "foo.bar", true},
+		{"exact single token", "foo", "foo", true},
+		{"single wildcard", "foo.*", "foo.bar", true},
+		{"single wildcard mismatched literal", "foo.*", "foo.bar.baz", false},
+		{"full wildcard", "foo.>", "foo.bar.baz", true},
+		{"full wildcard one token", "foo.>", "foo.bar", true},
+		{"literal mismatch", "foo.bar", "foo.baz", false},
+		{"endpoint longer than subject", "foo.bar", "foo", false},
+		// A shorter literal endpoint must not match a longer subject.
+		{"prefix over-match single token", "foo", "foo.bar", false},
+		{"prefix over-match multi token", "foo.bar", "foo.bar.baz", false},
+		{"wildcard prefix over-match", "foo.*", "foo.bar.baz", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := matchEndpointSubject(test.endpointSubject, test.literalSubject); got != test.match {
+				t.Errorf("matchEndpointSubject(%q, %q) = %v; want %v",
+					test.endpointSubject, test.literalSubject, got, test.match)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Bug

`matchEndpointSubject` (in `micro/service.go`, used by `matchSubscriptionSubject` to attribute an incoming subject to a registered endpoint) treats an endpoint subject that is a proper **prefix** of the literal subject as a match:

```go
matchEndpointSubject("foo", "foo.bar")          // true  (want false)
matchEndpointSubject("foo.bar", "foo.bar.baz")  // true  (want false)
matchEndpointSubject("foo.*", "foo.bar.baz")    // true  (want false)
```

This violates NATS subject-matching semantics: without a trailing `>`, `foo` matches only `foo`, and `foo.*` matches exactly one token after `foo`. The function only rejects endpoints that are *longer* than the subject (`len(endpointTokens) > len(subjectTokens)`); when the endpoint is a shorter prefix, the loop consumes all endpoint tokens and falls through to `return true`.

### Impact

A service with two endpoints that share a prefix — e.g. a wildcard endpoint `foo.>` and a literal endpoint `foo` — misattributes activity. When an async error arrives on `foo.bar.baz` (delivered via the `foo.>` subscription), `matchSubscriptionSubject` can match it against endpoint `foo` instead of `foo.>`, so the error count / `LastError` lands on the wrong endpoint's stats.

## Fix

After the token loop, require that the endpoint consumed every subject token (unless it ended with `>`, which returns early):

```go
return len(endpointTokens) == len(subjectTokens)
```

Exact matches, `*` single-token wildcards, and `>` full wildcards are unchanged; only the prefix-over-match cases now correctly return `false`.

## Testing

Added `TestMatchEndpointSubject` (white-box, `package micro`) covering exact, single/full wildcard, mismatch, endpoint-longer, and the prefix-over-match cases. The four over-match cases fail on the current code and pass with the fix. The full `./micro/...` suite (unit + integration, `-race`) passes; `gofmt`/`go vet` clean.
