### PR TITLE
feat(jetstream): map JetStream error code 10054 (stream message exceeds maximum)

### DIFF
--- a/jetstream/errors.go
+++ b/jetstream/errors.go
@@ -52,8 +52,9 @@ const (
 	JSErrCodeMessageNotFound               ErrorCode = 10037
 	JSErrCodeJetStreamNotEnabledForAccount ErrorCode = 10039
 
-	JSErrCodeStreamNameInUse ErrorCode = 10058
-	JSErrCodeStreamNotFound  ErrorCode = 10059
+	JSErrCodeStreamMessageExceedsMaximum ErrorCode = 10054
+	JSErrCodeStreamNameInUse             ErrorCode = 10058
+	JSErrCodeStreamNotFound              ErrorCode = 10059
 
 	JSErrCodeStreamWrongLastSequence ErrorCode = 10071
 	JSErrCodeJetStreamNotEnabled     ErrorCode = 10076
@@ -97,6 +98,10 @@ var (
 	// ErrJetStreamNotEnabledForAccount is an error returned when JetStream is
 	// not enabled for an account.
 	ErrJetStreamNotEnabledForAccount JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeJetStreamNotEnabledForAccount, Description: "jetstream not enabled for account", Code: 503}}
+
+	// ErrStreamMessageExceedsMaximum is an error returned when a message exceeds the
+	// maximum allowed size configured for the stream.
+	ErrStreamMessageExceedsMaximum JetStreamError = &jsError{apiErr: &APIError{ErrorCode: JSErrCodeStreamMessageExceedsMaximum, Description: "message size exceeds maximum allowed", Code: 400}}
 
 	// ErrStreamNotFound is an error returned when stream with given name does
 	// not exist.

--- a/jetstream/publish.go
+++ b/jetstream/publish.go
@@ -25,8 +25,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nuid"
+
+	"github.com/nats-io/nats.go"
 )
 
 type (
@@ -253,6 +254,9 @@ func (js *jetStream) PublishMsg(ctx context.Context, m *nats.Msg, opts ...Publis
 		return nil, ErrInvalidJSAck
 	}
 	if ackResp.Error != nil {
+		if ackResp.Error.ErrorCode == JSErrCodeStreamMessageExceedsMaximum {
+			return nil, ErrStreamMessageExceedsMaximum
+		}
 		return nil, fmt.Errorf("nats: %w", ackResp.Error)
 	}
 	if ackResp.PubAck == nil || ackResp.PubAck.Stream == "" {

--- a/jetstream/test/errors_test.go
+++ b/jetstream/test/errors_test.go
@@ -208,4 +208,101 @@ func TestJetStreamErrors(t *testing.T) {
 		}
 	})
 
+	t.Run("stream message exceeds maximum", func(t *testing.T) {
+		s := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, s)
+
+		nc, err := nats.Connect(s.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+			Name:       "MAXSIZE",
+			Subjects:   []string{"maxsize.*"},
+			MaxMsgSize: 10,
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		_, err = js.Publish(ctx, "maxsize.a", []byte("this payload is longer than 10 bytes"))
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
+
+		// check directly to var (backwards compatible)
+		if err != jetstream.ErrStreamMessageExceedsMaximum {
+			t.Fatalf("Expected: %v; got: %v", jetstream.ErrStreamMessageExceedsMaximum, err)
+		}
+
+		// matching via errors.Is
+		if ok := errors.Is(err, jetstream.ErrStreamMessageExceedsMaximum); !ok {
+			t.Fatal("Expected jetstream.ErrStreamMessageExceedsMaximum")
+		}
+
+		// matching wrapped via error.Is
+		err2 := fmt.Errorf("custom error: %w", jetstream.ErrStreamMessageExceedsMaximum)
+		if ok := errors.Is(err2, jetstream.ErrStreamMessageExceedsMaximum); !ok {
+			t.Fatal("Expected wrapped ErrStreamMessageExceedsMaximum")
+		}
+
+		// via classic type assertion.
+		jserr, ok := err.(jetstream.JetStreamError)
+		if !ok {
+			t.Fatal("Expected a jetstream.JetStreamError")
+		}
+		expected := jetstream.JSErrCodeStreamMessageExceedsMaximum
+		if jserr.APIError().ErrorCode != expected {
+			t.Fatalf("Expected: %v, got: %v", expected, jserr.APIError().ErrorCode)
+		}
+		if jserr.APIError() == nil {
+			t.Fatal("Expected APIError")
+		}
+
+		// matching to interface via errors.As(...)
+		var apierr jetstream.JetStreamError
+		ok = errors.As(err, &apierr)
+		if !ok {
+			t.Fatal("Expected a jetstream.JetStreamError")
+		}
+		if apierr.APIError() == nil {
+			t.Fatal("Expected APIError")
+		}
+		if apierr.APIError().ErrorCode != expected {
+			t.Fatalf("Expected: %v, got: %v", expected, apierr.APIError().ErrorCode)
+		}
+		expectedMessage := "nats: API error: code=400 err_code=10054 description=message size exceeds maximum allowed"
+		if apierr.Error() != expectedMessage {
+			t.Fatalf("Expected: %v, got: %v", expectedMessage, apierr.Error())
+		}
+
+		// matching arbitrary custom error via errors.Is(...)
+		customErr := &jetstream.APIError{ErrorCode: expected}
+		if ok := errors.Is(customErr, jetstream.ErrStreamMessageExceedsMaximum); !ok {
+			t.Fatal("Expected wrapped jetstream.ErrStreamMessageExceedsMaximum")
+		}
+		customErr = &jetstream.APIError{ErrorCode: 1}
+		if ok := errors.Is(customErr, jetstream.ErrStreamMessageExceedsMaximum); ok {
+			t.Fatal("Expected to not match ErrStreamMessageExceedsMaximum")
+		}
+
+		// matching to concrete type via errors.As(...)
+		var aerr *jetstream.APIError
+		ok = errors.As(err, &aerr)
+		if !ok {
+			t.Fatal("Expected an APIError")
+		}
+		if aerr.ErrorCode != expected {
+			t.Fatalf("Expected: %v, got: %v", expected, aerr.ErrorCode)
+		}
+	})
 }


### PR DESCRIPTION
Add client-side mapping for JetStream API error code 10054, returned by
nats-server when a published message exceeds the stream's configured
MaxMsgSize.

- Add JSErrCodeStreamMessageExceedsMaximum (10054) to the ErrorCode enum
  in jetstream/errors.go
- Add ErrStreamMessageExceedsMaximum sentinel error wrapping the
  corresponding APIError
- Add test coverage in jetstream/test/errors_test.go verifying the
  error is returned end-to-end when publishing a message that exceeds
  a stream's MaxMsgSize, and that it matches via errors.Is/errors.As
  and direct APIError inspection

Ref: https://github.com/nats-io/nats-server/blob/main/server/jetstream_errors_generated.go#L564
