### PR TITLE
Add docs.nats.io examples to main

### DIFF
--- a/examples/docs/basics-publish/main.go
+++ b/examples/docs/basics-publish/main.go
@@ -1,0 +1,16 @@
+package main
+
+import "github.com/nats-io/nats.go"
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Publish a message to the 'weather.updates' subject
+	nc.Publish("weather.updates", []byte("Temperature: 72°F"))
+	// NATS-DOC-END
+}

--- a/examples/docs/basics-subscribe/main.go
+++ b/examples/docs/basics-subscribe/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Subscribe to weather updates
+	sub, _ := nc.Subscribe("weather.updates", func(msg *nats.Msg) {
+		fmt.Printf("Received: %s\n", string(msg.Data))
+	})
+	// NATS-DOC-END
+	defer sub.Unsubscribe()
+}

--- a/examples/docs/getting-started-publish/main.go
+++ b/examples/docs/getting-started-publish/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"log"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	// Connect to NATS demo server
+	nc, err := nats.Connect("demo.nats.io")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	// Publish a message
+	err = nc.Publish("hello", []byte("Hello NATS!"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("Message published to hello")
+}

--- a/examples/docs/getting-started-subscribe/main.go
+++ b/examples/docs/getting-started-subscribe/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"log"
+	"runtime"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	// Connect to NATS demo server
+	nc, err := nats.Connect("demo.nats.io")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	// Subscribe to 'hello'
+	_, err = nc.Subscribe("hello", func(msg *nats.Msg) {
+		log.Printf("Received: %s", string(msg.Data))
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("Listening for messages on 'hello'...")
+
+	// Keep the connection alive
+	runtime.Goexit()
+}

--- a/examples/docs/getting-started-subscribe/main.go
+++ b/examples/docs/getting-started-subscribe/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"runtime"
 
 	"github.com/nats-io/nats.go"
 )
@@ -25,6 +24,6 @@ func main() {
 
 	log.Println("Listening for messages on 'hello'...")
 
-	// Keep the connection alive
-	runtime.Goexit()
+	// Keep the process running
+	select {}
 }

--- a/examples/docs/jetstream-basic/main.go
+++ b/examples/docs/jetstream-basic/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	// NATS-DOC-START
+	// Create a stream that captures any subject under `orders.`
+	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "ORDERS",
+		Subjects: []string{"orders.>"},
+		Storage:  jetstream.FileStorage,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Publish a few orders
+	js.Publish(ctx, "orders.new", []byte("Order #1001"))
+	js.Publish(ctx, "orders.new", []byte("Order #1002"))
+	js.Publish(ctx, "orders.shipped", []byte("Order #1001 shipped"))
+
+	// Create a durable pull consumer that delivers from the beginning
+	consumer, err := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+		Durable:   "order-processor",
+		AckPolicy: jetstream.AckExplicitPolicy,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Fetch a batch and acknowledge each message
+	msgs, err := consumer.Fetch(3)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for msg := range msgs.Messages() {
+		fmt.Printf("Received on %s: %s\n", msg.Subject(), string(msg.Data()))
+		msg.Ack()
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-core-nats-publish-subscribe-publish/main.go
+++ b/examples/docs/learn-core-nats-publish-subscribe-publish/main.go
@@ -1,0 +1,21 @@
+package main
+
+import "github.com/nats-io/nats.go"
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Publish one order to the orders.created subject. Publishing is
+	// fire-and-forget: the call hands the message to the server and returns.
+	order := `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}`
+	nc.Publish("orders.created", []byte(order))
+	// NATS-DOC-END
+
+	// Flush so the buffered publish reaches the server before we exit.
+	nc.Flush()
+}

--- a/examples/docs/learn-core-nats-publish-subscribe-subscribe/main.go
+++ b/examples/docs/learn-core-nats-publish-subscribe-subscribe/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Subscribe as the warehouse service to orders.created. The callback runs
+	// for each matching message as it is published.
+	nc.Subscribe("orders.created", func(m *nats.Msg) {
+		fmt.Printf("warehouse received: %s\n", string(m.Data))
+	})
+	// NATS-DOC-END
+
+	// Block so the subscriber keeps running.
+	select {}
+}

--- a/examples/docs/learn-core-nats-queue-groups-queue-subscribe/main.go
+++ b/examples/docs/learn-core-nats-queue-groups-queue-subscribe/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Join the "packers" queue group on orders.created. Every subscriber that
+	// names the same group shares the load: each order is delivered to exactly
+	// one member. Run this in several processes to watch the load balance.
+	nc.QueueSubscribe("orders.created", "packers", func(m *nats.Msg) {
+		fmt.Printf("packer handling: %s\n", string(m.Data))
+	})
+	// NATS-DOC-END
+
+	select {}
+}

--- a/examples/docs/learn-core-nats-request-reply-replies/main.go
+++ b/examples/docs/learn-core-nats-request-reply-replies/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Gather more than one reply to a single request. A plain Request returns
+	// only the first reply, so when several services may answer, subscribe to
+	// your own inbox, publish the request with that inbox as the reply subject,
+	// and collect replies until they stop arriving.
+	order := `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}`
+	inbox := nats.NewInbox()
+	sub, _ := nc.SubscribeSync(inbox)
+	nc.PublishRequest("orders.inventory.check", inbox, []byte(order))
+
+	var replies [][]byte
+	for {
+		// Stop once no further reply arrives within the gap deadline.
+		msg, err := sub.NextMsg(300 * time.Millisecond)
+		if err != nil {
+			break
+		}
+		replies = append(replies, msg.Data)
+	}
+	fmt.Printf("gathered %d replies\n", len(replies))
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-core-nats-request-reply-request/main.go
+++ b/examples/docs/learn-core-nats-request-reply-request/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Ask the inventory service whether an order's item is in stock. The client
+	// creates a private inbox, sends the request, and waits up to the timeout
+	// for one reply. A missing service surfaces immediately as
+	// nats.ErrNoResponders; a slow one as nats.ErrTimeout.
+	order := `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}`
+	msg, err := nc.Request("orders.inventory.check", []byte(order), 2*time.Second)
+	switch err {
+	case nats.ErrNoResponders:
+		fmt.Println("no inventory service is running")
+	case nats.ErrTimeout:
+		fmt.Println("inventory service did not answer in time")
+	case nil:
+		fmt.Printf("inventory replied: %s\n", string(msg.Data))
+	default:
+		fmt.Printf("request failed: %v\n", err)
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-core-nats-request-reply-respond/main.go
+++ b/examples/docs/learn-core-nats-request-reply-respond/main.go
@@ -1,0 +1,22 @@
+package main
+
+import "github.com/nats-io/nats.go"
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// The inventory service: subscribe to orders.inventory.check and answer
+	// every request by responding on the reply subject it carries.
+	nc.Subscribe("orders.inventory.check", func(m *nats.Msg) {
+		m.Respond([]byte(`{"in_stock":true,"warehouse":"us-east"}`))
+	})
+	// NATS-DOC-END
+
+	// Block so the service keeps answering.
+	select {}
+}

--- a/examples/docs/learn-core-nats-scatter-gather-gather/main.go
+++ b/examples/docs/learn-core-nats-scatter-gather-gather/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Scatter one request to every shipping-quote provider and gather the
+	// replies. Subscribe to a private inbox, publish the request with that
+	// inbox as the reply subject, then collect quotes until they stop arriving
+	// and pick the cheapest.
+	order := `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}`
+	inbox := nats.NewInbox()
+	sub, _ := nc.SubscribeSync(inbox)
+	nc.PublishRequest("shipping.quote", inbox, []byte(order))
+
+	var quotes []string
+	for {
+		msg, err := sub.NextMsg(300 * time.Millisecond)
+		if err != nil {
+			break
+		}
+		quotes = append(quotes, string(msg.Data))
+	}
+	fmt.Printf("gathered %d quotes: %v\n", len(quotes), quotes)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-core-nats-scatter-gather-provider/main.go
+++ b/examples/docs/learn-core-nats-scatter-gather-provider/main.go
@@ -1,0 +1,22 @@
+package main
+
+import "github.com/nats-io/nats.go"
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// A shipping-quote provider. Subscribe plainly to shipping.quote (NOT a
+	// queue group, so every provider sees each request) and reply with a price.
+	// Run several copies, each quoting a different number.
+	nc.Subscribe("shipping.quote", func(m *nats.Msg) {
+		m.Respond([]byte(`{"carrier":"carrier-a","quote_cents":1500}`))
+	})
+	// NATS-DOC-END
+
+	select {}
+}

