### PR TITLE
[FIXED] Ordered consumer silently losing messages on slow consumer

### DIFF
--- a/js.go
+++ b/js.go
@@ -2230,7 +2230,10 @@ func (sub *Subscription) checkOrderedDelivery(m *Msg) (jsMsgAction, orderedSeqs)
 	jsi := sub.jsi
 	// An unbuffered channel has no capacity signal. With nothing delivered
 	// since the last reset, resetting again would just refetch into the same
-	// wall, so leave it to the heartbeat.
+	// wall, so leave it to the heartbeat. Once something has been delivered
+	// the reader is there and a drop means it was merely busy, so reset at
+	// once; deferring to the heartbeat here would drain a backlog one message
+	// per interval.
 	if sub.mch != nil && cap(sub.mch) == 0 && jsi.dseq == 1 {
 		return jsMsgDrop, orderedSeqs{}
 	}

--- a/js.go
+++ b/js.go
@@ -1437,6 +1437,8 @@ type jsSub struct {
 	dseq    uint64
 	sseq    uint64
 	ccreq   *createConsumerRequest
+	// A reset waits for the buffer to drain, see tryResetOrderedConsumer.
+	resetPending bool
 
 	// Heartbeats and Flow Control handling from push consumers.
 	hbc    *time.Timer
@@ -2215,10 +2217,19 @@ const (
 // sequence and reports what processMsg should do with it.
 //
 // The caller has verified that sub.jsi != nil and that the consumer is ordered.
-// Lock is held on entry and on return, but the gap path releases and reacquires
-// it to recreate the consumer.
+// Lock is held on entry and on return, but a reset releases and reacquires it
+// to recreate the consumer.
 func (sub *Subscription) checkOrderedDelivery(m *Msg) (jsMsgAction, orderedSeqs) {
-	if sub.chanFull() {
+	jsi := sub.jsi
+	// Everything still arriving belongs to the consumer about to be replaced
+	// and is refetched by the reset, which may have room by now.
+	if jsi.resetPending {
+		sub.tryResetOrderedConsumer()
+		return jsMsgDrop, orderedSeqs{}
+	}
+	// A full channel would drop the message below anyway; checking first keeps
+	// the drop from reading as a gap.
+	if sub.mch != nil && cap(sub.mch) > 0 && len(sub.mch) == cap(sub.mch) {
 		return jsMsgDrop, orderedSeqs{}
 	}
 
@@ -2227,7 +2238,6 @@ func (sub *Subscription) checkOrderedDelivery(m *Msg) (jsMsgAction, orderedSeqs)
 		return jsMsgDeliver, seqs
 	}
 
-	jsi := sub.jsi
 	// An unbuffered channel has no capacity signal. With nothing delivered
 	// since the last reset, resetting again would just refetch into the same
 	// wall, so leave it to the heartbeat. Once something has been delivered
@@ -2238,26 +2248,24 @@ func (sub *Subscription) checkOrderedDelivery(m *Msg) (jsMsgAction, orderedSeqs)
 		return jsMsgDrop, orderedSeqs{}
 	}
 	sub.releaseReserved(m)
-	sub.resetOrderedConsumer(jsi.sseq + 1)
+	sub.tryResetOrderedConsumer()
 	return jsMsgDropGap, orderedSeqs{}
 }
 
-// chanFull reports whether a buffered delivery channel cannot take another
-// message. Lock should be held.
-func (sub *Subscription) chanFull() bool {
-	return sub.mch != nil && cap(sub.mch) > 0 && len(sub.mch) == cap(sub.mch)
-}
-
-// pendingFull reports whether the subscription cannot take another message, so
-// that a reset now would only refetch into it. An unbuffered channel has no
-// capacity signal and never reports full. Lock should be held.
-func (sub *Subscription) pendingFull() bool {
-	if sub.typ != ChanSubscription &&
-		((sub.pMsgsLimit > 0 && sub.pMsgs >= sub.pMsgsLimit) ||
-			(sub.pBytesLimit > 0 && sub.pBytes >= sub.pBytesLimit)) {
-		return true
+// tryResetOrderedConsumer recreates the consumer after a gap, or defers that
+// while more than half of the subscription's buffer is in use, so the refetch
+// is not dropped into a buffer that is still nearly full. A deferred reset is
+// retried as messages are delivered and as messages and heartbeats arrive.
+// Lock should be held.
+func (sub *Subscription) tryResetOrderedConsumer() {
+	jsi := sub.jsi
+	if (sub.pMsgsLimit > 0 && sub.pMsgs > sub.pMsgsLimit/2) ||
+		(sub.pBytesLimit > 0 && sub.pBytes > sub.pBytesLimit/2) ||
+		(sub.mch != nil && len(sub.mch) > cap(sub.mch)/2) {
+		jsi.resetPending = true
+		return
 	}
-	return sub.chanFull()
+	sub.resetOrderedConsumer(jsi.sseq + 1)
 }
 
 // Update and replace sid. Returns the old and the new sid. Returns ok == false,
@@ -2297,6 +2305,7 @@ func (sub *Subscription) resetOrderedConsumer(sseq uint64) {
 	if sub.jsi == nil || nc == nil || sub.closed || sub.draining {
 		return
 	}
+	sub.jsi.resetPending = false
 
 	var maxStr string
 	// If there was an AUTO_UNSUB done, we need to adjust the new value
@@ -2507,7 +2516,7 @@ func (sub *Subscription) activityCheck() {
 			return
 		}
 		sub.mu.Lock()
-		sub.resetOrderedConsumer(jsi.sseq + 1)
+		sub.tryResetOrderedConsumer()
 		sub.mu.Unlock()
 	}
 }
@@ -2560,12 +2569,10 @@ func (nc *Conn) checkForSequenceMismatch(msg *Msg, s *Subscription, jsi *jsSub) 
 		}
 		// jsi.dseq is the next sequence expected and advances only for messages
 		// handed off for delivery, so caught up means ldseq == jsi.dseq-1 and
-		// ldseq >= jsi.dseq means there is a gap. While the subscription is full
-		// a reset would only refetch into it; the first heartbeat after it
-		// drains picks the gap up.
+		// ldseq >= jsi.dseq means there is a gap.
 		s.mu.Lock()
-		if parser.ParseNum(ldseq) >= jsi.dseq && !s.pendingFull() {
-			s.resetOrderedConsumer(jsi.sseq + 1)
+		if parser.ParseNum(ldseq) >= jsi.dseq {
+			s.tryResetOrderedConsumer()
 		}
 		s.mu.Unlock()
 		return

--- a/js.go
+++ b/js.go
@@ -2157,31 +2157,97 @@ func (sub *Subscription) trackSequences(reply string) {
 	sub.jsi.cmeta = reply
 }
 
+// orderedSeqs carries the sequences of a message that passed the ordering check
+// but has not yet been handed off for delivery.
+type orderedSeqs struct {
+	dseq, sseq uint64
+}
+
 // Check to make sure messages are arriving in order.
-// Returns true if the sub had to be replaced. Will cause upper layers to return.
-// The caller has verified that sub.jsi != nil and that this is not a control message.
+// Returns true when m is not the message the ordered consumer was expecting
+// next.
 // Lock should be held.
-func (sub *Subscription) checkOrderedMsgs(m *Msg) bool {
+//
+// This only reports: the caller discards m on a gap and decides whether to
+// reset. The tracker is not advanced here either, so the caller must apply the
+// returned sequences with commitOrderedMsg once m is queued for delivery.
+func (sub *Subscription) checkOrderedMsgs(m *Msg) (bool, orderedSeqs) {
 	// Ignore msgs with no reply like HBs and flow control, they are handled elsewhere.
 	if m.Reply == _EMPTY_ {
-		return false
+		return false, orderedSeqs{}
 	}
 
 	// Normal message here.
 	tokens, err := parser.GetMetadataFields(m.Reply)
 	if err != nil {
-		return false
+		return false, orderedSeqs{}
 	}
 	sseq, dseq := parser.ParseNum(tokens[parser.AckStreamSeqTokenPos]), parser.ParseNum(tokens[parser.AckConsumerSeqTokenPos])
 
 	jsi := sub.jsi
 	if dseq != jsi.dseq {
-		sub.resetOrderedConsumer(jsi.sseq + 1)
-		return true
+		return true, orderedSeqs{}
 	}
-	// Update our tracking here.
-	jsi.dseq, jsi.sseq = dseq+1, sseq
-	return false
+	return false, orderedSeqs{dseq: dseq, sseq: sseq}
+}
+
+// commitOrderedMsg advances the ordered consumer tracker for a message that has
+// been queued for delivery. Pairs with checkOrderedMsgs.
+// Lock should be held.
+func (sub *Subscription) commitOrderedMsg(seqs orderedSeqs) {
+	if seqs.dseq == 0 {
+		return
+	}
+	sub.jsi.dseq, sub.jsi.sseq = seqs.dseq+1, seqs.sseq
+}
+
+// jsMsgAction tells processMsg what to do with a message once the ordered
+// consumer checks have run against it.
+type jsMsgAction int
+
+const (
+	// Deliver, then advance the tracker with commitOrderedMsg.
+	jsMsgDeliver jsMsgAction = iota
+	// The delivery channel is full. The caller's slow consumer path releases
+	// the pending accounting reserved for the message.
+	jsMsgDropAtCapacity
+	// Out of order and fully handled: reservation released, consumer reset.
+	// The caller only unlocks and returns.
+	jsMsgDropGap
+)
+
+// checkOrderedDelivery validates an ordered consumer message's place in the
+// sequence and reports what processMsg should do with it.
+//
+// The caller has verified that sub.jsi != nil and that the consumer is ordered.
+// Lock is held on entry and on return, but the gap path releases and reacquires
+// it to recreate the consumer.
+func (sub *Subscription) checkOrderedDelivery(m *Msg) (jsMsgAction, orderedSeqs) {
+	if sub.mch != nil && cap(sub.mch) > 0 && len(sub.mch) == cap(sub.mch) {
+		return jsMsgDropAtCapacity, orderedSeqs{}
+	}
+
+	gap, seqs := sub.checkOrderedMsgs(m)
+	if !gap {
+		return jsMsgDeliver, seqs
+	}
+
+	// We have a gap, so we need to reset the consumer - release the reserved
+	// pending accounting for this message before doing so.
+	sub.releaseReserved(m)
+
+	jsi := sub.jsi
+
+	unbufferedChan := sub.mch != nil && cap(sub.mch) == 0
+	// Only unbuffered channels need rate limiting: every other subscription type
+	// has a capacity signal that already stopped the check from running
+	if unbufferedChan && sub.sc && jsi.dseq == 1 {
+		// Dropped with nothing delivered since the last reset. Resetting again
+		// would just refetch into the same wall; the heartbeat recovers it.
+		return jsMsgDropGap, orderedSeqs{}
+	}
+	sub.resetOrderedConsumer(jsi.sseq + 1)
+	return jsMsgDropGap, orderedSeqs{}
 }
 
 // Update and replace sid. Returns the old and the new sid. Returns ok == false,
@@ -2472,6 +2538,29 @@ func (nc *Conn) checkForSequenceMismatch(msg *Msg, s *Subscription, jsi *jsSub) 
 	jsi.active = true
 	s.mu.Unlock()
 
+	// The server reports the last consumer sequence it delivered.
+	var ldseq string
+	if hdr := msg.Header[lastConsumerSeqHdr]; len(hdr) == 1 {
+		ldseq = hdr[0]
+	}
+
+	// for ordered consumers, check is we should reset the consumer and do not
+	// report an error.
+	if ordered {
+		if ldseq == _EMPTY_ {
+			return
+		}
+		// jsi.dseq is the next sequence expected and advances only for messages
+		// handed off for delivery, so caught up means ldseq == jsi.dseq-1 and
+		// ldseq >= jsi.dseq means there is a gap.
+		s.mu.Lock()
+		if parser.ParseNum(ldseq) >= jsi.dseq {
+			s.resetOrderedConsumer(jsi.sseq + 1)
+		}
+		s.mu.Unlock()
+		return
+	}
+
 	if ctrl == _EMPTY_ {
 		return
 	}
@@ -2482,12 +2571,7 @@ func (nc *Conn) checkForSequenceMismatch(msg *Msg, s *Subscription, jsi *jsSub) 
 	}
 
 	// Consumer sequence.
-	var ldseq string
 	dseq := tokens[parser.AckConsumerSeqTokenPos]
-	hdr := msg.Header[lastConsumerSeqHdr]
-	if len(hdr) == 1 {
-		ldseq = hdr[0]
-	}
 
 	// Detect consumer sequence mismatch and whether
 	// should restart the consumer.
@@ -2495,18 +2579,12 @@ func (nc *Conn) checkForSequenceMismatch(msg *Msg, s *Subscription, jsi *jsSub) 
 		// Dispatch async error including details such as
 		// from where the consumer could be restarted.
 		sseq := parser.ParseNum(tokens[parser.AckStreamSeqTokenPos])
-		if ordered {
-			s.mu.Lock()
-			s.resetOrderedConsumer(jsi.sseq + 1)
-			s.mu.Unlock()
-		} else {
-			ecs := &ErrConsumerSequenceMismatch{
-				StreamResumeSequence: uint64(sseq),
-				ConsumerSequence:     parser.ParseNum(dseq),
-				LastConsumerSequence: parser.ParseNum(ldseq),
-			}
-			nc.handleConsumerSequenceMismatch(s, ecs)
+		ecs := &ErrConsumerSequenceMismatch{
+			StreamResumeSequence: uint64(sseq),
+			ConsumerSequence:     parser.ParseNum(dseq),
+			LastConsumerSequence: parser.ParseNum(ldseq),
 		}
+		nc.handleConsumerSequenceMismatch(s, ecs)
 	}
 }
 

--- a/js.go
+++ b/js.go
@@ -2165,12 +2165,9 @@ type orderedSeqs struct {
 
 // Check to make sure messages are arriving in order.
 // Returns true when m is not the message the ordered consumer was expecting
-// next.
+// next. The tracker is not advanced here; the returned sequences are applied
+// with commitOrderedMsg once m is queued for delivery.
 // Lock should be held.
-//
-// This only reports: the caller discards m on a gap and decides whether to
-// reset. The tracker is not advanced here either, so the caller must apply the
-// returned sequences with commitOrderedMsg once m is queued for delivery.
 func (sub *Subscription) checkOrderedMsgs(m *Msg) (bool, orderedSeqs) {
 	// Ignore msgs with no reply like HBs and flow control, they are handled elsewhere.
 	if m.Reply == _EMPTY_ {
@@ -2206,13 +2203,11 @@ func (sub *Subscription) commitOrderedMsg(seqs orderedSeqs) {
 type jsMsgAction int
 
 const (
-	// Deliver, then advance the tracker with commitOrderedMsg.
 	jsMsgDeliver jsMsgAction = iota
-	// The delivery channel is full. The caller's slow consumer path releases
-	// the pending accounting reserved for the message.
-	jsMsgDropAtCapacity
-	// Out of order and fully handled: reservation released, consumer reset.
-	// The caller only unlocks and returns.
+	// Cannot be delivered. The caller's slow consumer path counts it and
+	// releases the pending accounting reserved for it.
+	jsMsgDrop
+	// Out of order and fully handled. The caller only unlocks and returns.
 	jsMsgDropGap
 )
 
@@ -2223,8 +2218,8 @@ const (
 // Lock is held on entry and on return, but the gap path releases and reacquires
 // it to recreate the consumer.
 func (sub *Subscription) checkOrderedDelivery(m *Msg) (jsMsgAction, orderedSeqs) {
-	if sub.mch != nil && cap(sub.mch) > 0 && len(sub.mch) == cap(sub.mch) {
-		return jsMsgDropAtCapacity, orderedSeqs{}
+	if sub.chanFull() {
+		return jsMsgDrop, orderedSeqs{}
 	}
 
 	gap, seqs := sub.checkOrderedMsgs(m)
@@ -2232,22 +2227,34 @@ func (sub *Subscription) checkOrderedDelivery(m *Msg) (jsMsgAction, orderedSeqs)
 		return jsMsgDeliver, seqs
 	}
 
-	// We have a gap, so we need to reset the consumer - release the reserved
-	// pending accounting for this message before doing so.
-	sub.releaseReserved(m)
-
 	jsi := sub.jsi
-
-	unbufferedChan := sub.mch != nil && cap(sub.mch) == 0
-	// Only unbuffered channels need rate limiting: every other subscription type
-	// has a capacity signal that already stopped the check from running
-	if unbufferedChan && sub.sc && jsi.dseq == 1 {
-		// Dropped with nothing delivered since the last reset. Resetting again
-		// would just refetch into the same wall; the heartbeat recovers it.
-		return jsMsgDropGap, orderedSeqs{}
+	// An unbuffered channel has no capacity signal. With nothing delivered
+	// since the last reset, resetting again would just refetch into the same
+	// wall, so leave it to the heartbeat.
+	if sub.mch != nil && cap(sub.mch) == 0 && jsi.dseq == 1 {
+		return jsMsgDrop, orderedSeqs{}
 	}
+	sub.releaseReserved(m)
 	sub.resetOrderedConsumer(jsi.sseq + 1)
 	return jsMsgDropGap, orderedSeqs{}
+}
+
+// chanFull reports whether a buffered delivery channel cannot take another
+// message. Lock should be held.
+func (sub *Subscription) chanFull() bool {
+	return sub.mch != nil && cap(sub.mch) > 0 && len(sub.mch) == cap(sub.mch)
+}
+
+// pendingFull reports whether the subscription cannot take another message, so
+// that a reset now would only refetch into it. An unbuffered channel has no
+// capacity signal and never reports full. Lock should be held.
+func (sub *Subscription) pendingFull() bool {
+	if sub.typ != ChanSubscription &&
+		((sub.pMsgsLimit > 0 && sub.pMsgs >= sub.pMsgsLimit) ||
+			(sub.pBytesLimit > 0 && sub.pBytes >= sub.pBytesLimit)) {
+		return true
+	}
+	return sub.chanFull()
 }
 
 // Update and replace sid. Returns the old and the new sid. Returns ok == false,
@@ -2544,17 +2551,17 @@ func (nc *Conn) checkForSequenceMismatch(msg *Msg, s *Subscription, jsi *jsSub) 
 		ldseq = hdr[0]
 	}
 
-	// for ordered consumers, check is we should reset the consumer and do not
-	// report an error.
 	if ordered {
 		if ldseq == _EMPTY_ {
 			return
 		}
 		// jsi.dseq is the next sequence expected and advances only for messages
 		// handed off for delivery, so caught up means ldseq == jsi.dseq-1 and
-		// ldseq >= jsi.dseq means there is a gap.
+		// ldseq >= jsi.dseq means there is a gap. While the subscription is full
+		// a reset would only refetch into it; the first heartbeat after it
+		// drains picks the gap up.
 		s.mu.Lock()
-		if parser.ParseNum(ldseq) >= jsi.dseq {
+		if parser.ParseNum(ldseq) >= jsi.dseq && !s.pendingFull() {
 			s.resetOrderedConsumer(jsi.sseq + 1)
 		}
 		s.mu.Unlock()

--- a/nats.go
+++ b/nats.go
@@ -3844,7 +3844,6 @@ func (nc *Conn) processMsg(data []byte) {
 	var ctrlMsg bool
 	var ctrlType int
 	var fcReply string
-	// Staged by checkOrderedDelivery, applied by commitOrderedMsg once queued.
 	var ordSeqs orderedSeqs
 
 	if nc.ps.ma.hdr > 0 {
@@ -3934,10 +3933,9 @@ func (nc *Conn) processMsg(data []byte) {
 			var action jsMsgAction
 			action, ordSeqs = sub.checkOrderedDelivery(m)
 			switch action {
-			case jsMsgDropAtCapacity:
+			case jsMsgDrop:
 				goto slowConsumer
 			case jsMsgDropGap:
-				// Fully handled, reservation included.
 				sub.mu.Unlock()
 				return
 			}
@@ -3969,7 +3967,6 @@ func (nc *Conn) processMsg(data []byte) {
 			}
 		}
 		if jsi != nil {
-			// Queued for delivery, so the ordered tracker can advance past it.
 			sub.commitOrderedMsg(ordSeqs)
 			// Store the ACK metadata from the message to
 			// compare later on with the received heartbeat.
@@ -4031,6 +4028,12 @@ func (nc *Conn) processMsg(data []byte) {
 slowConsumer:
 	// ordSeqs is deliberately not committed here: leaving the tracker behind is
 	// what makes the next message register as a gap and get refetched.
+	// Except for the consumer's first message: with nothing delivered yet the
+	// tracker has no position, and a reset would resume from the start of the
+	// stream rather than from where the consumer was told to start.
+	if jsi != nil && jsi.ordered && jsi.sseq == 0 && ordSeqs.dseq == 1 {
+		jsi.sseq = ordSeqs.sseq - 1
+	}
 	sub.dropped++
 	sc := !sub.sc
 	sub.sc = true

--- a/nats.go
+++ b/nats.go
@@ -3720,6 +3720,9 @@ func (nc *Conn) waitForMsgs(s *Subscription) {
 			s.pMsgs--
 			s.pBytes -= msgLen
 			msgLen = -1
+			if s.jsi != nil && s.jsi.resetPending {
+				s.tryResetOrderedConsumer()
+			}
 		}
 
 		if s.pHead == nil && !s.closed {
@@ -5724,6 +5727,9 @@ func (s *Subscription) processNextMsgDelivered(msg *Msg) error {
 	if s.typ == SyncSubscription {
 		s.pMsgs--
 		s.pBytes -= len(msg.Data)
+	}
+	if s.jsi != nil && s.jsi.resetPending {
+		s.tryResetOrderedConsumer()
 	}
 	s.mu.Unlock()
 

--- a/nats.go
+++ b/nats.go
@@ -3844,6 +3844,8 @@ func (nc *Conn) processMsg(data []byte) {
 	var ctrlMsg bool
 	var ctrlType int
 	var fcReply string
+	// Staged by checkOrderedDelivery, applied by commitOrderedMsg once queued.
+	var ordSeqs orderedSeqs
 
 	if nc.ps.ma.hdr > 0 {
 		hbuf := msgPayload[:nc.ps.ma.hdr]
@@ -3899,11 +3901,6 @@ func (nc *Conn) processMsg(data []byte) {
 				fcReply = m.Header.Get(consumerStalledHdr)
 			}
 		}
-		// Check for ordered consumer here. If checkOrderedMsgs returns true that means it detected a gap.
-		if !ctrlMsg && jsi.ordered && sub.checkOrderedMsgs(m) {
-			sub.mu.Unlock()
-			return
-		}
 	}
 
 	// Skip processing if this is a control message and
@@ -3929,6 +3926,21 @@ func (nc *Conn) processMsg(data []byte) {
 			}
 		} else if jsi != nil {
 			chanSubCheckFC = true
+		}
+
+		// Must run here, between the reservation above and the delivery below.
+		// See checkOrderedDelivery.
+		if jsi != nil && jsi.ordered {
+			var action jsMsgAction
+			action, ordSeqs = sub.checkOrderedDelivery(m)
+			switch action {
+			case jsMsgDropAtCapacity:
+				goto slowConsumer
+			case jsMsgDropGap:
+				// Fully handled, reservation included.
+				sub.mu.Unlock()
+				return
+			}
 		}
 
 		// We have two modes of delivery. One is the channel, used by channel
@@ -3957,6 +3969,8 @@ func (nc *Conn) processMsg(data []byte) {
 			}
 		}
 		if jsi != nil {
+			// Queued for delivery, so the ordered tracker can advance past it.
+			sub.commitOrderedMsg(ordSeqs)
 			// Store the ACK metadata from the message to
 			// compare later on with the received heartbeat.
 			sub.trackSequences(m.Reply)
@@ -4015,14 +4029,13 @@ func (nc *Conn) processMsg(data []byte) {
 	return
 
 slowConsumer:
+	// ordSeqs is deliberately not committed here: leaving the tracker behind is
+	// what makes the next message register as a gap and get refetched.
 	sub.dropped++
 	sc := !sub.sc
 	sub.sc = true
 	// Undo stats from above
-	if sub.typ != ChanSubscription {
-		sub.pMsgs--
-		sub.pBytes -= len(m.Data)
-	}
+	sub.releaseReserved(m)
 	if sc {
 		sub.changeSubStatus(SubscriptionSlowConsumer)
 		sub.mu.Unlock()
@@ -4037,6 +4050,16 @@ slowConsumer:
 		nc.mu.Unlock()
 	} else {
 		sub.mu.Unlock()
+	}
+}
+
+// releaseReserved undoes the pending accounting reserved for m earlier in
+// processMsg. pMsgsMax/pBytesMax are deliberately left alone: they are
+// high-water marks of what was reserved. Lock must be held.
+func (sub *Subscription) releaseReserved(m *Msg) {
+	if sub.typ != ChanSubscription {
+		sub.pMsgs--
+		sub.pBytes -= len(m.Data)
 	}
 }
 

--- a/test/js_internal_test.go
+++ b/test/js_internal_test.go
@@ -446,7 +446,7 @@ func TestJetStreamFlowControlStalled(t *testing.T) {
 
 // Ordered consumer resets run from the connection read loop and swap the
 // subscription's sid. This exercises that against concurrent unsubscribes,
-// which is where the sid was previously read under a different lock.
+// which read the same field.
 func TestJetStreamOrderedConsumerSIDRace(t *testing.T) {
 	withJSServer(t, func(t *testing.T, nc *nats.Conn) {
 		js, err := nc.JetStream(nats.MaxWait(10 * time.Second))

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -10167,3 +10167,556 @@ func TestJetStreamSubscribeContextCancel(t *testing.T) {
 		})
 	})
 }
+
+// oscStream dials inst and creates the stream the ordered consumer tests use.
+func oscStream(t *testing.T, inst *testservice.Instance, opts ...nats.Option) (*nats.Conn, nats.JetStreamContext) {
+	t.Helper()
+	nc := dialInstance(t, inst, opts...)
+	t.Cleanup(nc.Close)
+	js, err := nc.JetStream(nats.MaxWait(10 * time.Second))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if _, err := js.AddStream(&nats.StreamConfig{Name: "OSC", Subjects: []string{"osc.>"}}); err != nil {
+		t.Fatalf("Error adding stream: %v", err)
+	}
+	return nc, js
+}
+
+// countConsumerCreates watches consumer-create traffic from a separate connection.
+func countConsumerCreates(t *testing.T, inst *testservice.Instance) *atomic.Int64 {
+	t.Helper()
+	mon := dialInstance(t, inst)
+	t.Cleanup(mon.Close)
+	creates := &atomic.Int64{}
+	if _, err := mon.Subscribe("$JS.API.CONSUMER.CREATE.>", func(*nats.Msg) {
+		creates.Add(1)
+	}); err != nil {
+		t.Fatalf("Error subscribing monitor: %v", err)
+	}
+	if err := mon.Flush(); err != nil {
+		t.Fatalf("Error flushing monitor: %v", err)
+	}
+	return creates
+}
+
+// publishOSC publishes n messages to the stream and waits for the acks.
+func publishOSC(t *testing.T, js nats.JetStreamContext, n int) {
+	t.Helper()
+	for range n {
+		if _, err := js.PublishAsync("osc.a", []byte("x")); err != nil {
+			t.Fatalf("Error publishing: %v", err)
+		}
+	}
+	select {
+	case <-js.PublishAsyncComplete():
+	case <-time.After(30 * time.Second):
+		t.Fatalf("Timed out waiting for publishes to complete")
+	}
+}
+
+// seqRecorder records delivered stream sequences in arrival order.
+type seqRecorder struct {
+	mu       sync.Mutex
+	order    []uint64
+	metaErrs []error
+}
+
+func (r *seqRecorder) add(m *nats.Msg) {
+	meta, err := m.Metadata()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err != nil {
+		r.metaErrs = append(r.metaErrs, err)
+		return
+	}
+	r.order = append(r.order, meta.Sequence.Stream)
+}
+
+func (r *seqRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.order)
+}
+
+// readChan drains ch into the recorder until the test ends.
+func (r *seqRecorder) readChan(t *testing.T, ch <-chan *nats.Msg) {
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case m := <-ch:
+				r.add(m)
+			}
+		}
+	}()
+}
+
+// verifyComplete asserts the whole stream arrived, in order and exactly once.
+func (r *seqRecorder) verifyComplete(t *testing.T, want int) {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.metaErrs) != 0 {
+		t.Fatalf("Got %d metadata errors, first: %v", len(r.metaErrs), r.metaErrs[0])
+	}
+	if len(r.order) != want {
+		t.Fatalf("Expected %d messages, got %d", want, len(r.order))
+	}
+	for i, sseq := range r.order {
+		if sseq != uint64(i+1) {
+			t.Fatalf("Message %d out of order: expected stream seq %d, got %d", i, i+1, sseq)
+		}
+	}
+}
+
+// waitForDrops fails unless the subscription actually enters slow consumer.
+func waitForDrops(t *testing.T, sub *nats.Subscription) {
+	t.Helper()
+	checkFor(t, 10*time.Second, 10*time.Millisecond, func() error {
+		if dropped, _ := sub.Dropped(); dropped == 0 {
+			return fmt.Errorf("no messages dropped yet")
+		}
+		return nil
+	})
+}
+
+// A slow consumer episode must not cost an ordered consumer any messages; what
+// it drops has to be refetched.
+func TestJetStreamOrderedConsumerSlowConsumerNoLoss(t *testing.T) {
+	withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, inst *testservice.Instance) {
+		_, js := oscStream(t, inst, nats.ErrorHandler(func(*nats.Conn, *nats.Subscription, error) {}))
+
+		gate := make(chan struct{})
+		var once sync.Once
+		var rec seqRecorder
+
+		// Subscribe before publishing, so nothing is delivered under the default limits.
+		sub, err := js.Subscribe("osc.>", func(m *nats.Msg) {
+			rec.add(m)
+			// Stall the first callback so the pending queue overflows.
+			once.Do(func() { <-gate })
+		}, nats.OrderedConsumer())
+		if err != nil {
+			t.Fatalf("Error subscribing: %v", err)
+		}
+		defer sub.Unsubscribe()
+		// Also sets the wall clock cost: recovery absorbs about this much per round.
+		const pendingMsgs = 50
+		if err := sub.SetPendingLimits(pendingMsgs, 1024*1024); err != nil {
+			t.Fatalf("Error setting pending limits: %v", err)
+		}
+
+		const totalMsgs = 200
+		for range totalMsgs {
+			if _, err := js.Publish("osc.a", []byte("x")); err != nil {
+				t.Fatalf("Error publishing: %v", err)
+			}
+		}
+
+		waitForDrops(t, sub)
+		close(gate)
+
+		// Measured at two or three 5s heartbeat rounds (10-15s); the bound allows nine.
+		checkFor(t, 45*time.Second, 100*time.Millisecond, func() error {
+			if n := rec.count(); n < totalMsgs {
+				return fmt.Errorf("only %d of %d messages delivered", n, totalMsgs)
+			}
+			return nil
+		})
+		rec.verifyComplete(t, totalMsgs)
+	})
+}
+
+// A slow consumer episode must not turn every dropped message into a consumer
+// recreate. The async and unbuffered cases bound recreates only; the buffered
+// case also asserts that nothing was lost while doing so.
+func TestJetStreamOrderedConsumerNoResetStorm(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		totalMsgs  int
+		maxCreates int64
+		// subscribe returns the stalled subscription, the channel to drain after
+		// the stall (nil when the case asserts no delivery), and a stall-ending func.
+		subscribe func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, chan *nats.Msg, func())
+	}{
+		{
+			name:      "async",
+			totalMsgs: 500,
+			// Only the heartbeat safety net should fire, about once per 5s
+			// heartbeat; the stall stays under the 10s activity check deadline.
+			maxCreates: 2,
+			subscribe: func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, chan *nats.Msg, func()) {
+				gate := make(chan struct{})
+				var once sync.Once
+				sub, err := js.Subscribe("osc.>", func(*nats.Msg) {
+					once.Do(func() { <-gate })
+				}, nats.OrderedConsumer())
+				if err != nil {
+					t.Fatalf("Error subscribing: %v", err)
+				}
+				// Early deliveries under the default limits are fine: this counts recreates.
+				if err := sub.SetPendingLimits(20, 1024*1024); err != nil {
+					t.Fatalf("Error setting pending limits: %v", err)
+				}
+				return sub, nil, func() { close(gate) }
+			},
+		},
+		{
+			// An unbuffered channel reads len(mch) == cap(mch) == 0, so the capacity
+			// gate cannot predict a drop for it and every drop looks like a gap.
+			name:       "unbuffered chan",
+			totalMsgs:  500,
+			maxCreates: 10,
+			subscribe: func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, chan *nats.Msg, func()) {
+				// Nothing ever reads from it, so every delivery drops. SetPendingLimits
+				// returns an error for a ChanSubscription, so there is nothing to tune.
+				ch := make(chan *nats.Msg)
+				sub, err := js.ChanSubscribe("osc.>", ch, nats.OrderedConsumer())
+				if err != nil {
+					t.Fatalf("Error subscribing: %v", err)
+				}
+				return sub, nil, func() {}
+			},
+		},
+		{
+			// A buffered ChanSubscription reaches the ordered check with a full
+			// channel: the pending guard only runs for other subscription types.
+			name:       "buffered chan",
+			totalMsgs:  200,
+			maxCreates: 10,
+			subscribe: func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, chan *nats.Msg, func()) {
+				// Small buffer, read only after the stall, so it fills once and then drops.
+				ch := make(chan *nats.Msg, 20)
+				sub, err := js.ChanSubscribe("osc.>", ch, nats.OrderedConsumer())
+				if err != nil {
+					t.Fatalf("Error subscribing: %v", err)
+				}
+				return sub, ch, func() {}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, inst *testservice.Instance) {
+				_, js := oscStream(t, inst, nats.ErrorHandler(func(*nats.Conn, *nats.Subscription, error) {}))
+				creates := countConsumerCreates(t, inst)
+
+				// Publish first so the server has a backlog to blast at a stalled client.
+				publishOSC(t, js, test.totalMsgs)
+
+				sub, ch, endStall := test.subscribe(t, js)
+				defer sub.Unsubscribe()
+				// Subscribe creates the consumer synchronously; the baseline excludes that.
+				baseline := creates.Load()
+
+				waitForDrops(t, sub)
+
+				const stallFor = 5 * time.Second
+				time.Sleep(stallFor)
+				stalledCreates := creates.Load() - baseline
+				endStall()
+				if stalledCreates > test.maxCreates {
+					t.Fatalf("Ordered consumer recreated %d times during a %v stall; expected at most %d",
+						stalledCreates, stallFor, test.maxCreates)
+				}
+
+				if ch == nil {
+					return
+				}
+				// Bounding the resets must not cost messages: everything the
+				// buffer could not take still has to arrive.
+				var rec seqRecorder
+				rec.readChan(t, ch)
+				// Heartbeat-paced recovery, measured at two to five 5s rounds; bound allows twelve.
+				checkFor(t, 60*time.Second, 100*time.Millisecond, func() error {
+					if n := rec.count(); n < test.totalMsgs {
+						return fmt.Errorf("only %d of %d messages delivered", n, test.totalMsgs)
+					}
+					return nil
+				})
+				rec.verifyComplete(t, test.totalMsgs)
+			})
+		})
+	}
+}
+
+// Once a slow consumer episode has discarded the backlog and the server has
+// gone quiet, nothing arrives to trip the inline gap check and recovery is left
+// entirely to the heartbeat safety net.
+func TestJetStreamOrderedConsumerSlowConsumerRecoversWhenIdle(t *testing.T) {
+	withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, inst *testservice.Instance) {
+		// Keep every async error so an unexpected one is reported rather than
+		// presenting as an opaque timeout.
+		var errMu sync.Mutex
+		var asyncErrs []error
+		_, js := oscStream(t, inst, nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+			errMu.Lock()
+			asyncErrs = append(asyncErrs, err)
+			errMu.Unlock()
+		}))
+
+		// Deduplicated: the slow consumer errors run into the thousands.
+		summarizeAsyncErrs := func() string {
+			errMu.Lock()
+			defer errMu.Unlock()
+			counts := make(map[string]int)
+			var seen []string
+			for _, err := range asyncErrs {
+				msg := err.Error()
+				if _, ok := counts[msg]; !ok {
+					seen = append(seen, msg)
+				}
+				counts[msg]++
+			}
+			var b strings.Builder
+			for _, msg := range seen {
+				fmt.Fprintf(&b, "\n\t%dx %s", counts[msg], msg)
+			}
+			return b.String()
+		}
+
+		creates := countConsumerCreates(t, inst)
+
+		gate := make(chan struct{})
+		var once sync.Once
+		var rec seqRecorder
+
+		// Subscribe before publishing, so nothing is delivered under the default
+		// limits. The short heartbeat makes the reset happen well within the stall.
+		sub, err := js.Subscribe("osc.>", func(m *nats.Msg) {
+			rec.add(m)
+			once.Do(func() { <-gate })
+		}, nats.OrderedConsumer(), nats.IdleHeartbeat(200*time.Millisecond))
+		if err != nil {
+			t.Fatalf("Error subscribing: %v", err)
+		}
+		defer sub.Unsubscribe()
+		if err := sub.SetPendingLimits(20, 1024*1024); err != nil {
+			t.Fatalf("Error setting pending limits: %v", err)
+		}
+
+		baseline := creates.Load()
+
+		const totalMsgs = 2000
+		publishOSC(t, js, totalMsgs)
+
+		// Hold the stall until the server goes quiet: a message arriving as the gate
+		// opens could be recovered by the inline gap check, masking the bug. Quiet is
+		// only reachable while the bug is present, so bound the wait either way.
+		const settleFor = 600 * time.Millisecond
+		stallDeadline := time.Now().Add(2 * time.Second)
+		lastDropped, movedAt := -1, time.Now()
+		for time.Now().Before(stallDeadline) {
+			dropped, _ := sub.Dropped()
+			if dropped != lastDropped {
+				lastDropped, movedAt = dropped, time.Now()
+			} else if time.Since(movedAt) >= settleFor {
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		// The stall has to have reached the state under test, or a pass is vacuous.
+		if n := creates.Load() - baseline; n == 0 {
+			t.Fatalf("No ordered consumer reset during the stall, so jsi.cmeta was never cleared; the test would be vacuous")
+		}
+		if dropped, _ := sub.Dropped(); dropped < totalMsgs {
+			t.Fatalf("Only %d messages dropped during the stall, want at least %d; the backlog was not discarded and the test would be vacuous",
+				dropped, totalMsgs)
+		}
+		close(gate)
+
+		checkFor(t, 30*time.Second, 100*time.Millisecond, func() error {
+			if n := rec.count(); n < totalMsgs {
+				return fmt.Errorf("only %d of %d messages delivered; async errors:%s",
+					n, totalMsgs, summarizeAsyncErrs())
+			}
+			return nil
+		})
+		rec.verifyComplete(t, totalMsgs)
+	})
+}
+
+// A healthy ordered consumer must never be recreated by the heartbeat path: the
+// heartbeat carries the server's last delivered sequence while jsi.dseq is the
+// next expected one, so caught up is ldseq == jsi.dseq-1, not equality.
+func TestJetStreamOrderedConsumerNoResetWhenHealthy(t *testing.T) {
+	withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, inst *testservice.Instance) {
+		var errMu sync.Mutex
+		var asyncErrs []error
+		_, js := oscStream(t, inst, nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+			errMu.Lock()
+			asyncErrs = append(asyncErrs, err)
+			errMu.Unlock()
+		}))
+		creates := countConsumerCreates(t, inst)
+
+		var rec seqRecorder
+		sub, err := js.Subscribe("osc.>", rec.add,
+			nats.OrderedConsumer(), nats.IdleHeartbeat(200*time.Millisecond))
+		if err != nil {
+			t.Fatalf("Error subscribing: %v", err)
+		}
+		defer sub.Unsubscribe()
+
+		baseline := creates.Load()
+
+		reportErrs := func() string {
+			errMu.Lock()
+			defer errMu.Unlock()
+			if len(asyncErrs) == 0 {
+				return " (no async errors)"
+			}
+			return fmt.Sprintf(" async errors: %v", asyncErrs)
+		}
+
+		// Six heartbeats, or the absence of resets would mean nothing.
+		const idleWindow = 1200 * time.Millisecond
+
+		// Nothing delivered yet: the server reports Nats-Last-Consumer 0, jsi.dseq is 1.
+		time.Sleep(idleWindow)
+		if n := creates.Load() - baseline; n != 0 {
+			t.Fatalf("Ordered consumer recreated %d times while idle on an empty stream; expected 0.%s",
+				n, reportErrs())
+		}
+
+		// Steady state: the server's last delivered now equals jsi.dseq-1.
+		const totalMsgs = 5
+		for range totalMsgs {
+			if _, err := js.Publish("osc.a", []byte("x")); err != nil {
+				t.Fatalf("Error publishing: %v", err)
+			}
+		}
+		checkFor(t, 10*time.Second, 10*time.Millisecond, func() error {
+			if n := rec.count(); n < totalMsgs {
+				return fmt.Errorf("only %d of %d messages delivered", n, totalMsgs)
+			}
+			return nil
+		})
+
+		afterDelivery := creates.Load()
+		time.Sleep(idleWindow)
+		if n := creates.Load() - afterDelivery; n != 0 {
+			t.Fatalf("Ordered consumer recreated %d times while idle and caught up; expected 0.%s",
+				n, reportErrs())
+		}
+		// Also covers the whole run, in case a reset happened during delivery.
+		if n := creates.Load() - baseline; n != 0 {
+			t.Fatalf("Ordered consumer recreated %d times over a healthy run; expected 0.%s",
+				n, reportErrs())
+		}
+		rec.verifyComplete(t, totalMsgs)
+	})
+}
+
+// An unbuffered channel subscription must drain a backlog at wire speed and
+// never deliver out of order. The jsi.dseq > 1 term in the reset guard is what
+// allows the immediate resets; without it the subscription advances one message
+// per heartbeat interval, which a shortened heartbeat would hide.
+func TestJetStreamOrderedConsumerUnbufferedChanRecoveryLatency(t *testing.T) {
+	withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, inst *testservice.Instance) {
+		_, js := oscStream(t, inst, nats.ErrorHandler(func(*nats.Conn, *nats.Subscription, error) {}))
+
+		// The first message is published alone so jsi.dseq > 1 before the timed
+		// phase; the last few keep traffic arriving behind the assertion window.
+		const totalMsgs = 25
+		const assertMsgs = 20
+
+		if _, err := js.Publish("osc.a", []byte("x")); err != nil {
+			t.Fatalf("Error publishing: %v", err)
+		}
+
+		ch := make(chan *nats.Msg)
+		recv := make(chan uint64, totalMsgs*4)
+		readErr := make(chan error, 1)
+		stop := make(chan struct{})
+		defer close(stop)
+		go func() {
+			for {
+				select {
+				case <-stop:
+					return
+				case m := <-ch:
+					meta, err := m.Metadata()
+					if err != nil {
+						select {
+						case readErr <- err:
+						default:
+						}
+						return
+					}
+					recv <- meta.Sequence.Stream
+				}
+			}
+		}()
+
+		sub, err := js.ChanSubscribe("osc.>", ch, nats.OrderedConsumer())
+		if err != nil {
+			t.Fatalf("Error subscribing: %v", err)
+		}
+		defer sub.Unsubscribe()
+
+		// Untimed: it may be dropped and return on a heartbeat. Either way jsi.dseq is 2.
+		var order []uint64
+		select {
+		case sseq := <-recv:
+			order = append(order, sseq)
+		case err := <-readErr:
+			t.Fatalf("Error getting metadata: %v", err)
+		case <-time.After(20 * time.Second):
+			t.Fatalf("First message never delivered")
+		}
+
+		for range totalMsgs - 1 {
+			if _, err := js.PublishAsync("osc.a", []byte("x")); err != nil {
+				t.Fatalf("Error publishing: %v", err)
+			}
+		}
+
+		// The failure this guards against needs ~100s for 20 messages at the 5s default.
+		const recoverWithin = 3 * time.Second
+		start := time.Now()
+		deadline := time.After(recoverWithin)
+		for len(order) < assertMsgs {
+			select {
+			case sseq := <-recv:
+				order = append(order, sseq)
+			case err := <-readErr:
+				t.Fatalf("Error getting metadata: %v", err)
+			case <-deadline:
+				t.Fatalf("Only %d of %d messages delivered in %v (got %v); an unbuffered ordered consumer must not need a heartbeat per message to drain a backlog",
+					len(order), assertMsgs, time.Since(start).Round(time.Millisecond), order)
+			}
+		}
+
+		// Without drops the gap path never ran and the timing proves nothing.
+		if dropped, _ := sub.Dropped(); dropped == 0 {
+			t.Fatalf("No messages were dropped, so the gap path never ran and the test would be vacuous")
+		}
+
+		// The tail is refetched at the heartbeat's pace, so only completeness matters
+		// here; order[i] == i+1 over arrival order is what rules out reordering.
+		tailDeadline := time.After(60 * time.Second)
+		for len(order) < totalMsgs {
+			select {
+			case sseq := <-recv:
+				order = append(order, sseq)
+			case err := <-readErr:
+				t.Fatalf("Error getting metadata: %v", err)
+			case <-tailDeadline:
+				t.Fatalf("Only %d of %d messages delivered (got %v)", len(order), totalMsgs, order)
+			}
+		}
+		if len(order) != totalMsgs {
+			t.Fatalf("Expected %d messages, got %d", totalMsgs, len(order))
+		}
+		for i, sseq := range order {
+			if sseq != uint64(i+1) {
+				t.Fatalf("Message %d out of order: expected stream seq %d, got %d", i, i+1, sseq)
+			}
+		}
+	})
+}

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -10301,160 +10301,229 @@ func waitForDrops(t *testing.T, sub *nats.Subscription) {
 	})
 }
 
