### PR TITLE
[FIXED] Ordered consumer reset resurrecting a removed subscription

### DIFF
--- a/js.go
+++ b/js.go
@@ -2220,7 +2220,7 @@ func (sub *Subscription) applyNewSID() (osid, nsid int64, ok bool) {
 // Lock should be held.
 func (sub *Subscription) resetOrderedConsumer(sseq uint64) {
 	nc := sub.conn
-	if sub.jsi == nil || nc == nil || sub.closed {
+	if sub.jsi == nil || nc == nil || sub.closed || sub.draining {
 		return
 	}
 
@@ -2337,9 +2337,9 @@ func (sub *Subscription) resetOrderedConsumer(sseq uint64) {
 		}
 
 		sub.mu.Lock()
-		if sub.closed {
-			// Unsubscribed while the consumer was being created. The
-			// consumer is not attached to anything anymore, so delete it
+		if sub.closed || sub.draining {
+			// Unsubscribed or drained while the consumer was being created.
+			// The consumer is not attached to anything anymore, so delete it
 			// rather than waiting for the inactivity threshold.
 			sub.mu.Unlock()
 			go js.DeleteConsumer(jsi.stream, cinfo.Name)
@@ -2350,22 +2350,24 @@ func (sub *Subscription) resetOrderedConsumer(sseq uint64) {
 	}()
 }
 
-// rewireOrderedSub sends the protocol that moves an ordered consumer
-// subscription from its old sid to its new sid and deliver subject: UNSUB for
-// the old sid, SUB for the new one and, if the subscription has a max set,
-// the UNSUB carrying the adjusted max. Returns whether the subscription is
-// still registered on the connection. If it is not (it was unsubscribed, or
-// the connection was closed, after applyNewSID re-keyed it), only the UNSUB
-// for the old sid is sent and false is returned, so that no interest is
-// created on the server for a subscription that no longer exists. Since
-// unsubscribe also runs under nc.mu, the check here is exact.
+// rewireOrderedSub moves the subscription from osid to nsid on the server.
+// The old sid is always unsubscribed; the new one is only subscribed if the
+// subscription is still registered and not draining, so that no interest is
+// created for a subscription that will not accept messages anymore. Returns
+// whether that happened. unsubscribe runs under nc.mu too, so the check is
+// exact.
 func (nc *Conn) rewireOrderedSub(sub *Subscription, osid, nsid int64, deliver, maxStr string) bool {
 	nc.mu.Lock()
 	defer nc.mu.Unlock()
 
 	nc.bw.appendString(fmt.Sprintf(unsubProto, osid, _EMPTY_))
 	nc.subsMu.RLock()
-	registered := nc.subs[nsid] == sub
+	sub.mu.Lock()
+	// A draining subscription is only removed from nc.subs once the drain
+	// completes, and that removal sends no UNSUB, so subscribing the new sid
+	// here would leave interest on the server for the life of the connection.
+	registered := nc.subs[nsid] == sub && !sub.draining
+	sub.mu.Unlock()
 	nc.subsMu.RUnlock()
 	if registered {
 		nc.bw.appendString(fmt.Sprintf(subProto, deliver, _EMPTY_, nsid))

--- a/js.go
+++ b/js.go
@@ -2267,14 +2267,11 @@ func (sub *Subscription) resetOrderedConsumer(sseq uint64) {
 		// Unsubscribe and subscribe with new inbox and sid.
 		// Remap a new low level sub into this sub since its client accessible.
 		// This is done here in this go routine to prevent lock inversion.
-		nc.mu.Lock()
-		nc.bw.appendString(fmt.Sprintf(unsubProto, osid, _EMPTY_))
-		nc.bw.appendString(fmt.Sprintf(subProto, newDeliver, _EMPTY_, nsid))
-		if maxStr != _EMPTY_ {
-			nc.bw.appendString(fmt.Sprintf(unsubProto, nsid, maxStr))
+		if !nc.rewireOrderedSub(sub, osid, nsid, newDeliver, maxStr) {
+			// Unsubscribed (or connection closed) since applyNewSID:
+			// nothing to recreate.
+			return
 		}
-		nc.kickFlusher()
-		nc.mu.Unlock()
 
 		pushErr := func(err error) {
 			nc.handleConsumerSequenceMismatch(sub, fmt.Errorf("%w: recreating ordered consumer", err))
@@ -2340,9 +2337,44 @@ func (sub *Subscription) resetOrderedConsumer(sseq uint64) {
 		}
 
 		sub.mu.Lock()
+		if sub.closed {
+			// Unsubscribed while the consumer was being created. The
+			// consumer is not attached to anything anymore, so delete it
+			// rather than waiting for the inactivity threshold.
+			sub.mu.Unlock()
+			go js.DeleteConsumer(jsi.stream, cinfo.Name)
+			return
+		}
 		jsi.consumer = cinfo.Name
 		sub.mu.Unlock()
 	}()
+}
+
+// rewireOrderedSub sends the protocol that moves an ordered consumer
+// subscription from its old sid to its new sid and deliver subject: UNSUB for
+// the old sid, SUB for the new one and, if the subscription has a max set,
+// the UNSUB carrying the adjusted max. Returns whether the subscription is
+// still registered on the connection. If it is not (it was unsubscribed, or
+// the connection was closed, after applyNewSID re-keyed it), only the UNSUB
+// for the old sid is sent and false is returned, so that no interest is
+// created on the server for a subscription that no longer exists. Since
+// unsubscribe also runs under nc.mu, the check here is exact.
+func (nc *Conn) rewireOrderedSub(sub *Subscription, osid, nsid int64, deliver, maxStr string) bool {
+	nc.mu.Lock()
+	defer nc.mu.Unlock()
+
+	nc.bw.appendString(fmt.Sprintf(unsubProto, osid, _EMPTY_))
+	nc.subsMu.RLock()
+	registered := nc.subs[nsid] == sub
+	nc.subsMu.RUnlock()
+	if registered {
+		nc.bw.appendString(fmt.Sprintf(subProto, deliver, _EMPTY_, nsid))
+		if maxStr != _EMPTY_ {
+			nc.bw.appendString(fmt.Sprintf(unsubProto, nsid, maxStr))
+		}
+	}
+	nc.kickFlusher()
+	return registered
 }
 
 // For jetstream subscriptions, returns the number of delivered messages.

--- a/js.go
+++ b/js.go
@@ -2184,9 +2184,9 @@ func (sub *Subscription) checkOrderedMsgs(m *Msg) bool {
 	return false
 }
 
-// Update and replace sid. Returns the old and the new sid, and whether the
-// swap happened: it is refused (ok == false) when the subscription is no
-// longer registered on the connection.
+// Update and replace sid. Returns the old and the new sid. Returns ok == false,
+// leaving everything untouched, if the subscription is no longer registered on
+// the connection.
 // Lock should be held on entry but will be unlocked to prevent lock inversion.
 func (sub *Subscription) applyNewSID() (osid, nsid int64, ok bool) {
 	nc := sub.conn
@@ -2194,10 +2194,8 @@ func (sub *Subscription) applyNewSID() (osid, nsid int64, ok bool) {
 
 	nc.subsMu.Lock()
 	osid = sub.sid
-	// While sub.mu was released, the subscription may have been removed by
-	// removeSub (Unsubscribe/Drain) or the connection may have been closed
-	// (nc.subs is nil then). Registering it under a new sid would resurrect
-	// a closed subscription (or panic on the nil map), so refuse the swap.
+	// removeSub or close() may have run while sub.mu was released;
+	// re-registering would resurrect the sub or write to a nil nc.subs.
 	if nc.subs[osid] != sub {
 		nc.subsMu.Unlock()
 		sub.mu.Lock()
@@ -2252,8 +2250,6 @@ func (sub *Subscription) resetOrderedConsumer(sseq uint64) {
 	// Quick unsubscribe. Since we know this is a simple push subscriber we do in place.
 	osid, nsid, ok := sub.applyNewSID()
 	if !ok {
-		// The subscription was unsubscribed or the connection was closed
-		// while sub.mu was released: there is nothing left to reset.
 		return
 	}
 
@@ -2268,8 +2264,6 @@ func (sub *Subscription) resetOrderedConsumer(sseq uint64) {
 		// Remap a new low level sub into this sub since its client accessible.
 		// This is done here in this go routine to prevent lock inversion.
 		if !nc.rewireOrderedSub(sub, osid, nsid, newDeliver, maxStr) {
-			// Unsubscribed (or connection closed) since applyNewSID:
-			// nothing to recreate.
 			return
 		}
 

--- a/js.go
+++ b/js.go
@@ -2184,14 +2184,25 @@ func (sub *Subscription) checkOrderedMsgs(m *Msg) bool {
 	return false
 }
 
-// Update and replace sid. Returns the old and the new sid.
+// Update and replace sid. Returns the old and the new sid, and whether the
+// swap happened: it is refused (ok == false) when the subscription is no
+// longer registered on the connection.
 // Lock should be held on entry but will be unlocked to prevent lock inversion.
-func (sub *Subscription) applyNewSID() (osid, nsid int64) {
+func (sub *Subscription) applyNewSID() (osid, nsid int64, ok bool) {
 	nc := sub.conn
 	sub.mu.Unlock()
 
 	nc.subsMu.Lock()
 	osid = sub.sid
+	// While sub.mu was released, the subscription may have been removed by
+	// removeSub (Unsubscribe/Drain) or the connection may have been closed
+	// (nc.subs is nil then). Registering it under a new sid would resurrect
+	// a closed subscription (or panic on the nil map), so refuse the swap.
+	if nc.subs[osid] != sub {
+		nc.subsMu.Unlock()
+		sub.mu.Lock()
+		return osid, 0, false
+	}
 	delete(nc.subs, osid)
 	// Place new one.
 	nc.ssid++
@@ -2201,7 +2212,7 @@ func (sub *Subscription) applyNewSID() (osid, nsid int64) {
 	nc.subsMu.Unlock()
 
 	sub.mu.Lock()
-	return osid, nsid
+	return osid, nsid, true
 }
 
 // We are here if we have detected a gap with an ordered consumer.
@@ -2239,7 +2250,12 @@ func (sub *Subscription) resetOrderedConsumer(sseq uint64) {
 	}
 
 	// Quick unsubscribe. Since we know this is a simple push subscriber we do in place.
-	osid, nsid := sub.applyNewSID()
+	osid, nsid, ok := sub.applyNewSID()
+	if !ok {
+		// The subscription was unsubscribed or the connection was closed
+		// while sub.mu was released: there is nothing left to reset.
+		return
+	}
 
 	// Grab new inbox.
 	newDeliver := nc.NewInbox()

--- a/js_test.go
+++ b/js_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2023 The NATS Authors
+// Copyright 2012-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -130,4 +130,62 @@ func TestJetStreamConvertDirectMsgResponseToMsg(t *testing.T) {
 	if r.Header.Get("some") != "header" {
 		t.Fatalf("Wrong header: %v", r.Header)
 	}
+}
+
+func TestApplyNewSIDUnregisteredSub(t *testing.T) {
+	newConn := func() (*Conn, *Subscription) {
+		nc := &Conn{subs: make(map[int64]*Subscription)}
+		sub := &Subscription{conn: nc}
+		nc.ssid++
+		sub.sid = nc.ssid
+		nc.subs[sub.sid] = sub
+		return nc, sub
+	}
+
+	t.Run("registered sub is re-keyed", func(t *testing.T) {
+		nc, sub := newConn()
+		sub.mu.Lock()
+		osid, nsid, ok := sub.applyNewSID()
+		sub.mu.Unlock()
+		if !ok {
+			t.Fatal("expected the sid swap to succeed for a registered sub")
+		}
+		if osid != 1 || nsid != 2 {
+			t.Fatalf("expected sids 1 -> 2, got %d -> %d", osid, nsid)
+		}
+		if sub.sid != nsid || nc.subs[nsid] != sub || len(nc.subs) != 1 {
+			t.Fatalf("sub not registered under the new sid only: sid=%d subs=%v", sub.sid, nc.subs)
+		}
+	})
+
+	t.Run("removed sub is not re-registered", func(t *testing.T) {
+		// Simulates removeSub winning the race: the sub was unsubscribed
+		// while applyNewSID had released sub.mu.
+		nc, sub := newConn()
+		delete(nc.subs, sub.sid)
+		sub.mu.Lock()
+		_, _, ok := sub.applyNewSID()
+		sub.mu.Unlock()
+		if ok {
+			t.Fatal("expected the sid swap to be refused for an unregistered sub")
+		}
+		if len(nc.subs) != 0 {
+			t.Fatalf("unsubscribed sub was resurrected in the subs map: %v", nc.subs)
+		}
+		if sub.sid != 1 {
+			t.Fatalf("sid of an unregistered sub should be untouched, got %d", sub.sid)
+		}
+	})
+
+	t.Run("closed connection does not panic", func(t *testing.T) {
+		// close() sets nc.subs to nil, and writing to a nil map panics.
+		nc, sub := newConn()
+		nc.subs = nil
+		sub.mu.Lock()
+		_, _, ok := sub.applyNewSID()
+		sub.mu.Unlock()
+		if ok {
+			t.Fatal("expected the sid swap to be refused on a closed connection")
+		}
+	})
 }

--- a/js_test.go
+++ b/js_test.go
@@ -19,6 +19,7 @@ package nats
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -186,6 +187,57 @@ func TestApplyNewSIDUnregisteredSub(t *testing.T) {
 		sub.mu.Unlock()
 		if ok {
 			t.Fatal("expected the sid swap to be refused on a closed connection")
+		}
+	})
+}
+
+func TestRewireOrderedSub(t *testing.T) {
+	const osid, nsid, deliver, maxStr = 1, 2, "_INBOX.new", "5"
+	newConn := func() (*Conn, *Subscription) {
+		// A writer with a large limit never flushes, so the protocol lines
+		// stay in bufs for inspection.
+		nc := &Conn{subs: make(map[int64]*Subscription), bw: &natsWriter{limit: 1 << 20}}
+		sub := &Subscription{conn: nc, sid: nsid}
+		nc.ssid = nsid
+		nc.subs[nsid] = sub
+		return nc, sub
+	}
+	unsubOld := fmt.Sprintf(unsubProto, osid, _EMPTY_)
+	subNew := fmt.Sprintf(subProto, deliver, _EMPTY_, nsid)
+	unsubMax := fmt.Sprintf(unsubProto, nsid, maxStr)
+
+	t.Run("registered sub is moved to the new sid", func(t *testing.T) {
+		nc, sub := newConn()
+		if !nc.rewireOrderedSub(sub, osid, nsid, deliver, maxStr) {
+			t.Fatal("expected the rewire to proceed for a registered sub")
+		}
+		if got, want := string(nc.bw.bufs), unsubOld+subNew+unsubMax; got != want {
+			t.Fatalf("unexpected protocol:\n got %q\nwant %q", got, want)
+		}
+	})
+
+	t.Run("removed sub only gets the old sid unsubscribed", func(t *testing.T) {
+		// Simulates Unsubscribe landing between applyNewSID and the
+		// goroutine that sends the protocol: it removed the sub under the
+		// new sid, so no interest (nor consumer) must be created for it.
+		nc, sub := newConn()
+		delete(nc.subs, nsid)
+		if nc.rewireOrderedSub(sub, osid, nsid, deliver, maxStr) {
+			t.Fatal("expected the rewire to be refused for an unregistered sub")
+		}
+		if got, want := string(nc.bw.bufs), unsubOld; got != want {
+			t.Fatalf("unexpected protocol:\n got %q\nwant %q", got, want)
+		}
+	})
+
+	t.Run("closed connection only gets the old sid unsubscribed", func(t *testing.T) {
+		nc, sub := newConn()
+		nc.subs = nil
+		if nc.rewireOrderedSub(sub, osid, nsid, deliver, maxStr) {
+			t.Fatal("expected the rewire to be refused on a closed connection")
+		}
+		if got, want := string(nc.bw.bufs), unsubOld; got != want {
+			t.Fatalf("unexpected protocol:\n got %q\nwant %q", got, want)
 		}
 	})
 }

--- a/js_test.go
+++ b/js_test.go
@@ -230,6 +230,20 @@ func TestRewireOrderedSub(t *testing.T) {
 		}
 	})
 
+	t.Run("draining sub only gets the old sid unsubscribed", func(t *testing.T) {
+		// A draining sub stays in nc.subs until the drain completes, and it
+		// is then removed without an UNSUB, so subscribing the new sid would
+		// leave interest on the server for the life of the connection.
+		nc, sub := newConn()
+		sub.draining = true
+		if nc.rewireOrderedSub(sub, osid, nsid, deliver, maxStr) {
+			t.Fatal("expected the rewire to be refused for a draining sub")
+		}
+		if got, want := string(nc.bw.bufs), unsubOld; got != want {
+			t.Fatalf("unexpected protocol:\n got %q\nwant %q", got, want)
+		}
+	})
+
 	t.Run("closed connection only gets the old sid unsubscribed", func(t *testing.T) {
 		nc, sub := newConn()
 		nc.subs = nil

--- a/test/js_internal_test.go
+++ b/test/js_internal_test.go
@@ -483,6 +483,12 @@ func TestJetStreamOrderedConsumerSIDRace(t *testing.T) {
 		})
 		defer nc.RemoveMsgFilter("a")
 
+		// Everything created below is torn down again, so the number of
+		// low level subscriptions must come back to this after every round:
+		// a reset racing with Unsubscribe used to re-register the removed
+		// subscription under a new sid.
+		baseSubs := nc.NumSubscriptions()
+
 		const rounds, subsPerRound = 15, 12
 		for range rounds {
 			subs := make([]*nats.Subscription, 0, subsPerRound)
@@ -506,6 +512,9 @@ func TestJetStreamOrderedConsumerSIDRace(t *testing.T) {
 				}()
 			}
 			wg.Wait()
+			if n := nc.NumSubscriptions(); n != baseSubs {
+				t.Fatalf("Expected %d subscriptions after unsubscribing, got %d", baseSubs, n)
+			}
 		}
 		// Not proof that a reset happened, but without injected gaps the
 		// test would not be exercising the reset path at all.


### PR DESCRIPTION
Follow-up to the review discussion on #2122 (now merged; this is rebased on `main`).

## Problem

`applyNewSID` releases `sub.mu` before taking `subsMu`, and the protocol for the new sid is sent from a goroutine later still. An `Unsubscribe`/`Drain` (`removeSub`) or a connection close can land in either window.

**Window 1, inside `applyNewSID`.** The removed subscription was unconditionally re-registered under the new sid:

- a closed subscription stayed in `nc.subs` for the life of the connection,
- a `SUB` for it was sent to the server and a new ordered consumer was created for a subscription that will never deliver anything,
- when `close()` had already set `nc.subs` to `nil`, the write panicked with `assignment to entry in nil map` (reachable from the readLoop or the heartbeat `activityCheck` timer).

Re-checking `sub.closed` after `applyNewSID` returns is too late: the map write already happened. The guard has to sit inside `applyNewSID` under `subsMu`.

**Window 2, between `applyNewSID` and the reset goroutine taking `nc.mu`.** `Unsubscribe` removed the subscription under the new sid and sent an `UNSUB` for a sid the server had never seen, while the goroutine still sent `SUB` for the new sid and created a new consumer: interest for a dead subscription stayed on the server until the connection closed, and the consumer was left for the inactivity threshold.

**Window 3, a reset racing with `Drain`.** A draining subscription is a live entry in `nc.subs`: `unsubscribe` skips `removeSub` in drain mode, and `checkDrained` removes the entry later *without* sending an `UNSUB`. A registration check alone therefore passes for it, so a reset racing with `Drain` sent a `SUB` for the new sid *after* the drain's `UNSUB` had already gone out. That interest was never removed and stayed on the server for the life of the connection, and the server kept pushing messages into a subscription that was supposed to have stopped receiving them.

## Fix

- `applyNewSID` returns `ok == false` and leaves everything untouched when `nc.subs[osid] != sub`; `resetOrderedConsumer` bails out.
- The protocol part of the reset moves to `rewireOrderedSub`, which under `nc.mu` checks that the subscription is still registered under the new sid **and not draining**, and otherwise only sends the `UNSUB` for the old sid. `unsubscribe` runs under `nc.mu` too, so the check is exact.
- If the subscription got closed or drained while the consumer create request was in flight, the goroutine deletes the consumer it just created instead of leaving it for the inactivity threshold.
- `resetOrderedConsumer` also bails out at entry for a subscription that is already draining, so it is not re-keyed at all.

## Tests

- `TestApplyNewSIDUnregisteredSub` (white-box, no server): failed before the fix with the resurrected map entry and the nil-map panic.
- `TestRewireOrderedSub` (white-box, no server): asserts the exact protocol sent for a registered, a removed, a draining, and a closed-connection subscription.
- `TestJetStreamOrderedConsumerSIDRace` additionally asserts `nc.NumSubscriptions()` returns to its baseline after every round.
- Not covered by a test: the post-create `sub.closed || sub.draining` guard (needs a server-side race in the middle of a consumer create request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZSznPKF6L5UrYgryNRFsd
