### PR TITLE
[ADDED] Per-publish callback option for async publishes

### DIFF
--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -87,6 +87,9 @@ type (
 		// received by the server. It only guarantees that the message has been
 		// sent to the server and thus messages can be stored in the stream
 		// out of order in case of retries.
+		//
+		// A per-publish callback can be set with [WithAsyncHandler] to be
+		// notified when the publish is acknowledged or fails.
 		PublishAsync(subject string, payload []byte, opts ...PublishOpt) (PubAckFuture, error)
 
 		// PublishMsgAsync performs a publish to a stream and returns
@@ -98,6 +101,9 @@ type (
 		// received by the server. It only guarantees that the message has been
 		// sent to the server and thus messages can be stored in the stream
 		// out of order in case of retries.
+		//
+		// A per-publish callback can be set with [WithAsyncHandler] to be
+		// notified when the publish is acknowledged or fails.
 		PublishMsgAsync(msg *nats.Msg, opts ...PublishOpt) (PubAckFuture, error)
 
 		// PublishAsyncPending returns the number of async publishes outstanding

--- a/jetstream/jetstream_options.go
+++ b/jetstream/jetstream_options.go
@@ -830,6 +830,21 @@ func WithScheduleTimeZone(zone string) PublishOpt {
 	}
 }
 
+// WithAsyncHandler sets a callback for an individual async publish. The
+// callback is invoked when the message is acknowledged by the server or when
+// the publish fails, with the original message sent to the server, the
+// resulting PubAck (nil on error) and the error encountered (nil on success).
+//
+// Unlike [WithPublishAsyncErrHandler] and [WithPublishAsyncAckHandler], which
+// apply to all async publishes performed on the JetStream context, this option
+// is per-publish.
+func WithAsyncHandler(cb MsgAsyncHandler) PublishOpt {
+	return func(opts *pubOpts) error {
+		opts.cb = cb
+		return nil
+	}
+}
+
 type nextOptFunc func(*nextOpts)
 
 func (fn nextOptFunc) configureNext(opts *nextOpts) {

--- a/jetstream/publish.go
+++ b/jetstream/publish.go
@@ -62,8 +62,11 @@ type (
 		retryWait     time.Duration // Retry wait between attempts
 		retryAttempts int           // Retry attempts
 
-		// stallWait is the max wait of a async pub ack.
+		// stallWait is the max wait of an async pub ack.
 		stallWait time.Duration
+
+		// cb is the handler of an async message.
+		cb MsgAsyncHandler
 
 		// internal option to re-use existing paf in case of retry.
 		pafRetry *pubAckFuture
@@ -94,12 +97,19 @@ type (
 		doneCh     chan *PubAck
 		reply      string
 		timeout    *time.Timer
+		cb         MsgAsyncHandler
 	}
 
 	jetStreamClient struct {
 		asyncPublishContext
 		asyncPublisherOpts
 	}
+
+	// MsgAsyncHandler is a per-publish callback that can be set with
+	// [WithAsyncHandler] to process the outcome of an asynchronous publish.
+	// It is invoked with the original message sent to the server, the
+	// resulting PubAck (nil on error) and the error encountered (nil on success).
+	MsgAsyncHandler func(*nats.Msg, *PubAck, error)
 
 	// MsgErrHandler is used to process asynchronous errors from JetStream
 	// PublishAsync. It will return the original message sent to the server for
@@ -359,7 +369,7 @@ func (js *jetStream) PublishMsgAsync(m *nats.Msg, opts ...PublishOpt) (PubAckFut
 			return nil, fmt.Errorf("nats: error creating async reply handler: %s", err)
 		}
 		id = reply[js.opts.replyPrefixLen:]
-		paf = &pubAckFuture{msg: m, jsClient: js.publisher, maxRetries: o.retryAttempts, retryWait: o.retryWait, reply: reply}
+		paf = &pubAckFuture{msg: m, jsClient: js.publisher, maxRetries: o.retryAttempts, retryWait: o.retryWait, reply: reply, cb: o.cb}
 		numPending, maxPending := js.registerPAF(id, paf)
 
 		if maxPending > 0 && numPending > maxPending {
@@ -396,7 +406,10 @@ func (js *jetStream) PublishMsgAsync(m *nats.Msg, opts ...PublishOpt) (PubAckFut
 					paf.errCh <- paf.err
 				}
 
-				// call error callback if set
+				// call error callbacks if set
+				if paf.cb != nil {
+					paf.cb(paf.msg, nil, ErrAsyncPublishTimeout)
+				}
 				if js.publisher.asyncPublisherOpts.aecb != nil {
 					js.publisher.asyncPublisherOpts.aecb(js, paf.msg, ErrAsyncPublishTimeout)
 				}
@@ -526,6 +539,9 @@ func (js *jetStream) handleAsyncReply(m *nats.Msg) {
 		}
 		cb := js.publisher.asyncPublisherOpts.aecb
 		js.publisher.Unlock()
+		if paf.cb != nil {
+			paf.cb(paf.msg, nil, err)
+		}
 		if cb != nil {
 			cb(js, paf.msg, err)
 		}
@@ -584,13 +600,16 @@ func (js *jetStream) handleAsyncReply(m *nats.Msg) {
 		return
 	}
 
-	// So here we have received a proper puback.
+	// So here we have received a proper pubAck.
 	paf.ack = pa.PubAck
 	if paf.doneCh != nil {
 		paf.doneCh <- paf.ack
 	}
 	cb := js.publisher.asyncPublisherOpts.ackcb
 	js.publisher.Unlock()
+	if paf.cb != nil {
+		paf.cb(paf.msg, paf.ack, nil)
+	}
 	if cb != nil {
 		cb(js, paf.msg, paf.ack)
 	}

--- a/jetstream/test/publish_test.go
+++ b/jetstream/test/publish_test.go
@@ -2076,6 +2076,149 @@ func TestPublishAsyncAckHandlerSkippedOnTimeout(t *testing.T) {
 	}
 }
 
+func TestPublishAsyncHandlerOnAck(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, s)
+
+	nc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer nc.Close()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	cfg := jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}}
+	if _, err := js.CreateStream(t.Context(), cfg); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	acks := make(chan *jetstream.PubAck, 1)
+	paf, err := js.PublishAsync("FOO.A", []byte("flightless, not fightless"), jetstream.WithAsyncHandler(func(m *nats.Msg, ack *jetstream.PubAck, err error) {
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if m.Subject != "FOO.A" {
+			t.Fatalf("Unexpected subject in handler: %s", m.Subject)
+		}
+		acks <- ack
+	}))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatalf("Did not receive ack from handler")
+	case ack := <-acks:
+		if ack.Stream != "foo" {
+			t.Fatalf("Expected stream 'foo'; got: %s", ack.Stream)
+		}
+	}
+
+	// PubAckFuture must still resolve independently of the handler
+	select {
+	case <-time.After(time.Second):
+		t.Fatalf("Did not receive ack from PubAckFuture")
+	case err := <-paf.Err():
+		t.Fatalf("Unexpected error: %v", err)
+	case <-paf.Ok():
+	}
+}
+
+func TestPublishAsyncHandlerOnError(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, s)
+
+	nc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer nc.Close()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// publishing to a subject not bound to any stream results in ErrNoStreamResponse
+	errs := make(chan error, 1)
+	paf, err := js.PublishAsync("BAR.A", []byte("flightless, not fightless"), jetstream.WithAsyncHandler(func(_ *nats.Msg, ack *jetstream.PubAck, err error) {
+		if ack != nil {
+			t.Fatalf("Did not expect ack in error handler; got: %v", ack)
+		}
+		errs <- err
+	}))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	select {
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Did not receive error from handler")
+	case err := <-errs:
+		if !errors.Is(err, jetstream.ErrNoStreamResponse) {
+			t.Fatalf("Expected error: %v; got: %v", jetstream.ErrNoStreamResponse, err)
+		}
+	}
+
+	// PubAckFuture must still resolve independently of the handler
+	select {
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Did not receive error from PubAckFuture")
+	case ack := <-paf.Ok():
+		t.Fatalf("Did not expect ack; got: %v", ack)
+	case err := <-paf.Err():
+		if !errors.Is(err, jetstream.ErrNoStreamResponse) {
+			t.Fatalf("Expected error: %v; got: %v", jetstream.ErrNoStreamResponse, err)
+		}
+	}
+}
+
+func TestPublishAsyncHandlerOnTimeout(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, s)
+
+	nc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer nc.Close()
+
+	js, err := jetstream.New(nc, jetstream.WithPublishAsyncTimeout(50*time.Millisecond))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// use a stream with no acks to force the async publish timeout
+	cfg := jetstream.StreamConfig{Name: "bar", Subjects: []string{"BAZ.*"}, NoAck: true}
+	if _, err := js.CreateStream(t.Context(), cfg); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	errs := make(chan error, 1)
+	if _, err := js.PublishAsync("BAZ.A", []byte("hello"), jetstream.WithAsyncHandler(func(_ *nats.Msg, ack *jetstream.PubAck, err error) {
+		if ack != nil {
+			t.Fatalf("Did not expect ack in error handler; got: %v", ack)
+		}
+		errs <- err
+	})); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatalf("Did not receive error from handler")
+	case err := <-errs:
+		if !errors.Is(err, jetstream.ErrAsyncPublishTimeout) {
+			t.Fatalf("Expected error: %v; got: %v", jetstream.ErrAsyncPublishTimeout, err)
+		}
+	}
+}
+
 func TestPublishAsyncClearStall(t *testing.T) {
 	s := RunBasicJetStreamServer()
 	defer shutdownJSServerAndRemoveStorage(t, s)


### PR DESCRIPTION
Add `WithAsyncHandler` option allowing to set a callback for an individual `PublishAsync`/`PublishMsgAsync` call. The callback is invoked when the message is acknowledged by the server or when the publish fails, receiving the original message, the `PubAck` (nil on error) and the error (nil on success).

### Use case

I want to asynchronously publish a lot of messages, wait for ack (or error) and do some postprocessing for each message depending on whether it was successfully published or not.

Currently, you can call `PublishAsync` and either create a separate goroutine for each future or call `PublishAsyncComplete`. Both of those have some downsides.