### PR TITLE
[FIXED] JetStream async publish can exceed WithPublishAsyncMaxPending

### DIFF
--- a/jetstream/publish.go
+++ b/jetstream/publish.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 The NATS Authors
+// Copyright 2022-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -360,15 +360,8 @@ func (js *jetStream) PublishMsgAsync(m *nats.Msg, opts ...PublishOpt) (PubAckFut
 		}
 		id = reply[js.opts.replyPrefixLen:]
 		paf = &pubAckFuture{msg: m, jsClient: js.publisher, maxRetries: o.retryAttempts, retryWait: o.retryWait, reply: reply}
-		numPending, maxPending := js.registerPAF(id, paf)
-
-		if maxPending > 0 && numPending > maxPending {
-			select {
-			case <-js.asyncStall():
-			case <-time.After(stallWait):
-				js.clearPAF(id)
-				return nil, ErrTooManyStalledMsgs
-			}
+		if err := js.registerPAF(id, paf, stallWait); err != nil {
+			return nil, err
 		}
 		if js.publisher.ackTimeout > 0 {
 			paf.timeout = time.AfterFunc(js.publisher.ackTimeout, func() {
@@ -625,17 +618,43 @@ func (js *jetStream) resetPendingAcksOnReconnect() {
 	}
 }
 
-// registerPAF will register for a PubAckFuture.
-func (js *jetStream) registerPAF(id string, paf *pubAckFuture) (int, int) {
-	js.publisher.Lock()
-	if js.publisher.acks == nil {
-		js.publisher.acks = make(map[string]*pubAckFuture)
+// registerPAF will register for a PubAckFuture. If max pending is set and
+// the publisher is already at the cap, it stalls until a slot frees or
+// stallWait elapses. The cap check and insert run under the same lock so
+// pending cannot exceed maxPending.
+func (js *jetStream) registerPAF(id string, paf *pubAckFuture, stallWait time.Duration) error {
+	var timer *time.Timer
+	defer func() {
+		if timer != nil {
+			timer.Stop()
+		}
+	}()
+	for {
+		js.publisher.Lock()
+		if js.publisher.acks == nil {
+			js.publisher.acks = make(map[string]*pubAckFuture)
+		}
+		maxpa := js.publisher.asyncPublisherOpts.maxpa
+		if maxpa > 0 && len(js.publisher.acks) >= maxpa {
+			if js.publisher.stallCh == nil {
+				js.publisher.stallCh = make(chan struct{})
+			}
+			stc := js.publisher.stallCh
+			js.publisher.Unlock()
+			if timer == nil {
+				timer = time.NewTimer(stallWait)
+			}
+			select {
+			case <-stc:
+				continue
+			case <-timer.C:
+				return ErrTooManyStalledMsgs
+			}
+		}
+		js.publisher.acks[id] = paf
+		js.publisher.Unlock()
+		return nil
 	}
-	js.publisher.acks[id] = paf
-	np := len(js.publisher.acks)
-	maxpa := js.publisher.asyncPublisherOpts.maxpa
-	js.publisher.Unlock()
-	return np, maxpa
 }
 
 // Lock should be held.
@@ -651,16 +670,6 @@ func (js *jetStream) clearPAF(id string) {
 	js.publisher.Lock()
 	delete(js.publisher.acks, id)
 	js.publisher.Unlock()
-}
-
-func (js *jetStream) asyncStall() <-chan struct{} {
-	js.publisher.Lock()
-	if js.publisher.stallCh == nil {
-		js.publisher.stallCh = make(chan struct{})
-	}
-	stc := js.publisher.stallCh
-	js.publisher.Unlock()
-	return stc
 }
 
 func (paf *pubAckFuture) Ok() <-chan *PubAck {

--- a/jetstream/publish_test.go
+++ b/jetstream/publish_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jetstream
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Concurrent registerPAF used to insert before stalling, so pending could
+// exceed WithPublishAsyncMaxPending (issue #1612). Cap check and insert now
+// share one lock; this white-box burst does not need a server.
+func TestPublishAsyncMaxPendingNotExceeded(t *testing.T) {
+	const maxPending = 1
+	js := &jetStream{
+		publisher: &jetStreamClient{
+			asyncPublisherOpts: asyncPublisherOpts{maxpa: maxPending},
+		},
+	}
+
+	const n = 32
+	var observed atomic.Int32
+	track := func() {
+		p := int32(js.PublishAsyncPending())
+		for {
+			cur := observed.Load()
+			if p <= cur || observed.CompareAndSwap(cur, p) {
+				return
+			}
+		}
+	}
+
+	stopPoll := make(chan struct{})
+	var pollWg sync.WaitGroup
+	pollWg.Add(1)
+	go func() {
+		defer pollWg.Done()
+		for {
+			select {
+			case <-stopPoll:
+				return
+			default:
+				track()
+			}
+		}
+	}()
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			paf := &pubAckFuture{jsClient: js.publisher}
+			_ = js.registerPAF(fmt.Sprintf("%d", i), paf, time.Second)
+			track()
+		}(i)
+	}
+
+	close(start)
+	// Concurrent callers insert before stalling on unmodified code;
+	// sample while they are still in-flight / stalled.
+	time.Sleep(50 * time.Millisecond)
+	track()
+
+	wg.Wait()
+	close(stopPoll)
+	pollWg.Wait()
+
+	if got := observed.Load(); int(got) > maxPending {
+		t.Fatalf("PublishAsyncPending exceeded max pending: got %d, want <= %d", got, maxPending)
+	}
+}


### PR DESCRIPTION
## Bug

`registerPAF` inserted the pending ack, unlocked, then stalled if `len(acks)` was over `WithPublishAsyncMaxPending`. Concurrent `PublishAsync` callers could all insert before any of them waited, so `PublishAsyncPending()` could exceed the configured cap (issue #1612).

## Fix

Check the cap and insert under the same lock. If already at `maxPending`, wait on the stall channel (or `stallWait`) *before* inserting. Pending cannot exceed the cap.

## Testing

White-box `TestPublishAsyncMaxPendingNotExceeded` in `./jetstream` (no nats-server/v2, no Docker). 32 goroutines hit `registerPAF` with `maxPending=1` and assert pending never goes above 1.

```
go test ./jetstream -count=1 -timeout 60s -run TestPublishAsyncMaxPendingNotExceeded
```

`go.mod` is unchanged (no `nats-server/v2`). Nearby `./jetstream` unit tests pass without Docker.

Resolves #1612

Signed-off-by: Shravanth Reddy <shrvnthrdy@gmail.com>