-// A slow consumer episode must not cost an ordered consumer any messages; what
-// it drops has to be refetched.
-func TestJetStreamOrderedConsumerSlowConsumerNoLoss(t *testing.T) {
-	withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, inst *testservice.Instance) {
-		_, js := oscStream(t, inst, nats.ErrorHandler(func(*nats.Conn, *nats.Subscription, error) {}))
+// Messages dropped as slow consumer must be refetched before anything newer,
+// and a reset must wait until the reader has made room for the refetch.
+func TestJetStreamOrderedConsumerSlowConsumer(t *testing.T) {
+	const (
+		total    = 200
+		buffered = 32
+		msgSize  = 8 * 1024
+		// Short, so that recovery through a heartbeat does not take long.
+		hb = 500 * time.Millisecond
+	)
 
-		gate := make(chan struct{})
-		var once sync.Once
-		var rec seqRecorder
-
-		// Subscribe before publishing, so nothing is delivered under the default limits.
-		sub, err := js.Subscribe("osc.>", func(m *nats.Msg) {
-			rec.add(m)
-			// Stall the first callback so the pending queue overflows.
-			once.Do(func() { <-gate })
-		}, nats.OrderedConsumer(), nats.IdleHeartbeat(200*time.Millisecond))
-		if err != nil {
-			t.Fatalf("Error subscribing: %v", err)
+	type nextFunc func(time.Duration) (*nats.Msg, error)
+	readChan := func(ch chan *nats.Msg) nextFunc {
+		return func(d time.Duration) (*nats.Msg, error) {
+			select {
+			case m := <-ch:
+				return m, nil
+			case <-time.After(d):
+				return nil, nats.ErrTimeout
+			}
 		}
-		defer sub.Unsubscribe()
-		// Also sets the wall clock cost: recovery absorbs about this much per round.
-		const pendingMsgs = 50
-		if err := sub.SetPendingLimits(pendingMsgs, 1024*1024); err != nil {
-			t.Fatalf("Error setting pending limits: %v", err)
-		}
+	}
 
-		const totalMsgs = 200
-		publishOSC(t, js, totalMsgs)
-
-		waitForDrops(t, sub)
-		close(gate)
-
-		// The backlog is discarded by now and the server is quiet, so recovery
-		// rides on the heartbeat, refetching about one pending limit per round.
-		rec.waitFor(t, totalMsgs, 10*time.Second)
-		rec.verifyComplete(t, totalMsgs)
-	})
-}
-
-// A slow consumer episode must not turn every dropped message into a consumer
-// recreate. While the subscription is full a reset could only refetch into it,
-// so nothing should fire. An unbuffered channel has no capacity signal, so its
-// resets are paced by the heartbeat instead. The buffered case also asserts
-// that nothing was lost while doing so.
-func TestJetStreamOrderedConsumerNoResetStorm(t *testing.T) {
-	const hb = 200 * time.Millisecond
-	const stallFor = time.Second
-	// One reset per heartbeat, plus slack for a late one.
-	const hbPaced = int64(stallFor/hb) + 2
-	// A late heartbeat trips the activity check into one reset; a storm is dozens.
-	const lateHB = 1
-	// Pending limit or channel capacity: what a stalled subscription holds.
-	const held = 20
+	// Each holds exactly `buffered` messages before dropping.
+	subs := []struct {
+		name      string
+		subscribe func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, nextFunc)
+	}{
+		{"Subscribe", func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, nextFunc) {
+			// The callback hands each message to the reader, so the pending
+			// queue holds whatever the reader has not taken yet.
+			ch := make(chan *nats.Msg)
+			done := make(chan struct{})
+			t.Cleanup(func() { close(done) })
+			sub, err := js.Subscribe("osc.>", func(m *nats.Msg) {
+				select {
+				case ch <- m:
+				case <-done:
+				}
+			}, nats.OrderedConsumer(), nats.IdleHeartbeat(hb))
+			if err != nil {
+				t.Fatalf("Error subscribing: %v", err)
+			}
+			if err := sub.SetPendingLimits(-1, buffered*msgSize); err != nil {
+				t.Fatalf("Error setting pending limits: %v", err)
+			}
+			return sub, readChan(ch)
+		}},
+		{"SubscribeSync", func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, nextFunc) {
+			sub, err := js.SubscribeSync("osc.>", nats.OrderedConsumer(), nats.IdleHeartbeat(hb))
+			if err != nil {
+				t.Fatalf("Error subscribing: %v", err)
+			}
+			if err := sub.SetPendingLimits(-1, buffered*msgSize); err != nil {
+				t.Fatalf("Error setting pending limits: %v", err)
+			}
+			return sub, sub.NextMsg
+		}},
+		{"ChanSubscribe", func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, nextFunc) {
+			ch := make(chan *nats.Msg, buffered)
+			sub, err := js.ChanSubscribe("osc.>", ch, nats.OrderedConsumer(), nats.IdleHeartbeat(hb))
+			if err != nil {
+				t.Fatalf("Error subscribing: %v", err)
+			}
+			return sub, readChan(ch)
+		}},
+	}
 
 	for _, test := range []struct {
-		name       string
-		totalMsgs  int
-		payload    int
-		maxCreates int64
-		// subscribe returns the stalled subscription, the channel to drain after
-		// the stall (nil when the case asserts no delivery), and a stall-ending func.
-		subscribe func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, chan *nats.Msg, func())
+		name             string
+		publishAfterDrop bool
 	}{
-		{
-			name:       "async",
-			totalMsgs:  500,
-			payload:    1,
-			maxCreates: lateHB,
-			subscribe: func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, chan *nats.Msg, func()) {
-				gate := make(chan struct{})
-				var once sync.Once
-				sub, err := js.Subscribe("osc.>", func(*nats.Msg) {
-					once.Do(func() { <-gate })
-				}, nats.OrderedConsumer(), nats.IdleHeartbeat(hb))
-				if err != nil {
-					t.Fatalf("Error subscribing: %v", err)
-				}
-				if err := sub.SetPendingLimits(held, 1024*1024); err != nil {
-					t.Fatalf("Error setting pending limits: %v", err)
-				}
-				return sub, nil, func() { close(gate) }
-			},
-		},
-		{
-			// Nothing ever reads from it, so every delivery drops and every reset
-			// refetches into the same wall. The payload is large enough for the
-			// server to interleave flow control messages with the data.
-			name:       "unbuffered chan",
-			totalMsgs:  4000,
-			payload:    1024,
-			maxCreates: hbPaced,
-			subscribe: func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, chan *nats.Msg, func()) {
-				ch := make(chan *nats.Msg)
-				sub, err := js.ChanSubscribe("osc.>", ch, nats.OrderedConsumer(), nats.IdleHeartbeat(hb))
-				if err != nil {
-					t.Fatalf("Error subscribing: %v", err)
-				}
-				return sub, nil, func() {}
-			},
-		},
-		{
-			name:       "buffered chan",
-			totalMsgs:  200,
-			payload:    1,
-			maxCreates: lateHB,
-			subscribe: func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, chan *nats.Msg, func()) {
-				// Small buffer, read only after the stall, so it fills once and then drops.
-				ch := make(chan *nats.Msg, held)
-				sub, err := js.ChanSubscribe("osc.>", ch, nats.OrderedConsumer(), nats.IdleHeartbeat(hb))
-				if err != nil {
-					t.Fatalf("Error subscribing: %v", err)
-				}
-				return sub, ch, func() {}
-			},
-		},
+		{"NoSkippedMessages", true},
+		{"HeartbeatRecovery", false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, inst *testservice.Instance) {
-				_, js := oscStream(t, inst, nats.ErrorHandler(func(*nats.Conn, *nats.Subscription, error) {}))
-				creates := countConsumerCreates(t, inst)
+			for _, sub := range subs {
+				t.Run(sub.name, func(t *testing.T) {
+					withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, inst *testservice.Instance) {
+						_, js := oscStream(t, inst, nats.ErrorHandler(func(*nats.Conn, *nats.Subscription, error) {}))
+						publishOSCSized(t, js, total, msgSize)
 
-				sub, ch, endStall := test.subscribe(t, js)
-				defer sub.Unsubscribe()
-				baseline := creates.Load()
+						sub, next := sub.subscribe(t, js)
+						defer sub.Unsubscribe()
+						waitForDrops(t, sub)
 
-				publishOSCSized(t, js, test.totalMsgs, test.payload)
-				waitForDrops(t, sub)
+						// Reads stream sequences from through to, inclusive.
+						read := func(from, to uint64) {
+							t.Helper()
+							for expected := from; expected <= to; {
+								msg, err := next(3 * time.Second)
+								// Reported once after a drop.
+								if err == nats.ErrSlowConsumer {
+									continue
+								}
+								if err != nil {
+									t.Fatalf("Stalled waiting for stream sequence %d of %d: %v", expected, to, err)
+								}
+								meta, err := msg.Metadata()
+								if err != nil {
+									t.Fatalf("Error getting metadata: %v", err)
+								}
+								if meta.Sequence.Stream != expected {
+									t.Fatalf("Ordered consumer skipped a stream sequence: expected %d, got %d (consumer seq %d)",
+										expected, meta.Sequence.Stream, meta.Sequence.Consumer)
+								}
+								expected++
+							}
+						}
 
-				time.Sleep(stallFor)
-				stalledCreates := creates.Load() - baseline
-				endStall()
-				if stalledCreates > test.maxCreates {
-					t.Fatalf("Ordered consumer recreated %d times during a %v stall; expected at most %d",
-						stalledCreates, stallFor, test.maxCreates)
-				}
-				// Everything the stall could not hold counts as dropped, including
-				// what an unbuffered channel discards while waiting for the heartbeat.
-				if dropped, _ := sub.Dropped(); dropped < test.totalMsgs-held {
-					t.Fatalf("Dropped() reports %d, expected at least %d", dropped, test.totalMsgs-held)
-				}
+						if test.publishAfterDrop {
+							// The dropped messages must be redelivered before
+							// the one published after them.
+							read(1, buffered)
+							if _, err := js.Publish("osc.a", []byte("last")); err != nil {
+								t.Fatalf("Error publishing: %v", err)
+							}
+							read(buffered+1, total+1)
+							return
+						}
 
-				if ch == nil {
-					return
-				}
-				// Bounding the resets must not cost messages: everything the
-				// buffer could not take still has to arrive.
-				var rec seqRecorder
-				rec.readChan(t, ch)
-				// Recovery refetches about a buffer's worth per heartbeat round.
-				rec.waitFor(t, test.totalMsgs, 20*time.Second)
-				rec.verifyComplete(t, test.totalMsgs)
-			})
+						consumerName := func() string {
+							t.Helper()
+							ci, err := sub.ConsumerInfo()
+							if err != nil {
+								t.Fatalf("Error getting consumer info: %v", err)
+							}
+							return ci.Name
+						}
+						first := consumerName()
+
+						// Heartbeats report the gap while nothing is reading,
+						// but a reset now would only get its refetch dropped
+						// into the same full buffer, again and again. It must
+						// wait until the reader has made room.
+						time.Sleep(3 * hb)
+						if name := consumerName(); name != first {
+							t.Fatalf("Ordered consumer was recreated while the buffer was full: %q -> %q", first, name)
+						}
+						read(1, buffered/2-1)
+						time.Sleep(2 * hb)
+						if name := consumerName(); name != first {
+							t.Fatalf("Ordered consumer was recreated while more than half the buffer was in use: %q -> %q", first, name)
+						}
+						read(buffered/2, buffered/2)
+						checkFor(t, 3*time.Second, 10*time.Millisecond, func() error {
+							ci, err := sub.ConsumerInfo()
+							if err != nil {
+								return err
+							}
+							if ci.Name == first {
+								return fmt.Errorf("ordered consumer not recreated after making room")
+							}
+							return nil
+						})
+						read(buffered/2+1, total)
+					})
+				})
+			}
 		})
 	}
