### PR TITLE
[FIXED] Messages(): handle a reconnect that completes between Next calls

### DIFF
--- a/jetstream/pull.go
+++ b/jetstream/pull.go
@@ -560,17 +560,37 @@ func (p *pullConsumer) Messages(opts ...PullMessagesOpt) (MessagesContext, error
 	go sub.pullMessages(subject)
 
 	go func() {
+		// Connection state is tracked here, for the lifetime of the
+		// iterator, rather than inside Next: a reconnect that completes
+		// between two Next calls (for example when Next is driven with a
+		// short NextMaxWait) must still reset the pull request accounting,
+		// otherwise no new pull request is ever sent and the iterator goes
+		// silent on a healthy connection.
+		isConnected := true
 		for {
 			select {
 			case status, ok := <-sub.connStatusChanged:
 				if !ok {
 					return
 				}
-				if status == nats.CONNECTED {
-					sub.errs <- errConnected
-				}
-				if status == nats.RECONNECTING {
-					sub.errs <- errDisconnected
+				switch status {
+				case nats.RECONNECTING:
+					isConnected = false
+					select {
+					case sub.errs <- errDisconnected:
+					case <-sub.done:
+						return
+					}
+				case nats.CONNECTED:
+					if isConnected {
+						continue
+					}
+					isConnected = true
+					select {
+					case sub.errs <- errConnected:
+					case <-sub.done:
+						return
+					}
 				}
 			case <-sub.done:
 				return
@@ -633,7 +653,6 @@ func (s *pullSubscription) Next(opts ...NextOpt) (Msg, error) {
 		}
 	}()
 
-	isConnected := true
 	if s.consumeOpts.StopAfter > 0 && s.delivered >= s.consumeOpts.StopAfter {
 		s.Stop()
 		return nil, ErrMsgIteratorClosed
@@ -686,24 +705,23 @@ func (s *pullSubscription) Next(opts ...NextOpt) (Msg, error) {
 				}
 			}
 			if errors.Is(err, errConnected) {
-				if !isConnected {
-					isConnected = true
-
-					if s.consumeOpts.notifyOnReconnect {
-						return nil, errConnected
-					}
-					s.pending.msgCount = 0
-					s.pending.byteCount = 0
-					if hbMonitor != nil {
-						hbMonitor.Reset(2 * s.consumeOpts.Heartbeat)
-					}
+				// errConnected is only sent for a CONNECTED that follows a
+				// RECONNECTING, so this is always a real reconnect: the pull
+				// request parked on the previous server is gone and a new one
+				// has to be issued.
+				if s.consumeOpts.notifyOnReconnect {
+					return nil, errConnected
+				}
+				s.pending.msgCount = 0
+				s.pending.byteCount = 0
+				if hbMonitor != nil {
+					hbMonitor.Reset(2 * s.consumeOpts.Heartbeat)
 				}
 			}
 			if errors.Is(err, errDisconnected) {
 				if hbMonitor != nil {
 					hbMonitor.Stop()
 				}
-				isConnected = false
 			}
 		case <-timeoutCh:
 			return nil, nats.ErrTimeout

--- a/jetstream/test/pull_test.go
+++ b/jetstream/test/pull_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1503,6 +1504,72 @@ func TestPullConsumerMessages(t *testing.T) {
 				}
 			case err := <-errs:
 				t.Fatalf("Unexpected error: %s", err)
+			}
+		})
+	})
+
+	t.Run("with server restart and short Next timeout", func(t *testing.T) {
+		// Reconnect handling used to be tracked per Next call, so a reconnect
+		// that completed between two short Next calls was never acted on: the
+		// pull request parked on the old server was still counted as pending,
+		// no new pull request was sent and the iterator went silent on a
+		// healthy connection.
+		withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, js jetstream.JetStream, inst *testservice.Instance) {
+			ctx := newTesterCtx(t, 5*time.Second)
+			s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			c, err := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{Durable: "cons", AckPolicy: jetstream.AckExplicitPolicy})
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			it, err := c.Messages()
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			defer it.Stop()
+
+			var received atomic.Int32
+			done := make(chan struct{})
+			errs := make(chan error, 1)
+			go func() {
+				for received.Load() < int32(2*len(testMsgs)) {
+					msg, err := it.Next(jetstream.NextMaxWait(100 * time.Millisecond))
+					if errors.Is(err, nats.ErrTimeout) {
+						continue
+					}
+					if err != nil {
+						errs <- err
+						return
+					}
+					msg.Ack()
+					received.Add(1)
+				}
+				close(done)
+			}()
+
+			publishTestMsgs(t, js)
+			checkFor(t, 5*time.Second, 50*time.Millisecond, func() error {
+				if n := received.Load(); n != int32(len(testMsgs)) {
+					return fmt.Errorf("expected %d messages before restart; got %d", len(testMsgs), n)
+				}
+				return nil
+			})
+
+			// restart the server; the reconnect completes while no Next call
+			// is in flight for long enough to observe it
+			inst.StopServer(t, inst.Servers[0])
+			inst.StartServer(t, inst.Servers[0])
+			waitForStream(t, js, "foo")
+			publishTestMsgs(t, js)
+
+			select {
+			case <-done:
+			case err := <-errs:
+				t.Fatalf("Unexpected error: %s", err)
+			case <-time.After(10 * time.Second):
+				t.Fatalf("Timeout waiting for messages after restart; got %d of %d", received.Load(), 2*len(testMsgs))
 			}
 		})
 	})


