### PR TITLE
[FIXED] Migrate golangci-lint config to v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
                 go mod download -modfile=go_test.mod
                 go install honnef.co/go/tools/cmd/staticcheck@latest
                 go install github.com/client9/misspell/cmd/misspell@latest
-                go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+                go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 
             - name: Run linters
               shell: bash --noprofile --norc -x -eo pipefail {0}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,16 +1,43 @@
+version: "2"
+linters:
+  settings:
+    staticcheck:
+      # The merged staticcheck linter pulls in more check families than this
+      # repo has ever run; keep it to the set that was in force before.
+      checks:
+        - SA*
+        - S1*
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+        text: Unsubscribe
+      - linters:
+          - errcheck
+        text: Drain
+      - linters:
+          - errcheck
+        text: msg.Ack
+      - linters:
+          - errcheck
+        text: watcher.Stop
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude-rules:
-    - linters:
-      - errcheck
-      text: "Unsubscribe"
-    - linters:
-      - errcheck
-      text: "Drain"
-    - linters:
-      - errcheck
-      text: "msg.Ack"
-    - linters:
-      - errcheck
-      text: "watcher.Stop"
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
The v1 binary cannot decode export data from current Go toolchains, so typechecking collapses and the lint job fails on every branch.

Config migrated with `golangci-lint migrate`. The merged staticcheck linter enables check families this repo never ran, so `checks` is pinned to the previous set — no new findings, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)