+}
+
+// An unbuffered channel has no capacity signal, so a reader that is not there
+// yet cannot be told apart from one that is merely busy. While nothing has
+// been delivered, resets are paced by the heartbeat and everything discarded
+// in the meantime counts as dropped; once a reader shows up nothing is lost.
+func TestJetStreamOrderedConsumerUnbufferedChan(t *testing.T) {
+	const hb = 200 * time.Millisecond
+
+	t.Run("no reader", func(t *testing.T) {
+		withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, inst *testservice.Instance) {
+			_, js := oscStream(t, inst, nats.ErrorHandler(func(*nats.Conn, *nats.Subscription, error) {}))
+			creates := countConsumerCreates(t, inst)
+
+			ch := make(chan *nats.Msg)
+			sub, err := js.ChanSubscribe("osc.>", ch, nats.OrderedConsumer(), nats.IdleHeartbeat(hb))
+			if err != nil {
+				t.Fatalf("Error subscribing: %v", err)
+			}
+			defer sub.Unsubscribe()
+			baseline := creates.Load()
+
+			// Large enough for the server to interleave flow control messages
+			// with the data.
+			const totalMsgs = 4000
+			publishOSCSized(t, js, totalMsgs, 1024)
+			waitForDrops(t, sub)
+
+			const stallFor = time.Second
+			time.Sleep(stallFor)
+			// One reset per heartbeat, plus slack for a late one.
+			if n, max := creates.Load()-baseline, int64(stallFor/hb)+2; n > max {
+				t.Fatalf("Ordered consumer recreated %d times during a %v stall; expected at most %d", n, stallFor, max)
+			}
+			if dropped, _ := sub.Dropped(); dropped < totalMsgs {
+				t.Fatalf("Dropped() reports %d, expected at least %d", dropped, totalMsgs)
+			}
+		})
+	})
+
+	t.Run("late reader", func(t *testing.T) {
+		withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, inst *testservice.Instance) {
+			_, js := oscStream(t, inst, nats.ErrorHandler(func(*nats.Conn, *nats.Subscription, error) {}))
+			const totalMsgs = 100
+			publishOSC(t, js, totalMsgs)
+
+			ch := make(chan *nats.Msg)
+			sub, err := js.ChanSubscribe("osc.>", ch, nats.OrderedConsumer(), nats.IdleHeartbeat(hb))
+			if err != nil {
+				t.Fatalf("Error subscribing: %v", err)
+			}
+			defer sub.Unsubscribe()
+			// The whole backlog is discarded before anyone reads.
+			waitForDrops(t, sub)
+			time.Sleep(2 * hb)
+
+			var rec seqRecorder
+			rec.readChan(t, ch)
+			rec.waitFor(t, totalMsgs, 30*time.Second)
+			rec.verifyComplete(t, totalMsgs)
+		})
+	})
 }
 
 // A healthy ordered consumer must never be recreated by the heartbeat path: the

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -10203,8 +10203,14 @@ func countConsumerCreates(t *testing.T, inst *testservice.Instance) *atomic.Int6
 // publishOSC publishes n messages to the stream and waits for the acks.
 func publishOSC(t *testing.T, js nats.JetStreamContext, n int) {
 	t.Helper()
+	publishOSCSized(t, js, n, 1)
+}
+
+func publishOSCSized(t *testing.T, js nats.JetStreamContext, n, size int) {
+	t.Helper()
+	payload := make([]byte, size)
 	for range n {
-		if _, err := js.PublishAsync("osc.a", []byte("x")); err != nil {
+		if _, err := js.PublishAsync("osc.a", payload); err != nil {
 			t.Fatalf("Error publishing: %v", err)
 		}
 	}
@@ -10299,7 +10305,7 @@ func TestJetStreamOrderedConsumerSlowConsumerNoLoss(t *testing.T) {
 			rec.add(m)
 			// Stall the first callback so the pending queue overflows.
 			once.Do(func() { <-gate })
-		}, nats.OrderedConsumer())
+		}, nats.OrderedConsumer(), nats.IdleHeartbeat(200*time.Millisecond))
 		if err != nil {
 			t.Fatalf("Error subscribing: %v", err)
 		}
