### PR TITLE
Return ErrDisconnected when a request is interrupted by reconnect

### DIFF
--- a/context.go
+++ b/context.go
@@ -67,7 +67,10 @@ func (nc *Conn) requestWithContext(ctx context.Context, subj string, hdr, data [
 		select {
 		case m, ok = <-mch:
 			if !ok {
-				return nil, ErrConnectionClosed
+				if nc.IsClosed() {
+					return nil, ErrConnectionClosed
+				}
+				return nil, ErrDisconnected
 			}
 		case <-ctx.Done():
 			nc.mu.Lock()

--- a/nats.go
+++ b/nats.go
@@ -4795,7 +4795,10 @@ func (nc *Conn) newRequest(subj string, hdr, data []byte, timeout time.Duration)
 	select {
 	case msg, ok = <-mch:
 		if !ok {
-			return nil, ErrConnectionClosed
+			if nc.IsClosed() {
+				return nil, ErrConnectionClosed
+			}
+			return nil, ErrDisconnected
 		}
 	case <-t.C:
 		nc.mu.Lock()

--- a/test/context_test.go
+++ b/test/context_test.go
@@ -15,6 +15,7 @@ package test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -266,6 +267,27 @@ func testContextRequestWithCancel(t *testing.T, nc *nats.Conn) {
 	if !strings.Contains(err.Error(), expected) {
 		t.Errorf("Expected %q error, got: %q", expected, err.Error())
 	}
+}
+
+func TestRequestWithContextForceReconnectNotClosed(t *testing.T) {
+	withServer(t, func(t *testing.T, nc *nats.Conn) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := nc.RequestWithContext(ctx, "nobody-home", nil)
+			errCh <- err
+		}()
+		time.Sleep(20 * time.Millisecond)
+		if err := nc.ForceReconnect(); err != nil {
+			t.Fatal(err)
+		}
+		err := <-errCh
+		if errors.Is(err, nats.ErrConnectionClosed) {
+			t.Fatalf("RequestWithContext returned ErrConnectionClosed during reconnect: %v", err)
+		}
+	})
 }
 
 func TestContextOldRequestClosed(t *testing.T) {


### PR DESCRIPTION
ForceReconnect / reconnect handling closes pending request channels. `RequestWithContext` (and `newRequest`) treated a closed channel as `ErrConnectionClosed` even when the client was only reconnecting.

That is what JetStream publish hits during CONNECTED → RECONNECTING → CONNECTED.

If the connection is not actually closed, return `ErrDisconnected` instead.

Fixes #2128

## Test
- Added `TestRequestWithContextReconnectNotClosed` in `test/context_test.go`.
- `go test` for the client package compiles; the new test needs a NATS server to run.