--- a/examples/docs/learn-core-nats-subjects-and-wildcards-wildcard-multi/main.go
+++ b/examples/docs/learn-core-nats-subjects-and-wildcards-wildcard-multi/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Audit service: catch every order message at any depth. The multi-token
+	// wildcard > matches one or more tokens and must be the last token, so
+	// orders.> matches orders.created, orders.us.created, and
+	// orders.us.west.created alike.
+	nc.Subscribe("orders.>", func(m *nats.Msg) {
+		fmt.Printf("audit: %s\n", m.Subject)
+	})
+	// NATS-DOC-END
+
+	select {}
+}

--- a/examples/docs/learn-core-nats-subjects-and-wildcards-wildcard-single/main.go
+++ b/examples/docs/learn-core-nats-subjects-and-wildcards-wildcard-single/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Regional analytics: one subscription catches created orders from every
+	// region. The single-token wildcard * matches exactly one token, so
+	// orders.us.created and orders.eu.created both match, while orders.created
+	// and orders.us.west.created do not.
+	nc.Subscribe("orders.*.created", func(m *nats.Msg) {
+		fmt.Printf("analytics: new order on %s\n", m.Subject)
+	})
+	// NATS-DOC-END
+
+	select {}
+}

--- a/examples/docs/learn-jetstream-acknowledgment-nakWithDelay/main.go
+++ b/examples/docs/learn-jetstream-acknowledgment-nakWithDelay/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Bind to the durable "shipping" consumer created earlier.
+	cons, err := js.Consumer(ctx, "ORDERS", "shipping")
+	if err != nil {
+		panic(err)
+	}
+
+	// Fetch a single message from the consumer.
+	msg, err := cons.Next()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Received on %s: %s\n", msg.Subject(), string(msg.Data()))
+
+	// Negatively acknowledge with a delay. The server holds the message and
+	// redelivers it after the delay instead of right away, which is useful when
+	// a downstream dependency needs time to recover.
+	if err := msg.NakWithDelay(10 * time.Second); err != nil {
+		panic(err)
+	}
+	fmt.Println("Message NAK'd, redelivery delayed by 10s")
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-acknowledgment-termPoison/main.go
+++ b/examples/docs/learn-jetstream-acknowledgment-termPoison/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Bind to the durable "shipping" consumer created earlier.
+	cons, err := js.Consumer(ctx, "ORDERS", "shipping")
+	if err != nil {
+		panic(err)
+	}
+
+	// Fetch a single message from the consumer.
+	msg, err := cons.Next()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Received on %s: %s\n", msg.Subject(), string(msg.Data()))
+
+	// Terminate the message. This is for a poison message the consumer can never
+	// process. The server stops redelivering it and advances past it for good.
+	if err := msg.Term(); err != nil {
+		panic(err)
+	}
+	fmt.Println("Message terminated, it will not be redelivered")
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-acknowledgment-watchMaxDeliveries/main.go
+++ b/examples/docs/learn-jetstream-acknowledgment-watchMaxDeliveries/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Max-deliveries advisories are plain core NATS messages, so subscribe with
+	// the core client instead of a JetStream consumer. The server publishes one
+	// each time a message on the "shipping" consumer hits its delivery limit.
+	subject := "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.ORDERS.shipping"
+	sub, err := nc.SubscribeSync(subject)
+	if err != nil {
+		panic(err)
+	}
+	defer sub.Unsubscribe()
+
+	// Print each advisory as it arrives.
+	for {
+		msg, err := sub.NextMsg(nats.DefaultTimeout)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Max-deliveries advisory: %s\n", string(msg.Data))
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-acknowledgment-watchMaxDeliveries/main.go
+++ b/examples/docs/learn-jetstream-acknowledgment-watchMaxDeliveries/main.go
@@ -28,6 +28,10 @@ func main() {
 	// Print each advisory as it arrives.
 	for {
 		msg, err := sub.NextMsg(nats.DefaultTimeout)
+		if err == nats.ErrTimeout {
+			// No advisory yet; keep waiting.
+			continue
+		}
 		if err != nil {
 			panic(err)
 		}

--- a/examples/docs/learn-jetstream-advanced-publishing-async/main.go
+++ b/examples/docs/learn-jetstream-advanced-publishing-async/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	// NATS-DOC-START
+	// Async publish: fire every order without waiting for its PubAck, then
+	// collect the futures and check each one. The round trips overlap, so this
+	// is far faster than publishing one at a time -- but you still have to
+	// confirm every ack, because a publish whose ack never arrives is a lost
+	// order, not a stored one.
+	orders := []string{
+		`{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200}`,
+		`{"order_id":"ord_2zr9","customer":"globex","total_cents":7800}`,
+		`{"order_id":"ord_5t1m","customer":"initech","total_cents":1500}`,
+		`{"order_id":"ord_9p3x","customer":"hooli","total_cents":9900}`,
+	}
+
+	// PublishAsync returns immediately, before the server replies.
+	futures := make([]jetstream.PubAckFuture, 0, len(orders))
+	for _, order := range orders {
+		f, err := js.PublishAsync("orders.created", []byte(order))
+		if err != nil {
+			panic(err)
+		}
+		futures = append(futures, f)
+	}
+
+	// Wait until every publish has been answered, or give up after a timeout.
+	select {
+	case <-js.PublishAsyncComplete():
+	case <-time.After(5 * time.Second):
+		panic(fmt.Sprintf("timed out with %d publishes unconfirmed", js.PublishAsyncPending()))
+	}
+
+	// Check each ack. A publish whose ack failed has to be re-published.
+	for i, f := range futures {
+		select {
+		case ack := <-f.Ok():
+			fmt.Printf("order %d stored at sequence %d\n", i+1, ack.Sequence)
+		case err := <-f.Err():
+			fmt.Printf("order %d failed, re-publish it: %v\n", i+1, err)
+		}
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-filtering-createFiltered/main.go
+++ b/examples/docs/learn-jetstream-filtering-createFiltered/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Create a durable pull consumer named "analytics" on the ORDERS stream.
+	// FilterSubject narrows delivery to "orders.shipped", so the consumer never
+	// sees "orders.created" messages even though the stream stores both.
+	cons, err := js.CreateOrUpdateConsumer(ctx, "ORDERS", jetstream.ConsumerConfig{
+		Durable:       "analytics",
+		FilterSubject: "orders.shipped",
+		DeliverPolicy: jetstream.DeliverAllPolicy,
+		AckPolicy:     jetstream.AckExplicitPolicy,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Created consumer: %s\n", cons.CachedInfo().Name)
+	fmt.Printf("Filter: %s\n", cons.CachedInfo().Config.FilterSubject)
+
+	// Fetch up to 5 messages with a short expiry. Only "orders.shipped"
+	// messages come back; the filter excludes everything else.
+	msgs, err := cons.Fetch(5, jetstream.FetchMaxWait(2*time.Second))
+	if err != nil {
+		panic(err)
+	}
+	for msg := range msgs.Messages() {
+		fmt.Printf("Received on %s\n", msg.Subject())
+		msg.Ack()
+	}
+	if err := msgs.Error(); err != nil {
+		panic(err)
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-filtering-filterMatchesNothing/main.go
+++ b/examples/docs/learn-jetstream-filtering-filterMatchesNothing/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Create a durable pull consumer named "analytics-typo" on the ORDERS
+	// stream. The filter "orders.shiped" has a typo (one "p"), so it matches
+	// no subject the stream actually stores.
+	cons, err := js.CreateOrUpdateConsumer(ctx, "ORDERS", jetstream.ConsumerConfig{
+		Durable:       "analytics-typo",
+		FilterSubject: "orders.shiped",
+		DeliverPolicy: jetstream.DeliverAllPolicy,
+		AckPolicy:     jetstream.AckExplicitPolicy,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Fetch with a short expiry. The fetch succeeds with no error, but the
+	// channel yields zero messages because the filter matched no stored subject.
+	msgs, err := cons.Fetch(5, jetstream.FetchMaxWait(2*time.Second))
+	if err != nil {
+		panic(err)
+	}
+	count := 0
+	for range msgs.Messages() {
+		count++
+	}
+	if err := msgs.Error(); err != nil {
+		panic(err)
+	}
+
+	// A wrong filter fails silently: the pull returned nothing, and no error
+	// was raised. The consumer is healthy, it just never matches a message.
+	fmt.Printf("Received %d messages: the filter matched no stored subject, so the pull returned nothing (no error).\n", count)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-get-direct-by-sequence/main.go
+++ b/examples/docs/learn-jetstream-get-direct-by-sequence/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Look up the ORDERS stream.
+	stream, err := js.Stream(ctx, "ORDERS")
+	if err != nil {
+		panic(err)
+	}
+
+	// NATS-DOC-START
+	// Read the message stored at stream sequence 2. This is the regular get,
+	// served by the stream leader.
+	msg, err := stream.GetMsg(ctx, 2)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Subject: %s\n", msg.Subject)
+	fmt.Printf("Payload: %s\n", string(msg.Data))
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-get-direct-direct-read/main.go
+++ b/examples/docs/learn-jetstream-get-direct-direct-read/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Look up the ORDERS stream. The handle caches the stream config, including
+	// AllowDirect, which must already be enabled on the stream.
+	stream, err := js.Stream(ctx, "ORDERS")
+	if err != nil {
+		panic(err)
+	}
+
+	// NATS-DOC-START
+	// Read the message at sequence 1. Because the stream has AllowDirect
+	// enabled, GetMsg is served by the Direct Get API, so any replica can
+	// answer it, not only the leader.
+	msg, err := stream.GetMsg(ctx, 1)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Subject: %s\n", msg.Subject)
+	fmt.Printf("Payload: %s\n", string(msg.Data))
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-get-direct-enable/main.go
+++ b/examples/docs/learn-jetstream-get-direct-enable/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Look up the ORDERS stream.
+	stream, err := js.Stream(ctx, "ORDERS")
+	if err != nil {
+		panic(err)
+	}
+
+	// NATS-DOC-START
+	// Read the current config, turn on direct access, and push the update.
+	// AllowDirect lets any replica serve single-message gets.
+	info, err := stream.Info(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	cfg := info.Config
+	cfg.AllowDirect = true
+
+	updated, err := js.UpdateStream(ctx, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("AllowDirect: %v\n", updated.CachedInfo().Config.AllowDirect)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-get-direct-last-for-subject/main.go
+++ b/examples/docs/learn-jetstream-get-direct-last-for-subject/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Look up the ORDERS stream.
+	stream, err := js.Stream(ctx, "ORDERS")
+	if err != nil {
+		panic(err)
+	}
+
+	// NATS-DOC-START
+	// Read the last message stored on subject orders.shipped. This is the
+	// regular get, served by the stream leader.
+	msg, err := stream.GetLastMsgForSubject(ctx, "orders.shipped")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Subject: %s\n", msg.Subject)
+	fmt.Printf("Payload: %s\n", string(msg.Data))
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-message-ttl-publishWithTtl/main.go
+++ b/examples/docs/learn-jetstream-message-ttl-publishWithTtl/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Per-message TTL only works when the stream opts in with AllowMsgTTL.
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:        "ORDERS",
+		Subjects:    []string{"orders.>"},
+		AllowMsgTTL: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// NATS-DOC-START
+	// Publish with a 60-second TTL. WithMsgTTL sets the Nats-TTL header, so the
+	// server deletes this single message 60s after it is stored, ahead of the
+	// stream's MaxAge.
+	ack, err := js.Publish(ctx, "orders.cancelled", []byte("order 42 cancelled"),
+		jetstream.WithMsgTTL(60*time.Second))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Stored in %s at sequence %d\n", ack.Stream, ack.Sequence)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-message-ttl-publishWithTtl/main.go
+++ b/examples/docs/learn-jetstream-message-ttl-publishWithTtl/main.go
@@ -40,7 +40,7 @@ func main() {
 	// Publish with a 60-second TTL. WithMsgTTL sets the Nats-TTL header, so the
 	// server deletes this single message 60s after it is stored, ahead of the
 	// stream's MaxAge.
-	ack, err := js.Publish(ctx, "orders.cancelled", []byte("order 42 cancelled"),
+	ack, err := js.Publish(ctx, "orders.canceled", []byte("order 42 canceled"),
 		jetstream.WithMsgTTL(60*time.Second))
 	if err != nil {
 		panic(err)

--- a/examples/docs/learn-jetstream-message-ttl-ttl-on-disabled-stream/main.go
+++ b/examples/docs/learn-jetstream-message-ttl-ttl-on-disabled-stream/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// This stream never opted in: AllowMsgTTL is left at its default (false).
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "ORDERS_NO_TTL",
+		Subjects: []string{"no-ttl.>"},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// NATS-DOC-START
+	// Publishing with a TTL to a stream that hasn't enabled AllowMsgTTL fails.
+	// The server returns "per-message TTL is disabled" (err_code 10166) and
+	// stores nothing. The fix is to opt the stream in with AllowMsgTTL: true.
+	_, err = js.Publish(ctx, "no-ttl.msg", []byte("order 42 cancelled"),
+		jetstream.WithMsgTTL(60*time.Second))
+	if err != nil {
+		fmt.Printf("Publish rejected, message not stored: %s\n", err)
+		return
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-message-ttl-ttl-on-disabled-stream/main.go
+++ b/examples/docs/learn-jetstream-message-ttl-ttl-on-disabled-stream/main.go
@@ -39,7 +39,7 @@ func main() {
 	// Publishing with a TTL to a stream that hasn't enabled AllowMsgTTL fails.
 	// The server returns "per-message TTL is disabled" (err_code 10166) and
 	// stores nothing. The fix is to opt the stream in with AllowMsgTTL: true.
-	_, err = js.Publish(ctx, "no-ttl.msg", []byte("order 42 cancelled"),
+	_, err = js.Publish(ctx, "no-ttl.msg", []byte("order 42 canceled"),
 		jetstream.WithMsgTTL(60*time.Second))
 	if err != nil {
 		fmt.Printf("Publish rejected, message not stored: %s\n", err)

--- a/examples/docs/learn-jetstream-mirrors-and-sources-createMirror/main.go
+++ b/examples/docs/learn-jetstream-mirrors-and-sources-createMirror/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Create ORDERS-ARCHIVE as a read-only mirror of ORDERS. A mirror takes
+	// no subjects of its own; it follows the upstream stream.
+	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:   "ORDERS-ARCHIVE",
+		Mirror: &jetstream.StreamSource{Name: "ORDERS"},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Confirm: the new stream mirrors ORDERS.
+	cfg := stream.CachedInfo().Config
+	fmt.Printf("Created mirror %s of %s\n", cfg.Name, cfg.Mirror.Name)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-mirrors-and-sources-createSource/main.go
+++ b/examples/docs/learn-jetstream-mirrors-and-sources-createSource/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Setup: the three regional streams ALL-ORDERS aggregates, each with its
+	// own subjects.
+	regions := map[string]string{
+		"ORDERS-US":   "us.orders.>",
+		"ORDERS-EU":   "eu.orders.>",
+		"ORDERS-APAC": "apac.orders.>",
+	}
+	for name, subj := range regions {
+		if _, err := js.CreateStream(ctx, jetstream.StreamConfig{
+			Name:     name,
+			Subjects: []string{subj},
+		}); err != nil {
+			panic(err)
+		}
+	}
+
+	// NATS-DOC-START
+	// Create ALL-ORDERS as an aggregate that sources the three regional streams
+	// into one. Unlike a mirror, a stream can list several sources.
+	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name: "ALL-ORDERS",
+		Sources: []*jetstream.StreamSource{
+			{Name: "ORDERS-US"},
+			{Name: "ORDERS-EU"},
+			{Name: "ORDERS-APAC"},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cfg := stream.CachedInfo().Config
+	fmt.Printf("Created %s sourcing %d streams\n", cfg.Name, len(cfg.Sources))
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-mirrors-and-sources-mirrorLag/main.go
+++ b/examples/docs/learn-jetstream-mirrors-and-sources-mirrorLag/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// A mirror is eventually consistent. Read its Lag before trusting it to
+	// hold what the upstream just received: 0 means fully caught up.
+	stream, err := js.Stream(ctx, "ORDERS-ARCHIVE")
+	if err != nil {
+		panic(err)
+	}
+
+	info, err := stream.Info(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Upstream:  %s\n", info.Mirror.Name)
+	fmt.Printf("Lag:       %d\n", info.Mirror.Lag)
+	fmt.Printf("Last seen: %s ago\n", info.Mirror.Active)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-ordered-consumer-read/main.go
+++ b/examples/docs/learn-jetstream-ordered-consumer-read/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context.
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Ask for an ordered consumer over the stream. There's no name to manage and
+	// no ack to send: the library runs the consumer for you and recreates it if
+	// it ever misses a message, so you read every order in stream order. An
+	// empty config starts from the first order.
+	cons, err := js.OrderedConsumer(ctx, "ORDERS", jetstream.OrderedConsumerConfig{})
+	if err != nil {
+		panic(err)
+	}
+
+	iter, err := cons.Messages()
+	if err != nil {
+		panic(err)
+	}
+	defer iter.Stop()
+
+	// Read the whole log once, in order, stopping when caught up (NumPending 0).
+	for {
+		msg, err := iter.Next()
+		if err != nil {
+			break
+		}
+		meta, err := msg.Metadata()
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("order %s\n", string(msg.Data()))
+		if meta.NumPending == 0 {
+			break
+		}
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-publishing-confirmStored/main.go
+++ b/examples/docs/learn-jetstream-publishing-confirmStored/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	payload := `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}`
+
+	// NATS-DOC-START
+	// Publish one order and confirm it was stored. A failed publish returns an
+	// error rather than losing the message silently, so check err first.
+	ack, err := js.Publish(ctx, "orders.created", []byte(payload))
+	if err != nil {
+		panic(err)
+	}
+
+	// The returned PubAck is proof the message is on disk in the stream.
+	fmt.Printf("Stored in %s at sequence %d\n", ack.Stream, ack.Sequence)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-publishing-dedup/main.go
+++ b/examples/docs/learn-jetstream-publishing-dedup/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	payload := `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}`
+
+	// NATS-DOC-START
+	// Publish the same message twice with a message ID. The stream uses the ID
+	// to detect duplicates within its dedupe window.
+	first, err := js.Publish(ctx, "orders.created", []byte(payload), jetstream.WithMsgID("ord_8w2k-created"))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("First:  sequence %d, duplicate %t\n", first.Sequence, first.Duplicate)
+
+	// Re-publish with the same ID. The server recognizes it and reports the
+	// original sequence instead of storing the message again.
+	second, err := js.Publish(ctx, "orders.created", []byte(payload), jetstream.WithMsgID("ord_8w2k-created"))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Second: sequence %d, duplicate %t\n", second.Sequence, second.Duplicate)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-publishing-pubAck/main.go
+++ b/examples/docs/learn-jetstream-publishing-pubAck/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	payload := `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}`
+
+	// NATS-DOC-START
+	// Publish one order and inspect the PubAck the server returns.
+	ack, err := js.Publish(ctx, "orders.created", []byte(payload))
+	if err != nil {
+		panic(err)
+	}
+
+	// The PubAck confirms which stream stored the message, at what sequence,
+	// and whether it was treated as a duplicate.
+	fmt.Printf("Stream:    %s\n", ack.Stream)
+	fmt.Printf("Sequence:  %d\n", ack.Sequence)
+	fmt.Printf("Duplicate: %t\n", ack.Duplicate)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-publishing-sync/main.go
+++ b/examples/docs/learn-jetstream-publishing-sync/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Publish three order messages into the ORDERS stream. Each Publish blocks
+	// until the server replies with a PubAck confirming where it was stored.
+	orders := []struct {
+		subject string
+		payload string
+	}{
+		{"orders.created", `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}`},
+		{"orders.created", `{"order_id":"ord_2zr9","customer":"globex","total_cents":7800,"ts":"2026-05-22T10:14:25Z"}`},
+		{"orders.shipped", `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:31Z"}`},
+	}
+
+	for _, order := range orders {
+		ack, err := js.Publish(ctx, order.subject, []byte(order.payload))
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Stored in %s, sequence %d\n", ack.Stream, ack.Sequence)
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-pull-consumers-consumeContinuous/main.go
+++ b/examples/docs/learn-jetstream-pull-consumers-consumeContinuous/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context.
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Bind to the durable "shipping" consumer.
+	cons, err := js.Consumer(ctx, "ORDERS", "shipping")
+	if err != nil {
+		panic(err)
+	}
+
+	// Consume sets up a continuous flow: the library keeps pull requests open
+	// in the background and runs the handler for each order as soon as it lands
+	// in the stream. No fetch loop to write by hand; it runs until you stop it.
+	consCtx, err := cons.Consume(func(msg jetstream.Msg) {
+		fmt.Printf("shipping %s\n", string(msg.Data()))
+		msg.Ack()
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer consCtx.Stop()
+
+	// Keep consuming until interrupted (Ctrl-C).
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt)
+	<-sig
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-pull-consumers-emptyFetch/main.go
+++ b/examples/docs/learn-jetstream-pull-consumers-emptyFetch/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context.
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Bind to the durable "shipping" consumer.
+	cons, err := js.Consumer(ctx, "ORDERS", "shipping")
+	if err != nil {
+		panic(err)
+	}
+
+	// A fetch on a drained consumer returns an empty batch once the wait
+	// elapses, not an error. Treat "nothing right now" as normal: if no orders
+	// came back, wait and fetch again instead of failing.
+	msgs, err := cons.Fetch(10, jetstream.FetchMaxWait(2*time.Second))
+	if err != nil {
+		panic(err)
+	}
+	count := 0
+	for msg := range msgs.Messages() {
+		fmt.Printf("shipping %s\n", string(msg.Data()))
+		msg.Ack()
+		count++
+	}
+	if msgs.Error() != nil {
+		panic(msgs.Error())
+	}
+	if count == 0 {
+		fmt.Println("no orders waiting, will retry")
+		time.Sleep(time.Second)
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-pull-consumers-fetchBatch/main.go
+++ b/examples/docs/learn-jetstream-pull-consumers-fetchBatch/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context.
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Bind to the durable "shipping" consumer.
+	cons, err := js.Consumer(ctx, "ORDERS", "shipping")
+	if err != nil {
+		panic(err)
+	}
+
+	// Fetch a batch of up to 10 orders, waiting up to 2 seconds for them. The
+	// call returns when the batch is full or the wait elapses, whichever comes
+	// first. Process and ack each one, then fetch again to keep going.
+	msgs, err := cons.Fetch(10, jetstream.FetchMaxWait(2*time.Second))
+	if err != nil {
+		panic(err)
+	}
+	for msg := range msgs.Messages() {
+		fmt.Printf("shipping %s\n", string(msg.Data()))
+		msg.Ack()
+	}
+	if msgs.Error() != nil {
+		panic(msgs.Error())
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-reading-back-create/main.go
+++ b/examples/docs/learn-jetstream-reading-back-create/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Create a durable consumer on the ORDERS stream. The durable name lets a
+	// reader bind to the same consumer later and pick up where it left off.
+	cons, err := js.CreateOrUpdateConsumer(ctx, "ORDERS", jetstream.ConsumerConfig{
+		Durable:       "billing",
+		DeliverPolicy: jetstream.DeliverAllPolicy,
+		AckPolicy:     jetstream.AckExplicitPolicy,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Confirm the consumer is ready.
+	fmt.Printf("Created consumer: %s\n", cons.CachedInfo().Name)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-reading-back-read/main.go
+++ b/examples/docs/learn-jetstream-reading-back-read/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Bind to the durable consumer created earlier.
+	cons, err := js.Consumer(ctx, "ORDERS", "billing")
+	if err != nil {
+		panic(err)
+	}
+
+	// Ask the consumer how many messages are still waiting, then read exactly
+	// that many. This drains everything stored without assuming a count.
+	info, err := cons.Info(ctx)
+	if err != nil {
+		panic(err)
+	}
+	pending := info.NumPending
+	if pending == 0 {
+		fmt.Println("nothing to read")
+		return
+	}
+
+	msgs, err := cons.Fetch(int(pending))
+	if err != nil {
+		panic(err)
+	}
+
+	for msg := range msgs.Messages() {
+		// Metadata carries the position of this message in the stream and in
+		// the consumer's own delivery sequence.
+		meta, err := msg.Metadata()
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("stream seq=%d consumer seq=%d payload=%s\n",
+			meta.Sequence.Stream, meta.Sequence.Consumer, string(msg.Data()))
+
+		// Acknowledge so the server advances the consumer past this message.
+		if err := msg.Ack(); err != nil {
+			panic(err)
+		}
+	}
+	if msgs.Error() != nil {
+		panic(msgs.Error())
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-retention-policies-retentionSwitchRejected/main.go
+++ b/examples/docs/learn-jetstream-retention-policies-retentionSwitchRejected/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Make sure the FULFILLMENT WorkQueue stream exists.
+	if _, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:      "FULFILLMENT",
+		Subjects:  []string{"fulfill.>"},
+		Retention: jetstream.WorkQueuePolicy,
+	}); err != nil {
+		panic(err)
+	}
+
+	// NATS-DOC-START
+	// Load FULFILLMENT and take its current config.
+	stream, err := js.Stream(ctx, "FULFILLMENT")
+	if err != nil {
+		panic(err)
+	}
+	cfg := stream.CachedInfo().Config
+
+	// Try to turn the WorkQueue stream into a Limits stream by flipping
+	// retention and pushing the update back.
+	cfg.Retention = jetstream.LimitsPolicy
+	if _, err := js.UpdateStream(ctx, cfg); err != nil {
+		// The server refuses: a stream's retention policy is fixed for its
+		// lifetime (err 10052: stream configuration update can not change
+		// retention policy to/from workqueue). To change it, recreate the stream.
+		fmt.Printf("retention switch rejected: %v\n", err)
+		return
+	}
+	fmt.Println("update unexpectedly succeeded")
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-retention-policies-workQueueCreate/main.go
+++ b/examples/docs/learn-jetstream-retention-policies-workQueueCreate/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// FULFILLMENT is the queue of paid orders awaiting shipment. With WorkQueue
+	// retention the server keeps each message only until a consumer acks it,
+	// then deletes it from the stream.
+	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      "FULFILLMENT",
+		Subjects:  []string{"fulfill.>"},
+		Retention: jetstream.WorkQueuePolicy,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("FULFILLMENT retention: %s\n", stream.CachedInfo().Config.Retention)
+
+	// Queue one order to ship.
+	if _, err := js.Publish(ctx, "fulfill.us", []byte(`{"order_id":"ord_8w2k","customer":"acme-co"}`)); err != nil {
+		panic(err)
+	}
+
+	// A shipping worker binds to a durable pull consumer with explicit ack.
+	cons, err := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+		Durable:   "shippers",
+		AckPolicy: jetstream.AckExplicitPolicy,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Fetch the order and ack it once the worker has shipped it.
+	msgs, err := cons.Fetch(1)
+	if err != nil {
+		panic(err)
+	}
+	for msg := range msgs.Messages() {
+		fmt.Printf("shipping order: %s\n", string(msg.Data()))
+		if err := msg.Ack(); err != nil {
+			panic(err)
+		}
+	}
+	if msgs.Error() != nil {
+		panic(msgs.Error())
+	}
+
+	// The ack removed the task from the queue, so the stream is now empty. A
+	// Limits stream like ORDERS would still hold the message; a WorkQueue
+	// stream drains to zero as workers finish.
+	info, err := stream.Info(ctx)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("messages left in FULFILLMENT: %d\n", info.State.Msgs)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-retention-policies-workqueueOverlap/main.go
+++ b/examples/docs/learn-jetstream-retention-policies-workqueueOverlap/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Make sure the FULFILLMENT WorkQueue stream exists.
+	stream, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:      "FULFILLMENT",
+		Subjects:  []string{"fulfill.>"},
+		Retention: jetstream.WorkQueuePolicy,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// NATS-DOC-START
+	// One unfiltered consumer covers every order in the queue.
+	if _, err := stream.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		Durable:   "shippers",
+		AckPolicy: jetstream.AckExplicitPolicy,
+	}); err != nil {
+		panic(err)
+	}
+	fmt.Println("created unfiltered consumer: shippers")
+
+	// A WorkQueue stream delivers each message to exactly one consumer, so it
+	// refuses a second consumer whose reach overlaps the first. Two unfiltered
+	// consumers both cover fulfill.> , so this is rejected
+	// (err 10099: multiple non-filtered consumers not allowed on workqueue stream).
+	if _, err := stream.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		Durable:   "eu-shippers",
+		AckPolicy: jetstream.AckExplicitPolicy,
+	}); err != nil {
+		fmt.Printf("second unfiltered consumer rejected: %v\n", err)
+	}
+
+	// Drop the catch-all consumer so we can split the queue by region instead.
+	if err := stream.DeleteConsumer(ctx, "shippers"); err != nil {
+		panic(err)
+	}
+
+	// Filtered consumers are allowed as long as their subjects don't overlap.
+	// us-shippers takes fulfill.us, eu-shippers takes fulfill.eu, and each
+	// order still goes to exactly one worker.
+	if _, err := stream.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		Durable:       "us-shippers",
+		FilterSubject: "fulfill.us",
+		AckPolicy:     jetstream.AckExplicitPolicy,
+	}); err != nil {
+		panic(err)
+	}
+	if _, err := stream.CreateConsumer(ctx, jetstream.ConsumerConfig{
+		Durable:       "eu-shippers",
+		FilterSubject: "fulfill.eu",
+		AckPolicy:     jetstream.AckExplicitPolicy,
+	}); err != nil {
+		panic(err)
+	}
+	fmt.Println("created filtered consumers: us-shippers (fulfill.us), eu-shippers (fulfill.eu)")
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-shaping-the-stream-discardNew/main.go
+++ b/examples/docs/learn-jetstream-shaping-the-stream-discardNew/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context.
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Switch ORDERS to Discard New. Discard New never drops messages already
+	// stored, so capping it at one message leaves the existing orders in place
+	// and puts the stream instantly over its limit. The next publish is
+	// rejected rather than evicting an older order.
+	s, err := js.Stream(ctx, "ORDERS")
+	if err != nil {
+		panic(err)
+	}
+	cfg := s.CachedInfo().Config
+	cfg.Discard = jetstream.DiscardNew
+	cfg.MaxMsgs = 1
+	if _, err := js.UpdateStream(ctx, cfg); err != nil {
+		panic(err)
+	}
+
+	// This publish hits the full stream and fails with "maximum messages
+	// exceeded" instead of succeeding silently. Handle it in the publisher.
+	if _, err := js.Publish(ctx, "orders.created", []byte(`{"order_id":"ord_8w2k"}`)); err != nil {
+		fmt.Printf("publish rejected: %v\n", err)
+	}
+
+	// Put ORDERS back: Discard Old, no message cap (age and byte limits stay).
+	cfg.Discard = jetstream.DiscardOld
+	cfg.MaxMsgs = -1
+	if _, err := js.UpdateStream(ctx, cfg); err != nil {
+		panic(err)
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-shaping-the-stream-perSubjectLimit/main.go
+++ b/examples/docs/learn-jetstream-shaping-the-stream-perSubjectLimit/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context.
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Add a per-subject ceiling so one noisy subject can't evict another's
+	// messages. MaxMsgsPerSubject keeps the most recent N messages for every
+	// subject independently, alongside the whole-stream limits.
+	s, err := js.Stream(ctx, "ORDERS")
+	if err != nil {
+		panic(err)
+	}
+	cfg := s.CachedInfo().Config
+	cfg.MaxMsgsPerSubject = 100000
+	if _, err := js.UpdateStream(ctx, cfg); err != nil {
+		panic(err)
+	}
+	fmt.Println("ORDERS now keeps 100000 messages per subject")
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-shaping-the-stream-setLimits/main.go
+++ b/examples/docs/learn-jetstream-shaping-the-stream-setLimits/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context.
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Cap ORDERS so it can't grow without bound. Fetch the current config, add
+	// a seven-day age limit and a 1 GiB byte ceiling, and update the stream in
+	// place. Editing limits leaves the messages already stored alone.
+	s, err := js.Stream(ctx, "ORDERS")
+	if err != nil {
+		panic(err)
+	}
+	cfg := s.CachedInfo().Config
+	cfg.MaxAge = 7 * 24 * time.Hour
+	cfg.MaxBytes = 1 << 30 // 1 GiB
+	if _, err := js.UpdateStream(ctx, cfg); err != nil {
+		panic(err)
+	}
+	fmt.Println("ORDERS capped at 7d age and 1 GiB")
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-subject-mapping-republish/main.go
+++ b/examples/docs/learn-jetstream-subject-mapping-republish/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Look up the ORDERS stream.
+	stream, err := js.Stream(ctx, "ORDERS")
+	if err != nil {
+		panic(err)
+	}
+
+	// NATS-DOC-START
+	// Read the current config, add a republish rule, and push the update.
+	// Every message stored on "orders.>" is also echoed live to "dash.orders.>"
+	// so a dashboard can subscribe without touching the stream.
+	cfg := stream.CachedInfo().Config
+	cfg.RePublish = &jetstream.RePublish{
+		Source:      "orders.>",
+		Destination: "dash.orders.>",
+		// HeadersOnly: true, // republish only the headers, not the body
+	}
+
+	updated, err := js.UpdateStream(ctx, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Republish destination: %s\n", updated.CachedInfo().Config.RePublish.Destination)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-subject-mapping-transform/main.go
+++ b/examples/docs/learn-jetstream-subject-mapping-transform/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Create a stream that rewrites subjects as it stores them. The transform
+	// shards each customer into one of three buckets: partition(3,1) hashes the
+	// first wildcard token into 0, 1, or 2, and wildcard(1) keeps that token.
+	// So "ingest.alice" might land on "orders.2.alice".
+	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "ORDERS-SHARDED",
+		Subjects: []string{"ingest.*"},
+		SubjectTransform: &jetstream.SubjectTransformConfig{
+			Source:      "ingest.*",
+			Destination: "orders.{{partition(3,1)}}.{{wildcard(1)}}",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Created stream: %s\n", stream.CachedInfo().Config.Name)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-worker-pool-max-pending/main.go
+++ b/examples/docs/learn-jetstream-worker-pool-max-pending/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context.
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Raise MaxAckPending so a larger pool can hold more orders in progress at
+	// once. The cap is shared across the whole "shipping" consumer, not per
+	// worker, so size it to at least your worker count. CreateOrUpdateConsumer
+	// updates the existing consumer in place.
+	_, err = js.CreateOrUpdateConsumer(ctx, "ORDERS", jetstream.ConsumerConfig{
+		Durable:       "shipping",
+		AckPolicy:     jetstream.AckExplicitPolicy,
+		MaxAckPending: 5000,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("shipping MaxAckPending set to 5000")
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-worker-pool-redelivery-count/main.go
+++ b/examples/docs/learn-jetstream-worker-pool-redelivery-count/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context.
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Bind to the durable "shipping" consumer.
+	cons, err := js.Consumer(ctx, "ORDERS", "shipping")
+	if err != nil {
+		panic(err)
+	}
+
+	// Each message carries how many times it has been delivered. A count above
+	// one means a redelivery: the server handed this order out before, but a
+	// worker crashed or ran past AckWait before acking. Key your side effects by
+	// order_id so handling the same order twice is harmless.
+	msgs, err := cons.Fetch(10)
+	if err != nil {
+		panic(err)
+	}
+	for msg := range msgs.Messages() {
+		meta, err := msg.Metadata()
+		if err != nil {
+			panic(err)
+		}
+		if meta.NumDelivered > 1 {
+			fmt.Printf("redelivery #%d of %s\n", meta.NumDelivered, string(msg.Data()))
+		} else {
+			fmt.Printf("first delivery of %s\n", string(msg.Data()))
+		}
+		msg.Ack()
+	}
+	if msgs.Error() != nil {
+		panic(msgs.Error())
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-worker-pool-worker/main.go
+++ b/examples/docs/learn-jetstream-worker-pool-worker/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context.
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Bind to the durable "shipping" consumer created earlier.
+	cons, err := js.Consumer(ctx, "ORDERS", "shipping")
+	if err != nil {
+		panic(err)
+	}
+
+	// Consume runs the handler for every order the server hands this worker.
+	// Start this same program in several processes: they all share the one
+	// "shipping" consumer, and the server splits the stored orders across them,
+	// one order to one worker.
+	consCtx, err := cons.Consume(func(msg jetstream.Msg) {
+		fmt.Printf("shipping %s\n", string(msg.Data()))
+		msg.Ack()
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer consCtx.Stop()
+
+	// Keep this worker running until interrupted (Ctrl-C).
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt)
+	<-sig
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-your-first-consumer-create/main.go
+++ b/examples/docs/learn-jetstream-your-first-consumer-create/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Create a durable pull consumer named "shipping" on the ORDERS stream.
+	// DeliverAllPolicy starts from the first message in the stream, and
+	// AckExplicitPolicy means every message must be acknowledged by hand.
+	cons, err := js.CreateOrUpdateConsumer(ctx, "ORDERS", jetstream.ConsumerConfig{
+		Durable:       "shipping",
+		DeliverPolicy: jetstream.DeliverAllPolicy,
+		AckPolicy:     jetstream.AckExplicitPolicy,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Confirm the consumer is ready.
+	fmt.Printf("Created consumer: %s\n", cons.CachedInfo().Name)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-your-first-consumer-doubleAck/main.go
+++ b/examples/docs/learn-jetstream-your-first-consumer-doubleAck/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Bind to the durable "shipping" consumer created earlier.
+	cons, err := js.Consumer(ctx, "ORDERS", "shipping")
+	if err != nil {
+		panic(err)
+	}
+
+	// Fetch a single message from the consumer.
+	msg, err := cons.Next()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Received on %s: %s\n", msg.Subject(), string(msg.Data()))
+
+	// DoubleAck blocks until the server confirms it recorded the acknowledgment.
+	// Use it when losing an ack would be worse than the extra round trip.
+	if err := msg.DoubleAck(ctx); err != nil {
+		panic(err)
+	}
+	fmt.Println("Acknowledgment confirmed by the server")
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-your-first-consumer-next/main.go
+++ b/examples/docs/learn-jetstream-your-first-consumer-next/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Bind to the durable "shipping" consumer created earlier.
+	cons, err := js.Consumer(ctx, "ORDERS", "shipping")
+	if err != nil {
+		panic(err)
+	}
+
+	// Fetch a single message from the consumer.
+	msg, err := cons.Next()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Received on %s: %s\n", msg.Subject(), string(msg.Data()))
+
+	// We deliberately do not acknowledge this message. It stays in flight, and
+	// the server redelivers it once the consumer's Ack Wait window elapses.
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-your-first-consumer-pullAndAck/main.go
+++ b/examples/docs/learn-jetstream-your-first-consumer-pullAndAck/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Bind to the durable "shipping" consumer created earlier.
+	cons, err := js.Consumer(ctx, "ORDERS", "shipping")
+	if err != nil {
+		panic(err)
+	}
+
+	// Fetch a single message from the consumer.
+	msg, err := cons.Next()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Received on %s: %s\n", msg.Subject(), string(msg.Data()))
+
+	// Acknowledge so the server advances the consumer past this message.
+	if err := msg.Ack(); err != nil {
+		panic(err)
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-your-first-stream-create/main.go
+++ b/examples/docs/learn-jetstream-your-first-stream-create/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Create the ORDERS stream, capturing every subject under 'orders.>'.
+	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "ORDERS",
+		Subjects: []string{"orders.>"},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Confirm the stream was created.
+	fmt.Printf("Created stream: %s\n", stream.CachedInfo().Config.Name)
+	// NATS-DOC-END
+}

--- a/examples/docs/learn-jetstream-your-first-stream-info/main.go
+++ b/examples/docs/learn-jetstream-your-first-stream-info/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	// Connect to the NATS server.
+	nc, err := nats.Connect("nats://localhost:4222")
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+
+	// Create a JetStream context (the stream manager).
+	js, err := jetstream.New(nc)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// NATS-DOC-START
+	// Look up the ORDERS stream and fetch its latest info from the server.
+	stream, err := js.Stream(ctx, "ORDERS")
+	if err != nil {
+		panic(err)
+	}
+
+	info, err := stream.Info(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	// Print key fields: name, captured subjects, and current message count.
+	fmt.Printf("Name:     %s\n", info.Config.Name)
+	fmt.Printf("Subjects: %v\n", info.Config.Subjects)
+	fmt.Printf("Messages: %d\n", info.State.Msgs)
+	// NATS-DOC-END
+}

--- a/examples/docs/queue-groups-basic/main.go
+++ b/examples/docs/queue-groups-basic/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, _ := nats.Connect(nats.DefaultURL)
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Create three workers in the same queue group
+	nc.QueueSubscribe("orders.new", "workers", func(m *nats.Msg) {
+		fmt.Printf("Worker A processed: %s\n", string(m.Data))
+	})
+
+	nc.QueueSubscribe("orders.new", "workers", func(m *nats.Msg) {
+		fmt.Printf("Worker B processed: %s\n", string(m.Data))
+	})
+
+	nc.QueueSubscribe("orders.new", "workers", func(m *nats.Msg) {
+		fmt.Printf("Worker C processed: %s\n", string(m.Data))
+	})
+
+	// Publish messages - automatically load balanced
+	for i := 1; i <= 10; i++ {
+		nc.Publish("orders.new", []byte(fmt.Sprintf("Order %d", i)))
+	}
+	// NATS-DOC-END
+
+	time.Sleep(100 * time.Millisecond)
+}

--- a/examples/docs/queue-groups-dynamic-scaling/main.go
+++ b/examples/docs/queue-groups-dynamic-scaling/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, _ := nats.Connect(nats.DefaultURL)
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Worker that can be dynamically added/removed
+	type Worker struct {
+		ID   string
+		sub  *nats.Subscription
+		done chan bool
+	}
+
+	NewWorker := func(nc *nats.Conn, id string) *Worker {
+		w := &Worker{ID: id, done: make(chan bool)}
+
+		w.sub, _ = nc.QueueSubscribe("tasks", "workers", func(m *nats.Msg) {
+			fmt.Printf("Worker %s processing: %s\n", id, string(m.Data))
+			// Simulate work
+			time.Sleep(100 * time.Millisecond)
+		})
+
+		return w
+	}
+
+	Stop := func(w *Worker) {
+		w.sub.Unsubscribe()
+		close(w.done)
+	}
+
+	// Dynamic scaling
+	workers := make([]*Worker, 0)
+
+	// Scale up
+	for i := 1; i <= 5; i++ {
+		worker := NewWorker(nc, fmt.Sprintf("%d", i))
+		workers = append(workers, worker)
+	}
+
+	// Scale down
+	for i := 0; i < 5; i++ {
+		Stop(workers[i])
+	}
+	// NATS-DOC-END
+
+	time.Sleep(500 * time.Millisecond)
+}

--- a/examples/docs/queue-groups-mixed-subscribers/main.go
+++ b/examples/docs/queue-groups-mixed-subscribers/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Audit logger - receives all messages
+	nc.Subscribe("orders.>", func(m *nats.Msg) {
+		log.Printf("[AUDIT] %s: %s", m.Subject, string(m.Data))
+	})
+
+	// Metrics collector - receives all messages
+	nc.Subscribe("orders.>", func(m *nats.Msg) {
+		log.Printf("[METRICS] %s: %s", m.Subject, string(m.Data))
+	})
+
+	// Workers in queue group - load balanced
+	nc.QueueSubscribe("orders.new", "workers", func(m *nats.Msg) {
+		fmt.Printf("[WORKER A] Processing: %s\n", string(m.Data))
+		processOrder(m.Data)
+	})
+
+	nc.QueueSubscribe("orders.new", "workers", func(m *nats.Msg) {
+		fmt.Printf("[WORKER B] Processing: %s\n", string(m.Data))
+		processOrder(m.Data)
+	})
+
+	// Publish orders
+	nc.Publish("orders.new", []byte("Order 123"))
+	nc.Publish("orders.new", []byte("Order 124"))
+	// Audit and metrics see them, one worker processes each
+	// NATS-DOC-END
+
+	time.Sleep(500 * time.Millisecond)
+}
+
+func processOrder(data []byte) {
+	// Process order implementation
+}

--- a/examples/docs/queue-groups-request-reply/main.go
+++ b/examples/docs/queue-groups-request-reply/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, _ := nats.Connect(nats.DefaultURL)
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Service instance with queue group for load balancing
+	createServiceInstance := func(nc *nats.Conn, instanceID string) {
+		nc.QueueSubscribe("api.calculate", "api-workers", func(m *nats.Msg) {
+			// Parse request
+			var request map[string]int
+			json.Unmarshal(m.Data, &request)
+
+			// Process request
+			result := request["a"] + request["b"]
+
+			// Send response
+			response := map[string]interface{}{
+				"result":      result,
+				"processedBy": instanceID,
+			}
+			responseData, _ := json.Marshal(response)
+			m.Respond(responseData)
+
+			fmt.Printf("Instance %s processed request\n", instanceID)
+		})
+	}
+
+	// Start multiple service instances
+	for i := 1; i <= 3; i++ {
+		createServiceInstance(nc, fmt.Sprintf("instance-%d", i))
+	}
+
+	// Make requests - automatically load balanced
+	for i := 0; i < 10; i++ {
+		request := map[string]int{"a": i, "b": i * 2}
+		requestData, _ := json.Marshal(request)
+
+		msg, _ := nc.Request("api.calculate", requestData, time.Second)
+
+		var response map[string]interface{}
+		json.Unmarshal(msg.Data, &response)
+		fmt.Printf("Result: %v, processed by: %s\n",
+			response["result"], response["processedBy"])
+	}
+	// NATS-DOC-END
+}

--- a/examples/docs/request-reply-basic/main.go
+++ b/examples/docs/request-reply-basic/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, _ := nats.Connect(nats.DefaultURL)
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Set up a service
+	nc.Subscribe("time", func(m *nats.Msg) {
+		timeStr := time.Now().Format(time.RFC3339)
+		m.Respond([]byte(timeStr))
+	})
+
+	// Make a request
+	msg, err := nc.Request("time", nil, 1*time.Second)
+	if err != nil {
+		fmt.Printf("Request failed: %v\n", err)
+		return
+	}
+	fmt.Printf("Response: %s\n", string(msg.Data))
+	// NATS-DOC-END
+}

--- a/examples/docs/request-reply-calculator/main.go
+++ b/examples/docs/request-reply-calculator/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, _ := nats.Connect(nats.DefaultURL)
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Calculator service
+	nc.Subscribe("calc.add", func(msg *nats.Msg) {
+		parts := strings.Fields(string(msg.Data))
+		if len(parts) == 2 {
+			a, _ := strconv.Atoi(parts[0])
+			b, _ := strconv.Atoi(parts[1])
+			result := fmt.Sprintf("%d", a+b)
+			msg.Respond([]byte(result))
+		}
+	})
+
+	// Make calculations
+	time.Sleep(100 * time.Millisecond)
+
+	resp, _ := nc.Request("calc.add", []byte("5 3"), time.Second)
+	fmt.Printf("5 + 3 = %s\n", string(resp.Data))
+
+	resp, _ = nc.Request("calc.add", []byte("10 7"), time.Second)
+	fmt.Printf("10 + 7 = %s\n", string(resp.Data))
+	// NATS-DOC-END
+
+	time.Sleep(100 * time.Millisecond)
+}

--- a/examples/docs/request-reply-headers/main.go
+++ b/examples/docs/request-reply-headers/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, _ := nats.Connect(nats.DefaultURL)
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Header Aware service
+	nc.Subscribe("service", func(msg *nats.Msg) {
+		responseMsg := nats.NewMsg(msg.Reply)
+		responseMsg.Data = msg.Data
+		responseMsg.Header.Add("X-Response-ID", "123")
+		responseMsg.Header.Add("X-Request-ID", msg.Header.Get("X-Request-ID"))
+		responseMsg.Header.Add("X-Priority", msg.Header.Get("X-Priority"))
+		nc.PublishMsg(responseMsg)
+	})
+
+	// Create message with headers
+	msg := nats.NewMsg("service")
+	msg.Header.Add("X-Request-ID", "123")
+	msg.Header.Add("X-Priority", "high")
+	msg.Data = []byte("data")
+
+	// Send request with headers
+	response, err := nc.RequestMsg(msg, time.Second)
+	if err == nil {
+		fmt.Printf("Response: %s\n", response.Data)
+		fmt.Printf("Response ID: %s\n", response.Header.Get("X-Response-ID"))
+	} else {
+		fmt.Printf("Error: %s\n", err)
+	}
+	// NATS-DOC-END
+	time.Sleep(100 * time.Millisecond)
+}

--- a/examples/docs/request-reply-multiple-responders/main.go
+++ b/examples/docs/request-reply-multiple-responders/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, _ := nats.Connect(nats.DefaultURL)
+	defer nc.Close()
+
+	// NATS-DOC-START
+	processCalculation := func(data []byte) []byte {
+		return []byte("calculated result")
+	}
+
+	// Multiple responders - only first response is returned
+	nc.Subscribe("calc.add", func(m *nats.Msg) {
+		result := processCalculation(m.Data)
+		m.Respond(append(result, []byte(" from A")...))
+	})
+
+	nc.Subscribe("calc.add", func(m *nats.Msg) {
+		result := processCalculation(m.Data)
+		m.Respond(append(result, []byte(" from B")...))
+	})
+
+	// Gets one response
+	msg, _ := nc.Request("calc.add", []byte("data"), time.Second)
+	fmt.Printf("Got response: %s\n", msg.Data)
+	// NATS-DOC-END
+}

--- a/examples/docs/request-reply-no-responders/main.go
+++ b/examples/docs/request-reply-no-responders/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	// NATS-DOC-START
+	msg, err := nc.Request("no.such.service", []byte("test"), time.Second)
+	if err == nats.ErrNoResponders {
+		log.Println("No services available to handle request")
+	}
+	// NATS-DOC-END
+
+	_ = msg
+}

--- a/examples/docs/request-reply-timeout/main.go
+++ b/examples/docs/request-reply-timeout/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, _ := nats.Connect(nats.DefaultURL)
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Request with custom timeout
+	msg, err := nc.Request("service", []byte("data"), 2*time.Second)
+	if err != nil {
+		if err == nats.ErrTimeout {
+			fmt.Println("Request timed out")
+		} else {
+			fmt.Printf("Request failed: %v\n", err)
+		}
+		return
+	}
+	fmt.Printf("Response: %s\n", string(msg.Data))
+	// NATS-DOC-END
+}

--- a/examples/docs/subjects-monitoring/main.go
+++ b/examples/docs/subjects-monitoring/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, _ := nats.Connect(nats.DefaultURL)
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Create a wire tap for monitoring
+	nc.Subscribe(">", func(m *nats.Msg) {
+		fmt.Printf("[MONITOR] %s: %s\n", m.Subject, string(m.Data))
+	})
+	// NATS-DOC-END
+}

--- a/examples/docs/subjects-multi-wildcard/main.go
+++ b/examples/docs/subjects-multi-wildcard/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, _ := nats.Connect(nats.DefaultURL)
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Subscribe to all alarms
+	nc.Subscribe("sensor.alarm.*", func(m *nats.Msg) {
+		fmt.Printf("[sensor.alarm.*]       %-15s (%s)\n", string(m.Data), m.Subject)
+	})
+
+	// Subscribe to all critical
+	nc.Subscribe("sensor.*.*.critical", func(m *nats.Msg) {
+		fmt.Printf("[sensor.*.*.critical]  %-15s (%s)\n", string(m.Data), m.Subject)
+	})
+
+	// Subscribe to everything
+	nc.Subscribe("sensor.>", func(m *nats.Msg) {
+		fmt.Printf("[sensor.>]             %-15s (%s)\n", string(m.Data), m.Subject)
+	})
+
+	// Publish to specific subjects
+	nc.Publish("sensor.alarm.smoke", []byte("kitchen,14:22"))
+	nc.Publish("sensor.alarm.smoke.critical", []byte("kitchen,14:23"))
+	nc.Publish("sensor.alarm.water", []byte("basement,16:42"))
+	nc.Publish("sensor.alarm.water.critical", []byte("basement,16:43"))
+	// NATS-DOC-END
+
+	time.Sleep(100 * time.Millisecond)
+}

--- a/examples/docs/subjects-single-wildcard/main.go
+++ b/examples/docs/subjects-single-wildcard/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, _ := nats.Connect(nats.DefaultURL)
+	defer nc.Close()
+
+	// NATS-DOC-START
+	// Subscribe with single token wildcard
+	nc.Subscribe("orders.*.shipped", func(m *nats.Msg) {
+		fmt.Printf("[orders.*.shipped]  %s  (%s)\n", string(m.Data), m.Subject)
+	})
+
+	nc.Subscribe("orders.*.placed", func(m *nats.Msg) {
+		fmt.Printf("[orders.*.placed]   %s  (%s)\n", string(m.Data), m.Subject)
+	})
+
+	nc.Subscribe("orders.retail.*", func(m *nats.Msg) {
+		fmt.Printf("[orders.retail.*]   %s  (%s)\n", string(m.Data), m.Subject)
+	})
+
+	// Publish to specific subjects
+	nc.Publish("orders.wholesale.placed", []byte("Order W73737"))
+	nc.Publish("orders.retail.placed", []byte("Order R65432"))
+	nc.Publish("orders.wholesale.shipped", []byte("Order W73001"))
+	nc.Publish("orders.retail.shipped", []byte("Order R65321"))
+	// NATS-DOC-END
+
+	time.Sleep(100 * time.Millisecond)
+}


### PR DESCRIPTION
Moves the documentation examples from the `doc-examples`, `core-docs` and `jetstream-docs` branches into `examples/docs/` on main (70 example programs, additive union — no other changes).

Why: the new docs.nats.io build fetches these snippets at build time. On side branches they get zero CI (no workflow triggers on them) and can be broken by branch pruning. On main, `go vet ./...` / `go test ./...` compile them automatically — verified locally, gofmt-clean.

Note: please keep the three docs branches until the docs repo's fetch config is switched to `main` (follow-up PR there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)