### PR TITLE
[IMPROVED] Fix list consumers test to work agains latest server

### DIFF
--- a/jetstream/test/stream_test.go
+++ b/jetstream/test/stream_test.go
@@ -1178,6 +1178,11 @@ func TestListConsumers(t *testing.T) {
 			timeout:      5 * time.Second,
 		},
 		{
+			name:         "list consumers multiple pages",
+			consumersNum: 1025,
+			timeout:      5 * time.Second,
+		},
+		{
 			name:         "with empty context",
 			consumersNum: 500,
 		},
@@ -1196,7 +1201,7 @@ func TestListConsumers(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			withJSServer(t, func(t *testing.T, _ *nats.Conn, js jetstream.JetStream) {
-				s, err := js.CreateStream(context.Background(), jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+				s, err := js.CreateStream(context.Background(), jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}, MaxConsumers: 2000})
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}

--- a/test/js_test.go
+++ b/test/js_test.go
@@ -4509,7 +4509,7 @@ func TestConsumersLister(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
-				js.AddStream(&nats.StreamConfig{Name: "foo"})
+				js.AddStream(&nats.StreamConfig{Name: "foo", MaxConsumers: 2000})
 				for i := range test.consumersNum {
 					if _, err := js.AddConsumer("foo", &nats.ConsumerConfig{Durable: fmt.Sprintf("cons_%d", i), AckPolicy: nats.AckExplicitPolicy}); err != nil {
 						t.Fatalf("Unexpected error: %v", err)


### PR DESCRIPTION
Server now has a default max consumers limit per stream. This adjusts tests which create more than 1000 consumers to work against these changes.

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)