@@ -10311,17 +10317,14 @@ func TestJetStreamOrderedConsumerSlowConsumerNoLoss(t *testing.T) {
 		}
 
 		const totalMsgs = 200
-		for range totalMsgs {
-			if _, err := js.Publish("osc.a", []byte("x")); err != nil {
-				t.Fatalf("Error publishing: %v", err)
-			}
-		}
+		publishOSC(t, js, totalMsgs)
 
 		waitForDrops(t, sub)
 		close(gate)
 
-		// Measured at two or three 5s heartbeat rounds (10-15s); the bound allows nine.
-		checkFor(t, 45*time.Second, 100*time.Millisecond, func() error {
+		// The backlog is discarded by now and the server is quiet, so recovery
+		// rides on the heartbeat, refetching about one pending limit per round.
+		checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
 			if n := rec.count(); n < totalMsgs {
 				return fmt.Errorf("only %d of %d messages delivered", n, totalMsgs)
 			}
@@ -10332,12 +10335,23 @@ func TestJetStreamOrderedConsumerSlowConsumerNoLoss(t *testing.T) {
 }
 
 // A slow consumer episode must not turn every dropped message into a consumer
-// recreate. The async and unbuffered cases bound recreates only; the buffered
-// case also asserts that nothing was lost while doing so.
+// recreate. While the subscription is full a reset could only refetch into it,
+// so nothing should fire. An unbuffered channel has no capacity signal, so its
+// resets are paced by the heartbeat instead. The buffered case also asserts
+// that nothing was lost while doing so.
 func TestJetStreamOrderedConsumerNoResetStorm(t *testing.T) {
+	const hb = 200 * time.Millisecond
+	const stallFor = time.Second
+	// One reset per heartbeat, plus slack for a late one.
+	const hbPaced = int64(stallFor/hb) + 2
+	// Pending limit or channel capacity: what a stalled subscription holds.
+	const held = 20
+
 	for _, test := range []struct {
-		name       string
-		totalMsgs  int
+		name      string
+		totalMsgs int
+		payload   int
+		// Zero for subscription types with a capacity signal.
 		maxCreates int64
 		// subscribe returns the stalled subscription, the channel to drain after
 		// the stall (nil when the case asserts no delivery), and a stall-ending func.
@@ -10346,36 +10360,33 @@ func TestJetStreamOrderedConsumerNoResetStorm(t *testing.T) {
 		{
 			name:      "async",
 			totalMsgs: 500,
-			// Only the heartbeat safety net should fire, about once per 5s
-			// heartbeat; the stall stays under the 10s activity check deadline.
-			maxCreates: 2,
+			payload:   1,
 			subscribe: func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, chan *nats.Msg, func()) {
 				gate := make(chan struct{})
 				var once sync.Once
 				sub, err := js.Subscribe("osc.>", func(*nats.Msg) {
 					once.Do(func() { <-gate })
-				}, nats.OrderedConsumer())
+				}, nats.OrderedConsumer(), nats.IdleHeartbeat(hb))
 				if err != nil {
 					t.Fatalf("Error subscribing: %v", err)
 				}
-				// Early deliveries under the default limits are fine: this counts recreates.
-				if err := sub.SetPendingLimits(20, 1024*1024); err != nil {
+				if err := sub.SetPendingLimits(held, 1024*1024); err != nil {
 					t.Fatalf("Error setting pending limits: %v", err)
 				}
 				return sub, nil, func() { close(gate) }
 			},
 		},
 		{
-			// An unbuffered channel reads len(mch) == cap(mch) == 0, so the capacity
-			// gate cannot predict a drop for it and every drop looks like a gap.
+			// Nothing ever reads from it, so every delivery drops and every reset
+			// refetches into the same wall. The payload is large enough for the
+			// server to interleave flow control messages with the data.
 			name:       "unbuffered chan",
-			totalMsgs:  500,
-			maxCreates: 10,
+			totalMsgs:  4000,
+			payload:    1024,
+			maxCreates: hbPaced,
 			subscribe: func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, chan *nats.Msg, func()) {
-				// Nothing ever reads from it, so every delivery drops. SetPendingLimits
-				// returns an error for a ChanSubscription, so there is nothing to tune.
 				ch := make(chan *nats.Msg)
-				sub, err := js.ChanSubscribe("osc.>", ch, nats.OrderedConsumer())
+				sub, err := js.ChanSubscribe("osc.>", ch, nats.OrderedConsumer(), nats.IdleHeartbeat(hb))
 				if err != nil {
 					t.Fatalf("Error subscribing: %v", err)
 				}
@@ -10383,15 +10394,13 @@ func TestJetStreamOrderedConsumerNoResetStorm(t *testing.T) {
 			},
 		},
 		{
-			// A buffered ChanSubscription reaches the ordered check with a full
-			// channel: the pending guard only runs for other subscription types.
-			name:       "buffered chan",
-			totalMsgs:  200,
-			maxCreates: 10,
+			name:      "buffered chan",
+			totalMsgs: 200,
+			payload:   1,
 			subscribe: func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, chan *nats.Msg, func()) {
 				// Small buffer, read only after the stall, so it fills once and then drops.
-				ch := make(chan *nats.Msg, 20)
-				sub, err := js.ChanSubscribe("osc.>", ch, nats.OrderedConsumer())
+				ch := make(chan *nats.Msg, held)
+				sub, err := js.ChanSubscribe("osc.>", ch, nats.OrderedConsumer(), nats.IdleHeartbeat(hb))
 				if err != nil {
 					t.Fatalf("Error subscribing: %v", err)
 				}
@@ -10404,23 +10413,24 @@ func TestJetStreamOrderedConsumerNoResetStorm(t *testing.T) {
 				_, js := oscStream(t, inst, nats.ErrorHandler(func(*nats.Conn, *nats.Subscription, error) {}))
 				creates := countConsumerCreates(t, inst)
 
-				// Publish first so the server has a backlog to blast at a stalled client.
-				publishOSC(t, js, test.totalMsgs)
-
 				sub, ch, endStall := test.subscribe(t, js)
 				defer sub.Unsubscribe()
-				// Subscribe creates the consumer synchronously; the baseline excludes that.
 				baseline := creates.Load()
 
+				publishOSCSized(t, js, test.totalMsgs, test.payload)
 				waitForDrops(t, sub)
 
-				const stallFor = 5 * time.Second
 				time.Sleep(stallFor)
 				stalledCreates := creates.Load() - baseline
 				endStall()
 				if stalledCreates > test.maxCreates {
 					t.Fatalf("Ordered consumer recreated %d times during a %v stall; expected at most %d",
 						stalledCreates, stallFor, test.maxCreates)
+				}
+				// Everything the stall could not hold counts as dropped, including
+				// what an unbuffered channel discards while waiting for the heartbeat.
+				if dropped, _ := sub.Dropped(); dropped < test.totalMsgs-held {
+					t.Fatalf("Dropped() reports %d, expected at least %d", dropped, test.totalMsgs-held)
 				}
 
 				if ch == nil {
@@ -10430,8 +10440,8 @@ func TestJetStreamOrderedConsumerNoResetStorm(t *testing.T) {
 				// buffer could not take still has to arrive.
 				var rec seqRecorder
 				rec.readChan(t, ch)
-				// Heartbeat-paced recovery, measured at two to five 5s rounds; bound allows twelve.
-				checkFor(t, 60*time.Second, 100*time.Millisecond, func() error {
+				// Recovery refetches about a buffer's worth per heartbeat round.
+				checkFor(t, 20*time.Second, 100*time.Millisecond, func() error {
 					if n := rec.count(); n < test.totalMsgs {
 						return fmt.Errorf("only %d of %d messages delivered", n, test.totalMsgs)
 					}
@@ -10441,103 +10451,6 @@ func TestJetStreamOrderedConsumerNoResetStorm(t *testing.T) {
 			})
 		})
 	}
-}
-
-// Once a slow consumer episode has discarded the backlog and the server has
-// gone quiet, nothing arrives to trip the inline gap check and recovery is left
-// entirely to the heartbeat safety net.
-func TestJetStreamOrderedConsumerSlowConsumerRecoversWhenIdle(t *testing.T) {
-	withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, inst *testservice.Instance) {
-		// Keep every async error so an unexpected one is reported rather than
-		// presenting as an opaque timeout.
-		var errMu sync.Mutex
-		var asyncErrs []error
-		_, js := oscStream(t, inst, nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
-			errMu.Lock()
-			asyncErrs = append(asyncErrs, err)
-			errMu.Unlock()
-		}))
-
-		// Deduplicated: the slow consumer errors run into the thousands.
-		summarizeAsyncErrs := func() string {
-			errMu.Lock()
-			defer errMu.Unlock()
-			counts := make(map[string]int)
-			var seen []string
-			for _, err := range asyncErrs {
-				msg := err.Error()
-				if _, ok := counts[msg]; !ok {
-					seen = append(seen, msg)
-				}
-				counts[msg]++
-			}
-			var b strings.Builder
-			for _, msg := range seen {
-				fmt.Fprintf(&b, "\n\t%dx %s", counts[msg], msg)
-			}
-			return b.String()
-		}
-
-		creates := countConsumerCreates(t, inst)
-
-		gate := make(chan struct{})
-		var once sync.Once
-		var rec seqRecorder
-
-		// Subscribe before publishing, so nothing is delivered under the default
-		// limits. The short heartbeat makes the reset happen well within the stall.
-		sub, err := js.Subscribe("osc.>", func(m *nats.Msg) {
-			rec.add(m)
-			once.Do(func() { <-gate })
-		}, nats.OrderedConsumer(), nats.IdleHeartbeat(200*time.Millisecond))
-		if err != nil {
-			t.Fatalf("Error subscribing: %v", err)
-		}
-		defer sub.Unsubscribe()
-		if err := sub.SetPendingLimits(20, 1024*1024); err != nil {
-			t.Fatalf("Error setting pending limits: %v", err)
-		}
-
-		baseline := creates.Load()
-
-		const totalMsgs = 2000
-		publishOSC(t, js, totalMsgs)
-
-		// Hold the stall until the server goes quiet: a message arriving as the gate
-		// opens could be recovered by the inline gap check, masking the bug. Quiet is
-		// only reachable while the bug is present, so bound the wait either way.
-		const settleFor = 600 * time.Millisecond
-		stallDeadline := time.Now().Add(2 * time.Second)
-		lastDropped, movedAt := -1, time.Now()
-		for time.Now().Before(stallDeadline) {
-			dropped, _ := sub.Dropped()
-			if dropped != lastDropped {
-				lastDropped, movedAt = dropped, time.Now()
-			} else if time.Since(movedAt) >= settleFor {
-				break
-			}
-			time.Sleep(50 * time.Millisecond)
-		}
-
-		// The stall has to have reached the state under test, or a pass is vacuous.
-		if n := creates.Load() - baseline; n == 0 {
-			t.Fatalf("No ordered consumer reset during the stall, so jsi.cmeta was never cleared; the test would be vacuous")
-		}
-		if dropped, _ := sub.Dropped(); dropped < totalMsgs {
-			t.Fatalf("Only %d messages dropped during the stall, want at least %d; the backlog was not discarded and the test would be vacuous",
-				dropped, totalMsgs)
-		}
-		close(gate)
-
-		checkFor(t, 30*time.Second, 100*time.Millisecond, func() error {
-			if n := rec.count(); n < totalMsgs {
-				return fmt.Errorf("only %d of %d messages delivered; async errors:%s",
-					n, totalMsgs, summarizeAsyncErrs())
-			}
-			return nil
-		})
-		rec.verifyComplete(t, totalMsgs)
-	})
 }
 
 // A healthy ordered consumer must never be recreated by the heartbeat path: the
@@ -10717,6 +10630,43 @@ func TestJetStreamOrderedConsumerUnbufferedChanRecoveryLatency(t *testing.T) {
 			if sseq != uint64(i+1) {
 				t.Fatalf("Message %d out of order: expected stream seq %d, got %d", i, i+1, sseq)
 			}
+		}
+	})
+}
+
+// A reset before anything was delivered must resume from the consumer's first
+// message, not from the start of the stream, or the deliver policy is lost.
+func TestJetStreamOrderedConsumerFirstMsgDroppedKeepsStartPosition(t *testing.T) {
+	withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, inst *testservice.Instance) {
+		_, js := oscStream(t, inst, nats.ErrorHandler(func(*nats.Conn, *nats.Subscription, error) {}))
+		publishOSC(t, js, 100)
+
+		// No reader yet, so the first message is dropped.
+		ch := make(chan *nats.Msg)
+		sub, err := js.ChanSubscribe("osc.>", ch, nats.OrderedConsumer(), nats.DeliverNew(), nats.IdleHeartbeat(200*time.Millisecond))
+		if err != nil {
+			t.Fatalf("Error subscribing: %v", err)
+		}
+		defer sub.Unsubscribe()
+		if _, err := js.Publish("osc.a", []byte("x")); err != nil {
+			t.Fatalf("Error publishing: %v", err)
+		}
+		waitForDrops(t, sub)
+
+		var rec seqRecorder
+		rec.readChan(t, ch)
+		checkFor(t, 10*time.Second, 50*time.Millisecond, func() error {
+			if rec.count() == 0 {
+				return fmt.Errorf("nothing delivered")
+			}
+			return nil
+		})
+		// Leave time for a replay of the history to show up.
+		time.Sleep(500 * time.Millisecond)
+		rec.mu.Lock()
+		defer rec.mu.Unlock()
+		if len(rec.order) != 1 || rec.order[0] != 101 {
+			t.Fatalf("Expected only stream seq 101, got %v", rec.order)
 		}
 	})
 }

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -10350,23 +10350,25 @@ func TestJetStreamOrderedConsumerNoResetStorm(t *testing.T) {
 	const stallFor = time.Second
 	// One reset per heartbeat, plus slack for a late one.
 	const hbPaced = int64(stallFor/hb) + 2
+	// A late heartbeat trips the activity check into one reset; a storm is dozens.
+	const lateHB = 1
 	// Pending limit or channel capacity: what a stalled subscription holds.
 	const held = 20
 
 	for _, test := range []struct {
-		name      string
-		totalMsgs int
-		payload   int
-		// Zero for subscription types with a capacity signal.
+		name       string
+		totalMsgs  int
+		payload    int
 		maxCreates int64
 		// subscribe returns the stalled subscription, the channel to drain after
 		// the stall (nil when the case asserts no delivery), and a stall-ending func.
 		subscribe func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, chan *nats.Msg, func())
 	}{
 		{
-			name:      "async",
-			totalMsgs: 500,
-			payload:   1,
+			name:       "async",
+			totalMsgs:  500,
+			payload:    1,
+			maxCreates: lateHB,
 			subscribe: func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, chan *nats.Msg, func()) {
 				gate := make(chan struct{})
 				var once sync.Once
@@ -10400,9 +10402,10 @@ func TestJetStreamOrderedConsumerNoResetStorm(t *testing.T) {
 			},
 		},
 		{
-			name:      "buffered chan",
-			totalMsgs: 200,
-			payload:   1,
+			name:       "buffered chan",
+			totalMsgs:  200,
+			payload:    1,
+			maxCreates: lateHB,
 			subscribe: func(t *testing.T, js nats.JetStreamContext) (*nats.Subscription, chan *nats.Msg, func()) {
 				// Small buffer, read only after the stall, so it fills once and then drops.
 				ch := make(chan *nats.Msg, held)
@@ -10459,68 +10462,32 @@ func TestJetStreamOrderedConsumerNoResetStorm(t *testing.T) {
 // next expected one, so caught up is ldseq == jsi.dseq-1, not equality.
 func TestJetStreamOrderedConsumerNoResetWhenHealthy(t *testing.T) {
 	withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, inst *testservice.Instance) {
-		var errMu sync.Mutex
-		var asyncErrs []error
-		_, js := oscStream(t, inst, nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
-			errMu.Lock()
-			asyncErrs = append(asyncErrs, err)
-			errMu.Unlock()
-		}))
+		_, js := oscStream(t, inst, nats.ErrorHandler(func(*nats.Conn, *nats.Subscription, error) {}))
 		creates := countConsumerCreates(t, inst)
 
 		var rec seqRecorder
-		sub, err := js.Subscribe("osc.>", rec.add,
-			nats.OrderedConsumer(), nats.IdleHeartbeat(200*time.Millisecond))
+		sub, err := js.Subscribe("osc.>", rec.add, nats.OrderedConsumer(), nats.IdleHeartbeat(200*time.Millisecond))
 		if err != nil {
 			t.Fatalf("Error subscribing: %v", err)
 		}
 		defer sub.Unsubscribe()
-
 		baseline := creates.Load()
-
-		reportErrs := func() string {
-			errMu.Lock()
-			defer errMu.Unlock()
-			if len(asyncErrs) == 0 {
-				return " (no async errors)"
-			}
-			return fmt.Sprintf(" async errors: %v", asyncErrs)
-		}
 
 		// Six heartbeats, or the absence of resets would mean nothing.
 		const idleWindow = 1200 * time.Millisecond
 
 		// Nothing delivered yet: the server reports Nats-Last-Consumer 0, jsi.dseq is 1.
 		time.Sleep(idleWindow)
-		if n := creates.Load() - baseline; n != 0 {
-			t.Fatalf("Ordered consumer recreated %d times while idle on an empty stream; expected 0.%s",
-				n, reportErrs())
-		}
-
 		// Steady state: the server's last delivered now equals jsi.dseq-1.
 		const totalMsgs = 5
-		for range totalMsgs {
-			if _, err := js.Publish("osc.a", []byte("x")); err != nil {
-				t.Fatalf("Error publishing: %v", err)
-			}
-		}
-		checkFor(t, 10*time.Second, 10*time.Millisecond, func() error {
-			if n := rec.count(); n < totalMsgs {
-				return fmt.Errorf("only %d of %d messages delivered", n, totalMsgs)
-			}
-			return nil
-		})
-
-		afterDelivery := creates.Load()
+		publishOSC(t, js, totalMsgs)
+		rec.waitFor(t, totalMsgs, 10*time.Second)
 		time.Sleep(idleWindow)
-		if n := creates.Load() - afterDelivery; n != 0 {
-			t.Fatalf("Ordered consumer recreated %d times while idle and caught up; expected 0.%s",
-				n, reportErrs())
-		}
-		// Also covers the whole run, in case a reset happened during delivery.
-		if n := creates.Load() - baseline; n != 0 {
-			t.Fatalf("Ordered consumer recreated %d times over a healthy run; expected 0.%s",
-				n, reportErrs())
+
+		// A late heartbeat trips the activity check into one reset; the bug
+		// would produce one per heartbeat.
+		if n := creates.Load() - baseline; n > 1 {
+			t.Fatalf("Ordered consumer recreated %d times over a healthy run; expected none", n)
 		}
 		rec.verifyComplete(t, totalMsgs)
 	})

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -10245,6 +10245,17 @@ func (r *seqRecorder) count() int {
 	return len(r.order)
 }
 
+// waitFor fails unless at least want messages arrive within timeout.
+func (r *seqRecorder) waitFor(t *testing.T, want int, timeout time.Duration) {
+	t.Helper()
+	checkFor(t, timeout, 10*time.Millisecond, func() error {
+		if n := r.count(); n < want {
+			return fmt.Errorf("only %d of %d messages delivered", n, want)
+		}
+		return nil
+	})
+}
+
 // readChan drains ch into the recorder until the test ends.
 func (r *seqRecorder) readChan(t *testing.T, ch <-chan *nats.Msg) {
 	stop := make(chan struct{})
@@ -10324,12 +10335,7 @@ func TestJetStreamOrderedConsumerSlowConsumerNoLoss(t *testing.T) {
 
 		// The backlog is discarded by now and the server is quiet, so recovery
 		// rides on the heartbeat, refetching about one pending limit per round.
-		checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
-			if n := rec.count(); n < totalMsgs {
-				return fmt.Errorf("only %d of %d messages delivered", n, totalMsgs)
-			}
-			return nil
-		})
+		rec.waitFor(t, totalMsgs, 10*time.Second)
 		rec.verifyComplete(t, totalMsgs)
 	})
 }
