### PR TITLE
docs(jetstream): document typed errors returned by interfaces

### DIFF
--- a/jetstream/consumer.go
+++ b/jetstream/consumer.go
@@ -98,6 +98,7 @@ type (
 		// retrieve messages in comparison to Messages or Consume methods, as it
 		// does not perform any optimizations (e.g. overlapping pull requests)
 		// and new subscription is created for each execution.
+		// May return ErrMaxBytesExceeded if the batch exceeds maximum bytes.
 		FetchBytes(maxBytes int, opts ...FetchOpt) (MessageBatch, error)
 
 		// FetchNoWait is used to retrieve up to a provided number of messages
@@ -134,6 +135,7 @@ type (
 		//
 		// Consume returns a ConsumeContext, which can be used to stop or drain
 		// the consumer.
+		// May return ErrConsumerDeleted if the consumer is deleted while consuming.
 		Consume(handler MessageHandler, opts ...PullConsumeOpt) (ConsumeContext, error)
 
 		// Messages returns MessagesContext, allowing continuous iteration
@@ -154,6 +156,7 @@ type (
 		Next(opts ...FetchOpt) (Msg, error)
 
 		// Info fetches current ConsumerInfo from the server.
+		// Returns ErrConsumerNotFound if the consumer does not exist.
 		Info(context.Context) (*ConsumerInfo, error)
 
 		// CachedInfo returns ConsumerInfo currently cached on this consumer.

--- a/jetstream/kv.go
+++ b/jetstream/kv.go
@@ -91,12 +91,13 @@ type (
 	// - Close the KeyValue store
 	KeyValue interface {
 		// Get returns the latest value for the key. If the key does not exist,
-		// ErrKeyNotFound will be returned.
+		// ErrKeyNotFound will be returned. Returns ErrInvalidKey if the key name is invalid.
+		// Returns ErrKeyDeleted if the key was deleted.
 		Get(ctx context.Context, key string) (KeyValueEntry, error)
 
 		// GetRevision returns a specific revision value for the key. If the key
 		// does not exist or the provided revision does not exists,
-		// ErrKeyNotFound will be returned.
+		// ErrKeyNotFound will be returned. Returns ErrInvalidKey if the key name is invalid.
 		GetRevision(ctx context.Context, key string, revision uint64) (KeyValueEntry, error)
 
 		// Put will place the new value for the key into the store. If the key
@@ -104,7 +105,7 @@ type (
 		// be updated.
 		//
 		// A key has to consist of alphanumeric characters, dashes, underscores,
-		// equal signs, and dots.
+		// equal signs, and dots. Returns ErrInvalidKey if the key name is invalid.
 		Put(ctx context.Context, key string, value []byte) (uint64, error)
 
 		// PutString will place the string for the key into the store. If the
@@ -112,19 +113,19 @@ type (
 		// will be updated.
 		//
 		// A key has to consist of alphanumeric characters, dashes, underscores,
-		// equal signs, and dots.
+		// equal signs, and dots. Returns ErrInvalidKey if the key name is invalid.
 		PutString(ctx context.Context, key string, value string) (uint64, error)
 
 		// Create will add the key/value pair if it does not exist. If the key
 		// already exists, ErrKeyExists will be returned.
 		//
 		// A key has to consist of alphanumeric characters, dashes, underscores,
-		// equal signs, and dots.
+		// equal signs, and dots. Returns ErrInvalidKey if the key name is invalid.
 		Create(ctx context.Context, key string, value []byte, opts ...KVCreateOpt) (uint64, error)
 
 		// Update will update the value if the latest revision matches.
 		// If the provided revision does not match the key's current revision,
-		// ErrKeyRevisionMismatch is returned.
+		// ErrKeyRevisionMismatch is returned. Returns ErrInvalidKey if the key name is invalid.
 		// Update also resets the TTL associated with the key (if any).
 		Update(ctx context.Context, key string, value []byte, revision uint64) (uint64, error)
 
@@ -135,7 +136,7 @@ type (
 		//
 		// [LastRevision] option can be specified to only perform delete if the
 		// latest revision matches the provided one; if it does not,
-		// ErrKeyRevisionMismatch is returned.
+		// ErrKeyRevisionMismatch is returned. Returns ErrInvalidKey if the key name is invalid.
 		Delete(ctx context.Context, key string, opts ...KVDeleteOpt) error
 
 		// Purge will place a delete marker and remove all previous revisions.
@@ -145,7 +146,7 @@ type (
 		//
 		// [LastRevision] option can be specified to only perform purge if the
 		// latest revision matches the provided one; if it does not,
-		// ErrKeyRevisionMismatch is returned.
+		// ErrKeyRevisionMismatch is returned. Returns ErrInvalidKey if the key name is invalid.
 		Purge(ctx context.Context, key string, opts ...KVDeleteOpt) error
 
 		// Watch for any updates to keys that match the keys argument which
@@ -191,7 +192,8 @@ type (
 		ListKeysFiltered(ctx context.Context, filters ...string) (KeyLister, error)
 
 		// History will return all historical values for the key (up to
-		// KeyValueMaxHistory).
+		// KeyValueMaxHistory). Returns ErrKeyNotFound if the key does not exist.
+		// Returns ErrInvalidKey if the key name is invalid.
 		History(ctx context.Context, key string, opts ...WatchOpt) ([]KeyValueEntry, error)
 
 		// Bucket returns the KV store name.

--- a/jetstream/stream.go
+++ b/jetstream/stream.go
@@ -45,19 +45,23 @@ type (
 		Purge(ctx context.Context, opts ...StreamPurgeOpt) error
 
 		// GetMsg retrieves a raw stream message stored in JetStream by sequence number.
+		// Returns ErrMsgNotFound if the message with the provided sequence number does not exist.
 		GetMsg(ctx context.Context, seq uint64, opts ...GetMsgOpt) (*RawStreamMsg, error)
 
 		// GetLastMsgForSubject retrieves the last raw stream message stored in
 		// JetStream on a given subject.
+		// Returns ErrMsgNotFound if a message with the provided subject does not exist.
 		GetLastMsgForSubject(ctx context.Context, subject string) (*RawStreamMsg, error)
 
 		// DeleteMsg deletes a message from a stream.
 		// On the server, the message is marked as erased, but not overwritten.
+		// Returns ErrMsgNotFound if the message does not exist.
 		DeleteMsg(ctx context.Context, seq uint64) error
 
 		// SecureDeleteMsg deletes a message from a stream. The deleted message
 		// is overwritten with random data. As a result, this operation is slower
 		// than DeleteMsg.
+		// Returns ErrMsgNotFound if the message does not exist.
 		SecureDeleteMsg(ctx context.Context, seq uint64) error
 	}
 


### PR DESCRIPTION
### Description
This PR updates the GoDoc comments for the JetStream interfaces (`KeyValue`, `Stream`, and `Consumer`) to explicitly document the typed errors that can be returned by their methods (such as `ErrKeyNotFound`, `ErrInvalidKey`, `ErrMsgNotFound`, etc.). 

This makes it easier for consumers of this package to rely on these errors to drive behavior after calling the interface methods without needing to dig into the source implementation. 

Resolves #1528

Signed-off-by: Abhishek Gawande <iabhi.gawande@gmail.com>