### PR DESCRIPTION
## Problem

A durable pull consumer driven by `Messages()` goes silent after a NATS server restart when `Next()` is called with a short `NextMaxWait`. The connection reconnects and stays healthy, `Next()` keeps returning `nats.ErrTimeout`, and the server reports `num_waiting: 0` with `num_pending` growing. Nothing is logged, no error is returned, and only recreating the iterator recovers it. We hit this in production on a 3-node cluster rolling restart with nats.go v1.53.1 and `Next(NextMaxWait(5 * time.Second))`.

## Cause

Reconnect handling for `Messages()` was scoped to a single `Next()` call. The status goroutine started by `Messages()` forwards `RECONNECTING` and `CONNECTED` into `sub.errs`, but `isConnected` was a local of `Next`, so only a `Next` that had observed the `RECONNECTING` event reset the pending counters when the matching `CONNECTED` arrived. If the disconnect was observed by call N and the reconnect landed after call N returned, call N+1 started with `isConnected = true` and discarded `errConnected`. `pending.msgCount` stayed at `MaxMessages`, `checkPending` never sent a new `CONSUMER.MSG.NEXT`, and the iterator waited forever on a request the server no longer held.

`Consume()` is not affected: its status goroutine owns the connection state for the lifetime of the subscription.

## Fix

Track `isConnected` in the status goroutine that lives as long as the iterator and only forward a `CONNECTED` that follows a `RECONNECTING`. `Next` now treats every `errConnected` as a real reconnect and resets the pending counters (or returns it, for `notifyOnReconnect` used by the ordered consumer, whose behaviour is unchanged). The forwards also select on `done`, so the goroutine can no longer block forever on a full `errs` channel after `Stop`.

## Test

`TestPullConsumerMessages/with_server_restart_and_short_Next_timeout` restarts the server while `Next` is polled with a 100ms `NextMaxWait`. On `main` it fails with `Timeout waiting for messages after restart; got 5 of 10`; with this change it passes. `TestPullConsumerMessages`, `TestPullConsumerConsume`, `TestPullConsumerNext` and `TestOrderedConsumer*` pass with `-race` against the tester.

Note: the missed-heartbeat monitor is still armed per `Next` call, so a `NextMaxWait` shorter than `2 * Heartbeat` never lets it fire. That is a separate, smaller gap; happy to follow up on it if you want a subscription-level monitor for `Messages()` too.