@@ -10441,12 +10447,7 @@ func TestJetStreamOrderedConsumerNoResetStorm(t *testing.T) {
 				var rec seqRecorder
 				rec.readChan(t, ch)
 				// Recovery refetches about a buffer's worth per heartbeat round.
-				checkFor(t, 20*time.Second, 100*time.Millisecond, func() error {
-					if n := rec.count(); n < test.totalMsgs {
-						return fmt.Errorf("only %d of %d messages delivered", n, test.totalMsgs)
-					}
-					return nil
-				})
+				rec.waitFor(t, test.totalMsgs, 20*time.Second)
 				rec.verifyComplete(t, test.totalMsgs)
 			})
 		})
@@ -10525,115 +10526,6 @@ func TestJetStreamOrderedConsumerNoResetWhenHealthy(t *testing.T) {
 	})
 }
 
-// An unbuffered channel subscription must drain a backlog at wire speed and
-// never deliver out of order. The jsi.dseq > 1 term in the reset guard is what
-// allows the immediate resets; without it the subscription advances one message
-// per heartbeat interval, which a shortened heartbeat would hide.
-func TestJetStreamOrderedConsumerUnbufferedChanRecoveryLatency(t *testing.T) {
-	withJSServerInstance(t, func(t *testing.T, _ *nats.Conn, inst *testservice.Instance) {
-		_, js := oscStream(t, inst, nats.ErrorHandler(func(*nats.Conn, *nats.Subscription, error) {}))
-
-		// The first message is published alone so jsi.dseq > 1 before the timed
-		// phase; the last few keep traffic arriving behind the assertion window.
-		const totalMsgs = 25
-		const assertMsgs = 20
-
-		if _, err := js.Publish("osc.a", []byte("x")); err != nil {
-			t.Fatalf("Error publishing: %v", err)
-		}
-
-		ch := make(chan *nats.Msg)
-		recv := make(chan uint64, totalMsgs*4)
-		readErr := make(chan error, 1)
-		stop := make(chan struct{})
-		defer close(stop)
-		go func() {
-			for {
-				select {
-				case <-stop:
-					return
-				case m := <-ch:
-					meta, err := m.Metadata()
-					if err != nil {
-						select {
-						case readErr <- err:
-						default:
-						}
-						return
-					}
-					recv <- meta.Sequence.Stream
-				}
-			}
-		}()
-
-		sub, err := js.ChanSubscribe("osc.>", ch, nats.OrderedConsumer())
-		if err != nil {
-			t.Fatalf("Error subscribing: %v", err)
-		}
-		defer sub.Unsubscribe()
-
-		// Untimed: it may be dropped and return on a heartbeat. Either way jsi.dseq is 2.
-		var order []uint64
-		select {
-		case sseq := <-recv:
-			order = append(order, sseq)
-		case err := <-readErr:
-			t.Fatalf("Error getting metadata: %v", err)
-		case <-time.After(20 * time.Second):
-			t.Fatalf("First message never delivered")
-		}
-
-		for range totalMsgs - 1 {
-			if _, err := js.PublishAsync("osc.a", []byte("x")); err != nil {
-				t.Fatalf("Error publishing: %v", err)
-			}
-		}
-
-		// The failure this guards against needs ~100s for 20 messages at the 5s default.
-		const recoverWithin = 3 * time.Second
-		start := time.Now()
-		deadline := time.After(recoverWithin)
-		for len(order) < assertMsgs {
-			select {
-			case sseq := <-recv:
-				order = append(order, sseq)
-			case err := <-readErr:
-				t.Fatalf("Error getting metadata: %v", err)
-			case <-deadline:
-				t.Fatalf("Only %d of %d messages delivered in %v (got %v); an unbuffered ordered consumer must not need a heartbeat per message to drain a backlog",
-					len(order), assertMsgs, time.Since(start).Round(time.Millisecond), order)
-			}
-		}
-
-		// Without drops the gap path never ran and the timing proves nothing.
-		if dropped, _ := sub.Dropped(); dropped == 0 {
-			t.Fatalf("No messages were dropped, so the gap path never ran and the test would be vacuous")
-		}
-
-		// The tail is refetched at the heartbeat's pace, so only completeness matters
-		// here; order[i] == i+1 over arrival order is what rules out reordering.
-		tailDeadline := time.After(60 * time.Second)
-		for len(order) < totalMsgs {
-			select {
-			case sseq := <-recv:
-				order = append(order, sseq)
-			case err := <-readErr:
-				t.Fatalf("Error getting metadata: %v", err)
-			case <-tailDeadline:
-				t.Fatalf("Only %d of %d messages delivered (got %v)", len(order), totalMsgs, order)
-			}
-		}
-		if len(order) != totalMsgs {
-			t.Fatalf("Expected %d messages, got %d", totalMsgs, len(order))
-		}
-		for i, sseq := range order {
-			if sseq != uint64(i+1) {
-				t.Fatalf("Message %d out of order: expected stream seq %d, got %d", i, i+1, sseq)
-			}
-		}
-	})
-}
-
 // A reset before anything was delivered must resume from the consumer's first
 // message, not from the start of the stream, or the deliver policy is lost.
 func TestJetStreamOrderedConsumerFirstMsgDroppedKeepsStartPosition(t *testing.T) {
@@ -10655,12 +10547,7 @@ func TestJetStreamOrderedConsumerFirstMsgDroppedKeepsStartPosition(t *testing.T)
 
 		var rec seqRecorder
 		rec.readChan(t, ch)
-		checkFor(t, 10*time.Second, 50*time.Millisecond, func() error {
-			if rec.count() == 0 {
-				return fmt.Errorf("nothing delivered")
-			}
-			return nil
-		})
+		rec.waitFor(t, 1, 10*time.Second)
 		// Leave time for a replay of the history to show up.
 		time.Sleep(500 * time.Millisecond)
 		rec.mu.Lock()


### PR DESCRIPTION
Fixes #2107

`processMsg` validated ordering before deciding whether the message could be delivered. `checkOrderedMsgs` advanced jsi.dseq/jsi.sseq, and the pending-limit guard could then drop the message, leaving the tracker past a message that was never delivered, so the next one matched and no gap was ever detected.

This fix decouples checking the sequences and gap detection from actually moving the trackers forward.

To keep that from becoming a reset storm:

- While the subscription is full, neither a gap nor a heartbeat resets the consumer, since a new one could only refetch into the same wall.
- An unbuffered channel has no capacity signal, so while nothing has been delivered since the last reset it waits for the heartbeat instead.

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)